### PR TITLE
fix: add nixpacks.toml to keep devDependencies at runtime

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,11 @@
+[phases.setup]
+nixPkgs = ["nodejs_20"]
+
+[phases.install]
+cmds = ["npm ci"]
+
+[phases.build]
+cmds = ["npm run build"]
+
+[start]
+cmd = "npm run start"


### PR DESCRIPTION
Railway's Nixpacks builder was only installing production dependencies, but the bundled dist/index.js contains dynamic imports to vite (even though they're only used in development mode). Node.js tries to resolve these imports at module load time, causing MODULE_NOT_FOUND errors.

This config ensures all dependencies are installed, making vite available for the dynamic imports in the bundled code.

Fixes: Cannot find package 'vite' imported from /app/dist/index.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)