### PR TITLE
fix(ci): add timeout protection to Claude Code Review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
@@ -24,6 +25,8 @@ jobs:
 
       - name: Run Automated PR Review
         id: claude-review
+        timeout-minutes: 12
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Add job-level timeout of 15 minutes
- Add step-level timeout of 12 minutes  
- Add `continue-on-error: true` to prevent blocking PR merges

## Why
The Claude Code Review workflow was hanging indefinitely in some cases, blocking CI checks. These timeout protections ensure the workflow completes within reasonable time.

## Test Plan
- [ ] Workflow completes within timeout limits
- [ ] PR checks not blocked if Claude Code encounters issues

---

**Note**: This PR must be merged first before PR #229 (Mobile-First Redesign) can have its Claude Code Review pass. The Claude Code Action validates that workflow files match the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)