### PR TITLE
Release v0.15.3: Auto-activate Athletes on OAuth Linking

### DIFF
--- a/packages/api/services/oauth-service.ts
+++ b/packages/api/services/oauth-service.ts
@@ -290,7 +290,8 @@ export class OAuthService extends BaseService {
         return { success: false, error: 'This linking token has been invalidated due to too many failed attempts', shouldIncrementFailedAttempts: false };
       }
 
-      // Link OAuth account to existing user
+      // Link OAuth account to existing user and activate them
+      // (mirrors invitation acceptance flow where athletes are activated on account claim)
       await this.storage.updateUser(linkingToken.userId, {
         googleId: linkingToken.provider === 'google' ? linkingToken.providerId : undefined,
         appleId: linkingToken.provider === 'apple' ? linkingToken.providerId : undefined,
@@ -298,6 +299,7 @@ export class OAuthService extends BaseService {
         oauthEmail: linkingToken.providerEmail,
         oauthEmailVerified: true,
         accountLinkedAt: new Date(),
+        isActive: true,
       });
 
       // Mark token as used


### PR DESCRIPTION
## Summary
- **fix:** Auto-activate athletes when they link their OAuth account (Google/Apple)

This mirrors the behavior in the invitation acceptance flow where athletes are set to `isActive: true` when they claim their accounts. Previously, deactivated athletes who linked OAuth would remain inactive, creating an inconsistency.

## Changes
- `packages/api/services/oauth-service.ts`: Added `isActive: true` to the `updateUser` call in `confirmAccountLinking()`

## Test plan
- [x] TypeScript compilation passes
- [ ] Manual test: Deactivate an athlete, have them link OAuth, verify `is_active` becomes `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)