### PR TITLE
Release v0.15.4: Auto-activate Athletes on OAuth Login

### DIFF
--- a/packages/api/services/oauth-service.ts
+++ b/packages/api/services/oauth-service.ts
@@ -327,11 +327,13 @@ export class OAuthService extends BaseService {
 
   /**
    * Update last login timestamp and auth method
+   * Also activates the user - if they can authenticate via OAuth, they should be active
    */
   private async updateLastLogin(userId: string, authMethod: 'google' | 'apple'): Promise<void> {
     await this.storage.updateUser(userId, {
       lastLoginAt: new Date(),
       lastAuthMethod: authMethod,
+      isActive: true,
     });
   }
 


### PR DESCRIPTION
## Summary
- **fix:** Auto-activate athletes when they log in via OAuth (returning users)

Extends the v0.15.3 fix to also cover returning OAuth users. When an athlete logs in via Google/Apple OAuth, they are now automatically activated.

## Why This Matters
Previously, if an athlete was deactivated (or created before `isActive` defaulted to true), logging in via OAuth would NOT reactivate them. Now, any successful OAuth authentication activates the user.

## OAuth Activation Coverage

| Path | Activates User? |
|------|-----------------|
| Account linking confirmation | ✅ (v0.15.3) |
| Returning OAuth user login | ✅ (this fix) |
| New OAuth user creation | ✅ (schema default) |

## Changes
- `packages/api/services/oauth-service.ts`: Added `isActive: true` to `updateLastLogin()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)