### PR TITLE
feat(reports): add audience-aware AI coaching insights

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,7 +73,8 @@ jobs:
             - Categorize issues by severity so authors know what to prioritize
             - Do not read .claude/agents/ or invoke sub-agents
 
-          claude_args: --max-turns 25 --allowed-tools "Bash(gh:*),Read,Grep,Glob"
+          model: claude-sonnet-4-6
+          claude_args: --max-turns 40 --allowed-tools "Bash(gh:*),Read,Grep,Glob"
 
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: "claude"
 
           prompt: |
             Review PR #${{ github.event.pull_request.number }}.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,8 +73,7 @@ jobs:
             - Categorize issues by severity so authors know what to prioritize
             - Do not read .claude/agents/ or invoke sub-agents
 
-          model: claude-sonnet-4-6
-          claude_args: --max-turns 40 --allowed-tools "Bash(gh:*),Read,Grep,Glob"
+          claude_args: --model claude-sonnet-4-6 --max-turns 40 --allowed-tools "Bash(gh:*),Read,Grep,Glob"
 
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,7 +72,7 @@ jobs:
             - Categorize issues by severity so authors know what to prioritize
             - Do not read .claude/agents/ or invoke sub-agents
 
-          claude_args: --max-turns 15 --allowed-tools "Bash(gh:*),Read,Grep,Glob"
+          claude_args: --max-turns 25 --allowed-tools "Bash(gh:*),Read,Grep,Glob"
 
           additional_permissions: |
             actions: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.32",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.32.tgz",
-      "integrity": "sha512-TWySpzIPJCdn/RNHI7nIn/j/2PLGaw1d+v7v9JyVHk8i+cNND3eUm2YACO9219psbdtE1IpG1qeq/xsaHxlyDg==",
+      "version": "2.1.87",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.87.tgz",
+      "integrity": "sha512-R40p85lv270MsOmuP0VrgZlsBnq6HIoW/aIrPwny6AfhPUmsChPNLkxv/F8Mf6g9iYpGNEfICt5CDw++tKZD0g==",
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "cli.js"
@@ -126,90 +126,15 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.33.5",
-        "@img/sharp-darwin-x64": "^0.33.5",
-        "@img/sharp-linux-arm": "^0.33.5",
-        "@img/sharp-linux-arm64": "^0.33.5",
-        "@img/sharp-linux-x64": "^0.33.5",
-        "@img/sharp-linuxmusl-arm64": "^0.33.5",
-        "@img/sharp-linuxmusl-x64": "^0.33.5",
-        "@img/sharp-win32-x64": "^0.33.5"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-code/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-code/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-code/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-code/node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -2781,9 +2706,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -2799,13 +2724,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -2821,13 +2746,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -2841,9 +2766,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -2857,9 +2782,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -2873,9 +2798,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -2937,9 +2862,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -2985,9 +2910,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -3003,13 +2928,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -3025,7 +2950,7 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
@@ -3095,9 +3020,9 @@
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -3113,7 +3038,7 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
@@ -3218,9 +3143,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -5891,9 +5816,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8132,9 +8057,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10456,9 +10381,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10947,9 +10872,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -11019,18 +10944,34 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "20.0.10",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.10.tgz",
-      "integrity": "sha512-6umCCHcjQrhP5oXhrHQQvLB0bwb1UzHAHdsXy+FjtKoYjUhmNZsQL8NivwM1vDvNEChJabVrUYxUnp/ZdYmy2g==",
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
-        "whatwg-mimetype": "^3.0.0"
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/has-bigints": {
@@ -15501,9 +15442,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -15649,9 +15590,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -17290,9 +17231,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -17417,215 +17358,6 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/sharp/node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/sharp/node_modules/semver": {
@@ -18651,9 +18383,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19598,9 +19330,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19684,9 +19416,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -21,6 +21,7 @@ import {
   teams,
   auditLogs,
   userOrganizations,
+  siteMetrics,
   MAX_INSIGHTS_LENGTH,
   type Report,
 } from "@shared/schema";

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -48,6 +48,7 @@ interface IndividualReportConfig {
     customEnd?: string;
   };
   metrics: string[];
+  audience?: 'coach' | 'athlete' | 'parent';
   benchmarks?: {
     site?: string[];
     custom?: string[];
@@ -67,6 +68,7 @@ interface TeamReportConfig {
     customEnd?: string;
   };
   metrics: string[];
+  audience?: 'coach' | 'athlete' | 'parent';
   filters?: {
     teamIds?: string[];
     gender?: string;
@@ -4071,6 +4073,9 @@ async function buildReportDataForAI(report: Report, userId: string, reportServic
       }
     }
 
+    // Extract audience from report config
+    const audience = (reportConfig as any)?.audience as 'coach' | 'athlete' | 'parent' | undefined;
+
     // Build final ReportData object
     const aiReportData: import("../services/ai-insights-service").ReportData = {
       reportType: report.reportType as "individual" | "team",
@@ -4081,6 +4086,7 @@ async function buildReportDataForAI(report: Report, userId: string, reportServic
       improvements,
       concerns,
       benchmarkComparisons,
+      audience,
     };
 
     // Add team-specific data

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -4097,8 +4097,12 @@ async function buildReportDataForAI(report: Report, userId: string, reportServic
       }
     }
 
-    // Extract audience from report config
-    const audience = reportConfig?.audience;
+    // Extract and validate audience from report config
+    const VALID_AUDIENCES = ['coach', 'athlete', 'parent'] as const;
+    const rawAudience = reportConfig?.audience;
+    const audience = VALID_AUDIENCES.includes(rawAudience as typeof VALID_AUDIENCES[number])
+      ? (rawAudience as typeof VALID_AUDIENCES[number])
+      : undefined;
 
     // Build final ReportData object
     const aiReportData: import("../services/ai-insights-service").ReportData = {

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -4074,7 +4074,7 @@ async function buildReportDataForAI(report: Report, userId: string, reportServic
     }
 
     // Extract audience from report config
-    const audience = (reportConfig as any)?.audience as 'coach' | 'athlete' | 'parent' | undefined;
+    const audience = reportConfig?.audience;
 
     // Build final ReportData object
     const aiReportData: import("../services/ai-insights-service").ReportData = {

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -4098,11 +4098,14 @@ async function buildReportDataForAI(report: Report, userId: string, reportServic
     }
 
     // Extract and validate audience from report config
+    // athlete/parent audiences only apply to individual reports — team reports always use coach
     const VALID_AUDIENCES = ['coach', 'athlete', 'parent'] as const;
     const rawAudience = reportConfig?.audience;
-    const audience = VALID_AUDIENCES.includes(rawAudience as typeof VALID_AUDIENCES[number])
-      ? (rawAudience as typeof VALID_AUDIENCES[number])
-      : undefined;
+    const audience = report.reportType === 'team'
+      ? 'coach' as const
+      : VALID_AUDIENCES.includes(rawAudience as typeof VALID_AUDIENCES[number])
+        ? (rawAudience as typeof VALID_AUDIENCES[number])
+        : undefined;
 
     // Build final ReportData object
     const aiReportData: import("../services/ai-insights-service").ReportData = {

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -3971,6 +3971,17 @@ async function buildReportDataForAI(report: Report, userId: string, reportServic
 
       // Team report metrics (limited to MAX_METRICS)
       const statsToProcess = typedReportData.teamStatistics.slice(0, MAX_METRICS);
+
+      // Batch query metricType for all codes to avoid N+1 DB queries
+      const teamMetricCodes = statsToProcess.map(s => s.metric);
+      const teamMetricTypes = teamMetricCodes.length > 0
+        ? await db
+            .select({ code: siteMetrics.code, metricType: siteMetrics.metricType })
+            .from(siteMetrics)
+            .where(inArray(siteMetrics.code, teamMetricCodes))
+        : [];
+      const teamLowerIsBetterMap = new Map(teamMetricTypes.map(m => [m.code, m.metricType === 'lower_is_better']));
+
       for (const stat of statsToProcess) {
         const metricCode = stat.metric;
         const values: number[] = [];
@@ -3990,7 +4001,7 @@ async function buildReportDataForAI(report: Report, userId: string, reportServic
           label: typedReportData.metricLabels?.[metricCode] || metricCode, // Human-readable label
           values: limitedValues,
           unit: stat.units || "",
-          lowerIsBetter: isMetricLowerBetter(metricCode),
+          lowerIsBetter: teamLowerIsBetterMap.get(metricCode) ?? false,
         });
       }
     } else if (report.reportType === 'individual' && typedReportData.athlete) {
@@ -3998,14 +4009,26 @@ async function buildReportDataForAI(report: Report, userId: string, reportServic
       const athlete = typedReportData.athlete;
       if (athlete.measurements) {
         const entries = Object.entries(athlete.measurements).slice(0, MAX_METRICS);
+
+        // Batch query unit and metricType for all codes to avoid N+1 DB queries
+        const individualMetricCodes = entries.filter(([, v]) => typeof v === 'number').map(([code]) => code);
+        const individualMetricInfo = individualMetricCodes.length > 0
+          ? await db
+              .select({ code: siteMetrics.code, unit: siteMetrics.unit, metricType: siteMetrics.metricType })
+              .from(siteMetrics)
+              .where(inArray(siteMetrics.code, individualMetricCodes))
+          : [];
+        const individualUnitMap = new Map(individualMetricInfo.map(m => [m.code, m.unit || '']));
+        const individualLowerIsBetterMap = new Map(individualMetricInfo.map(m => [m.code, m.metricType === 'lower_is_better']));
+
         for (const [metricCode, value] of entries) {
           if (typeof value === 'number') {
             metrics.push({
               code: metricCode,
               label: typedReportData.metricLabels?.[metricCode] || metricCode, // Human-readable label
               values: [value],
-              unit: getMetricUnit(metricCode),
-              lowerIsBetter: isMetricLowerBetter(metricCode),
+              unit: individualUnitMap.get(metricCode) || '',
+              lowerIsBetter: individualLowerIsBetterMap.get(metricCode) ?? false,
               percentile: athlete.percentiles?.[metricCode],
               teamAverage: athlete.teamAverages?.[metricCode],
             });

--- a/packages/api/services/__tests__/ai-insights-audience-prompt.test.ts
+++ b/packages/api/services/__tests__/ai-insights-audience-prompt.test.ts
@@ -202,6 +202,18 @@ describe('buildPrompt audience branches', () => {
       expect(prompt).toContain('PARENTS of youth athletes');
       expect(prompt).not.toContain("athlete's first name");
     });
+
+    it('should skip first-name instruction when sanitized name is empty', () => {
+      // A name composed entirely of markdown special chars sanitizes to ''
+      const data = makeBaseReportData({
+        audience: 'parent',
+        athleteName: '***',
+      });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).not.toContain("athlete's first name ()");
+      expect(prompt).not.toContain("athlete's first name");
+    });
   });
 
   describe('all audiences share common constraints', () => {

--- a/packages/api/services/__tests__/ai-insights-audience-prompt.test.ts
+++ b/packages/api/services/__tests__/ai-insights-audience-prompt.test.ts
@@ -90,14 +90,14 @@ describe('buildPrompt audience branches', () => {
       expect(prompt).toContain('Clinical or passive language');
     });
 
-    it('should include the four athlete-oriented sections', () => {
+    it('should include the three athlete-oriented sections (no Next Steps)', () => {
       const data = makeBaseReportData({ audience: 'athlete' });
       const prompt = buildPrompt(data);
 
       expect(prompt).toContain('**Summary**');
       expect(prompt).toContain("**What's Going Well**");
       expect(prompt).toContain('**What to Work On**');
-      expect(prompt).toContain('**Next Steps**');
+      expect(prompt).not.toContain('**Next Steps**');
     });
 
     it('should request 150-200 words for athlete audience', () => {
@@ -139,14 +139,15 @@ describe('buildPrompt audience branches', () => {
       expect(prompt).toContain('non-technical language');
     });
 
-    it('should include parent-specific sections', () => {
+    it('should include parent-specific sections (no training recommendations)', () => {
       const data = makeBaseReportData({ audience: 'parent' });
       const prompt = buildPrompt(data);
 
       expect(prompt).toContain("**What the numbers mean**");
       expect(prompt).toContain("**What's Going Well**");
       expect(prompt).toContain('**What to Work On**');
-      expect(prompt).toContain('**Why Continued Training Matters**');
+      expect(prompt).not.toContain('**Why Continued Training Matters**');
+      expect(prompt).not.toContain('**Next Steps**');
     });
 
     it('should use the athlete first name throughout', () => {

--- a/packages/api/services/__tests__/ai-insights-audience-prompt.test.ts
+++ b/packages/api/services/__tests__/ai-insights-audience-prompt.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { buildPrompt, ReportData } from '../ai-insights-service';
+
+/**
+ * Unit tests for the audience-specific prompt branches in buildPrompt().
+ *
+ * buildPrompt() tailors the Instructions section based on reportData.audience:
+ *   - 'coach'   (default) — language for sports coaches
+ *   - 'athlete' — second-person "you" language directed at the athlete
+ *   - 'parent'  — plain-language for parents of youth athletes
+ */
+
+function makeBaseReportData(overrides: Partial<ReportData> = {}): ReportData {
+  return {
+    reportType: 'individual',
+    reportName: 'Sprint Performance Report',
+    organizationName: 'Test Org',
+    timeframe: '2025-01-01 to 2025-03-31',
+    metrics: [
+      {
+        code: 'FLY10_TIME',
+        label: '10-Yard Fly Time',
+        values: [1.45, 1.42],
+        unit: 's',
+        lowerIsBetter: true,
+      },
+    ],
+    athleteName: 'Jordan Smith',
+    athleteAge: 15,
+    athleteGender: 'Male',
+    athleteSport: 'Soccer',
+    ...overrides,
+  };
+}
+
+describe('buildPrompt audience branches', () => {
+  describe('coach audience (default)', () => {
+    it('should contain coach-specific language when audience is "coach"', () => {
+      const data = makeBaseReportData({ audience: 'coach' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('sports coaches and athletes');
+      expect(prompt).toContain('coaching insights in markdown format');
+    });
+
+    it('should fall back to coach language when audience is not set', () => {
+      const data = makeBaseReportData();
+      // audience is undefined — should default to 'coach'
+      expect(data.audience).toBeUndefined();
+
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('sports coaches and athletes');
+      expect(prompt).toContain('coaching insights in markdown format');
+    });
+
+    it('should include the standard four sections for coach audience', () => {
+      const data = makeBaseReportData({ audience: 'coach' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('**Summary**');
+      expect(prompt).toContain("**What's Going Well**");
+      expect(prompt).toContain('**What to Work On**');
+      expect(prompt).toContain('**Next Steps**');
+    });
+
+    it('should request 150-250 words for coach audience', () => {
+      const data = makeBaseReportData({ audience: 'coach' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('150-250 words');
+    });
+  });
+
+  describe('athlete audience', () => {
+    it('should contain athlete-specific "you" language', () => {
+      const data = makeBaseReportData({ audience: 'athlete' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('You are writing directly TO the athlete');
+      expect(prompt).toContain('"you" language');
+    });
+
+    it('should be motivating and specific', () => {
+      const data = makeBaseReportData({ audience: 'athlete' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('motivating and specific');
+      expect(prompt).toContain('exactly what to focus on in training');
+    });
+
+    it('should include the four athlete-oriented sections', () => {
+      const data = makeBaseReportData({ audience: 'athlete' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('**Summary**');
+      expect(prompt).toContain("**What's Going Well**");
+      expect(prompt).toContain('**What to Work On**');
+      expect(prompt).toContain('**Next Steps**');
+    });
+
+    it('should request 150-200 words for athlete audience', () => {
+      const data = makeBaseReportData({ audience: 'athlete' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('150-200 words');
+    });
+
+    it('should not contain parent-specific or coach-specific language', () => {
+      const data = makeBaseReportData({ audience: 'athlete' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).not.toContain('PARENTS of youth athletes');
+      expect(prompt).not.toContain('sports coaches and athletes, NOT strength');
+    });
+  });
+
+  describe('parent audience', () => {
+    it('should contain parent-specific language', () => {
+      const data = makeBaseReportData({ audience: 'parent' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('PARENTS of youth athletes');
+      expect(prompt).toContain('non-technical language');
+    });
+
+    it('should include parent-specific sections', () => {
+      const data = makeBaseReportData({ audience: 'parent' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain("**What the numbers mean**");
+      expect(prompt).toContain("**What's Going Well**");
+      expect(prompt).toContain('**What to Work On**');
+      expect(prompt).toContain('**Why Continued Training Matters**');
+    });
+
+    it('should use the athlete first name throughout', () => {
+      const data = makeBaseReportData({
+        audience: 'parent',
+        athleteName: 'Jordan Smith',
+      });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('Jordan');
+      expect(prompt).toContain("athlete's first name (Jordan)");
+    });
+
+    it('should handle athlete with single-word name', () => {
+      const data = makeBaseReportData({
+        audience: 'parent',
+        athleteName: 'Zendaya',
+      });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain("athlete's first name (Zendaya)");
+    });
+
+    it('should request 200-300 words for parent audience', () => {
+      const data = makeBaseReportData({ audience: 'parent' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('200-300 words');
+    });
+
+    it('should set encouraging and professional tone', () => {
+      const data = makeBaseReportData({ audience: 'parent' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('Encouraging, professional, data-backed');
+    });
+
+    it('should instruct to avoid jargon and negative framing', () => {
+      const data = makeBaseReportData({ audience: 'parent' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('AVOID');
+      expect(prompt).toContain('negative framing');
+    });
+
+    it('should frame areas to work on as growth opportunities', () => {
+      const data = makeBaseReportData({ audience: 'parent' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('growth opportunities, not deficiencies');
+    });
+
+    it('should not contain coach-specific or athlete-specific language', () => {
+      const data = makeBaseReportData({ audience: 'parent' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).not.toContain('sports coaches and athletes, NOT strength');
+      expect(prompt).not.toContain('You are writing directly TO the athlete');
+    });
+
+    it('should skip first-name instruction when athleteName is missing', () => {
+      const data = makeBaseReportData({
+        audience: 'parent',
+        athleteName: undefined,
+      });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('PARENTS of youth athletes');
+      expect(prompt).not.toContain("athlete's first name");
+    });
+  });
+
+  describe('all audiences share common constraints', () => {
+    const audiences: Array<ReportData['audience']> = ['coach', 'athlete', 'parent'];
+
+    audiences.forEach((audience) => {
+      it(`should include IMPORTANT CONSTRAINTS for "${audience}" audience`, () => {
+        const data = makeBaseReportData({ audience });
+        const prompt = buildPrompt(data);
+
+        expect(prompt).toContain('IMPORTANT CONSTRAINTS');
+        expect(prompt).toContain('Base ALL observations strictly on the provided metrics');
+        expect(prompt).toContain('Do NOT comment on effort, attitude, coachability');
+      });
+    });
+
+    it('should include IMPORTANT CONSTRAINTS for undefined audience (default)', () => {
+      const data = makeBaseReportData();
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain('IMPORTANT CONSTRAINTS');
+    });
+  });
+});

--- a/packages/api/services/__tests__/ai-insights-audience-prompt.test.ts
+++ b/packages/api/services/__tests__/ai-insights-audience-prompt.test.ts
@@ -81,12 +81,13 @@ describe('buildPrompt audience branches', () => {
       expect(prompt).toContain('"you" language');
     });
 
-    it('should be motivating and specific', () => {
+    it('should have energizing tone and avoid clinical language', () => {
       const data = makeBaseReportData({ audience: 'athlete' });
       const prompt = buildPrompt(data);
 
-      expect(prompt).toContain('motivating and specific');
-      expect(prompt).toContain('exactly what to focus on in training');
+      expect(prompt).toContain('Direct, confident, and energizing');
+      expect(prompt).toContain('AVOID');
+      expect(prompt).toContain('Clinical or passive language');
     });
 
     it('should include the four athlete-oriented sections', () => {
@@ -104,6 +105,20 @@ describe('buildPrompt audience branches', () => {
       const prompt = buildPrompt(data);
 
       expect(prompt).toContain('150-200 words');
+    });
+
+    it('should use the athlete first name when available', () => {
+      const data = makeBaseReportData({ audience: 'athlete', athleteName: 'Jordan Smith' });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).toContain("athlete's first name (Jordan)");
+    });
+
+    it('should skip first-name instruction when athleteName is missing', () => {
+      const data = makeBaseReportData({ audience: 'athlete', athleteName: undefined });
+      const prompt = buildPrompt(data);
+
+      expect(prompt).not.toContain("athlete's first name");
     });
 
     it('should not contain parent-specific or coach-specific language', () => {

--- a/packages/api/services/ai-insights-service.ts
+++ b/packages/api/services/ai-insights-service.ts
@@ -427,6 +427,9 @@ export interface ReportData {
     metric: string;
     performance: string;
   }>;
+
+  // Audience for tailored language
+  audience?: 'coach' | 'athlete' | 'parent';
 }
 
 /**
@@ -575,21 +578,51 @@ function buildPrompt(reportData: ReportData): string {
     prompt += `\n`;
   }
 
-  // Instructions
+  // Instructions — tailored by audience
+  const audience = reportData.audience || 'coach';
+
   prompt += `## Instructions\n`;
-  prompt += `You are writing for sports coaches and athletes, NOT strength & conditioning experts. Use simple, everyday language.\n\n`;
-  prompt += `Provide coaching insights in markdown format with these sections:\n\n`;
-  prompt += `1. **Summary**: 2-3 sentences giving the big picture of this report based on the numbers\n`;
-  prompt += `2. **What's Going Well**: Top strengths shown by the data (metrics meeting or exceeding benchmarks)\n`;
-  prompt += `3. **What to Work On**: Key areas needing attention based on metrics and benchmarks\n`;
-  prompt += `4. **Next Steps**: 2-3 specific, actionable training recommendations to improve the metrics\n\n`;
-  prompt += `IMPORTANT CONSTRAINTS:\n`;
+
+  if (audience === 'parent') {
+    prompt += `You are writing for PARENTS of youth athletes, NOT coaches or trainers.\n\n`;
+    prompt += `Write in clear, non-technical language that a parent with no sports science background can understand. Focus on:\n\n`;
+    prompt += `1. **What the numbers mean** for their child's development\n`;
+    prompt += `2. **What's Going Well** — celebrate specific achievements with context\n`;
+    prompt += `3. **What to Work On** — frame as growth opportunities, not deficiencies\n`;
+    prompt += `4. **Why Continued Training Matters** — connect metrics to real athletic outcomes (making the team, getting faster, reducing injury risk)\n\n`;
+    prompt += `TONE: Encouraging, professional, data-backed. Like a doctor explaining test results — clear, honest, but not alarming.\n\n`;
+    prompt += `AVOID: Jargon (percentile ranks are OK, but explain what they mean), negative framing, comparisons that might discourage.\n\n`;
+    if (reportData.athleteName) {
+      const firstName = reportData.athleteName.split(' ')[0];
+      prompt += `Use the athlete's first name (${firstName}) throughout.\n\n`;
+    }
+    prompt += `Keep it to 200-300 words.\n`;
+  } else if (audience === 'athlete') {
+    prompt += `You are writing directly TO the athlete. Use "you" language.\n`;
+    prompt += `Be motivating and specific. Tell them exactly what to focus on in training.\n\n`;
+    prompt += `Provide insights in markdown format with these sections:\n\n`;
+    prompt += `1. **Summary**: 2-3 sentences — where you stand right now\n`;
+    prompt += `2. **What's Going Well**: Your top strengths shown by the data\n`;
+    prompt += `3. **What to Work On**: Specific areas to focus on\n`;
+    prompt += `4. **Next Steps**: 2-3 concrete things to do in your next training sessions\n\n`;
+    prompt += `Keep it short (150-200 words). Be real — athletes respect honesty over hype. Use bullet points and **bold** for emphasis.\n`;
+  } else {
+    // Default: coach audience
+    prompt += `You are writing for sports coaches and athletes, NOT strength & conditioning experts. Use simple, everyday language.\n\n`;
+    prompt += `Provide coaching insights in markdown format with these sections:\n\n`;
+    prompt += `1. **Summary**: 2-3 sentences giving the big picture of this report based on the numbers\n`;
+    prompt += `2. **What's Going Well**: Top strengths shown by the data (metrics meeting or exceeding benchmarks)\n`;
+    prompt += `3. **What to Work On**: Key areas needing attention based on metrics and benchmarks\n`;
+    prompt += `4. **Next Steps**: 2-3 specific, actionable training recommendations to improve the metrics\n\n`;
+    prompt += `Keep it short (150-250 words total). Be direct and objective. Use bullet points and **bold** for emphasis. Avoid technical jargon.\n`;
+  }
+
+  prompt += `\nIMPORTANT CONSTRAINTS:\n`;
   prompt += `- Base ALL observations strictly on the provided metrics and benchmark data\n`;
   prompt += `- Do NOT comment on effort, attitude, coachability, consistency, or other unmeasured qualities\n`;
   prompt += `- Do NOT make assumptions about behaviors, habits, or character traits\n`;
   prompt += `- Focus only on what the numbers show and specific training actions to improve them\n`;
-  prompt += `- When data is limited, acknowledge it rather than filling gaps with assumptions\n\n`;
-  prompt += `Keep it short (150-250 words total). Be direct and objective. Use bullet points and **bold** for emphasis. Avoid technical jargon.\n`;
+  prompt += `- When data is limited, acknowledge it rather than filling gaps with assumptions\n`;
 
   return prompt;
 }

--- a/packages/api/services/ai-insights-service.ts
+++ b/packages/api/services/ai-insights-service.ts
@@ -588,8 +588,7 @@ export function buildPrompt(reportData: ReportData): string {
     prompt += `Write in clear, non-technical language that a parent with no sports science background can understand. Focus on:\n\n`;
     prompt += `1. **What the numbers mean** for their child's development\n`;
     prompt += `2. **What's Going Well** — celebrate specific achievements with context\n`;
-    prompt += `3. **What to Work On** — frame as growth opportunities, not deficiencies\n`;
-    prompt += `4. **Why Continued Training Matters** — connect metrics to real athletic outcomes (making the team, getting faster, reducing injury risk)\n\n`;
+    prompt += `3. **What to Work On** — frame as growth opportunities, not deficiencies\n\n`;
     prompt += `TONE: Encouraging, professional, data-backed. Like a doctor explaining test results — clear, honest, but not alarming.\n\n`;
     prompt += `AVOID: Jargon (percentile ranks are OK, but explain what they mean), negative framing, comparisons that might discourage.\n\n`;
     if (reportData.athleteName) {
@@ -604,8 +603,7 @@ export function buildPrompt(reportData: ReportData): string {
     prompt += `Provide insights in markdown format with these sections:\n\n`;
     prompt += `1. **Summary**: 2-3 sentences — where you stand and what jumped out from the data\n`;
     prompt += `2. **What's Going Well**: Lead with wins — celebrate specific strengths the data proves\n`;
-    prompt += `3. **What to Work On**: Frame as challenges to attack, not weaknesses. Athletes want to know what to chase\n`;
-    prompt += `4. **Next Steps**: 2-3 concrete, specific things to do in the next training sessions\n\n`;
+    prompt += `3. **What to Work On**: Frame as challenges to attack, not weaknesses. Athletes want to know what to chase\n\n`;
     prompt += `TONE: Direct, confident, and energizing — like a coach who believes in you giving you your game plan. Speak to them as a competitor. Acknowledge effort where the data shows improvement. Be honest but never deflating.\n\n`;
     prompt += `AVOID: Clinical or passive language, hedging ("you might want to consider..."), generic praise ("great job!"), talking down to them. Athletes respect realness — show them the data backs up what you're saying.\n\n`;
     if (reportData.athleteName) {

--- a/packages/api/services/ai-insights-service.ts
+++ b/packages/api/services/ai-insights-service.ts
@@ -612,6 +612,9 @@ export function buildPrompt(reportData: ReportData): string {
         prompt += `Use the athlete's first name (${firstName}) to keep it personal.\n\n`;
       }
     }
+    // Note: athlete audience intentionally omits a "Next Steps" section — "What to Work On"
+    // already implies action (it tells the athlete what to chase). Adding a separate next-steps
+    // block would be redundant and dilute the direct, competitor-facing tone.
     prompt += `Keep it to 150-200 words. Use bullet points and **bold** for emphasis.\n`;
   } else {
     // Default: coach audience

--- a/packages/api/services/ai-insights-service.ts
+++ b/packages/api/services/ai-insights-service.ts
@@ -594,7 +594,9 @@ export function buildPrompt(reportData: ReportData): string {
     prompt += `AVOID: Jargon (percentile ranks are OK, but explain what they mean), negative framing, comparisons that might discourage.\n\n`;
     if (reportData.athleteName) {
       const firstName = sanitizeForPrompt(reportData.athleteName).split(' ')[0];
-      prompt += `Use the athlete's first name (${firstName}) throughout.\n\n`;
+      if (firstName) {
+        prompt += `Use the athlete's first name (${firstName}) throughout.\n\n`;
+      }
     }
     prompt += `Keep it to 200-300 words.\n`;
   } else if (audience === 'athlete') {

--- a/packages/api/services/ai-insights-service.ts
+++ b/packages/api/services/ai-insights-service.ts
@@ -593,7 +593,7 @@ export function buildPrompt(reportData: ReportData): string {
     prompt += `TONE: Encouraging, professional, data-backed. Like a doctor explaining test results — clear, honest, but not alarming.\n\n`;
     prompt += `AVOID: Jargon (percentile ranks are OK, but explain what they mean), negative framing, comparisons that might discourage.\n\n`;
     if (reportData.athleteName) {
-      const firstName = reportData.athleteName.split(' ')[0];
+      const firstName = sanitizeForPrompt(reportData.athleteName).split(' ')[0];
       prompt += `Use the athlete's first name (${firstName}) throughout.\n\n`;
     }
     prompt += `Keep it to 200-300 words.\n`;

--- a/packages/api/services/ai-insights-service.ts
+++ b/packages/api/services/ai-insights-service.ts
@@ -600,14 +600,21 @@ export function buildPrompt(reportData: ReportData): string {
     }
     prompt += `Keep it to 200-300 words.\n`;
   } else if (audience === 'athlete') {
-    prompt += `You are writing directly TO the athlete. Use "you" language.\n`;
-    prompt += `Be motivating and specific. Tell them exactly what to focus on in training.\n\n`;
+    prompt += `You are writing directly TO the athlete. Use "you" language.\n\n`;
     prompt += `Provide insights in markdown format with these sections:\n\n`;
-    prompt += `1. **Summary**: 2-3 sentences — where you stand right now\n`;
-    prompt += `2. **What's Going Well**: Your top strengths shown by the data\n`;
-    prompt += `3. **What to Work On**: Specific areas to focus on\n`;
-    prompt += `4. **Next Steps**: 2-3 concrete things to do in your next training sessions\n\n`;
-    prompt += `Keep it short (150-200 words). Be real — athletes respect honesty over hype. Use bullet points and **bold** for emphasis.\n`;
+    prompt += `1. **Summary**: 2-3 sentences — where you stand and what jumped out from the data\n`;
+    prompt += `2. **What's Going Well**: Lead with wins — celebrate specific strengths the data proves\n`;
+    prompt += `3. **What to Work On**: Frame as challenges to attack, not weaknesses. Athletes want to know what to chase\n`;
+    prompt += `4. **Next Steps**: 2-3 concrete, specific things to do in the next training sessions\n\n`;
+    prompt += `TONE: Direct, confident, and energizing — like a coach who believes in you giving you your game plan. Speak to them as a competitor. Acknowledge effort where the data shows improvement. Be honest but never deflating.\n\n`;
+    prompt += `AVOID: Clinical or passive language, hedging ("you might want to consider..."), generic praise ("great job!"), talking down to them. Athletes respect realness — show them the data backs up what you're saying.\n\n`;
+    if (reportData.athleteName) {
+      const firstName = sanitizeForPrompt(reportData.athleteName).split(' ')[0];
+      if (firstName) {
+        prompt += `Use the athlete's first name (${firstName}) to keep it personal.\n\n`;
+      }
+    }
+    prompt += `Keep it to 150-200 words. Use bullet points and **bold** for emphasis.\n`;
   } else {
     // Default: coach audience
     prompt += `You are writing for sports coaches and athletes, NOT strength & conditioning experts. Use simple, everyday language.\n\n`;

--- a/packages/api/services/ai-insights-service.ts
+++ b/packages/api/services/ai-insights-service.ts
@@ -472,7 +472,7 @@ export async function generateCoachingInsights(
  * Sanitize user-generated content before including in AI prompts
  * Prevents potential prompt injection attacks by escaping markdown and special characters
  */
-function sanitizeForPrompt(input: string): string {
+export function sanitizeForPrompt(input: string): string {
   if (!input) return '';
   return input
     .replace(/[#*_`\[\]<>]/g, '') // Remove markdown special characters
@@ -485,7 +485,7 @@ function sanitizeForPrompt(input: string): string {
 /**
  * Build the prompt for the AI model based on report data
  */
-function buildPrompt(reportData: ReportData): string {
+export function buildPrompt(reportData: ReportData): string {
   const { reportType } = reportData;
 
   // Sanitize user-provided content to prevent prompt injection

--- a/packages/shared/schema-original.ts
+++ b/packages/shared/schema-original.ts
@@ -2181,6 +2181,8 @@ export const insertReportSchema = createInsertSchema(reports).omit({
     // Individual report athlete identifiers
     athleteIds: z.array(z.string()).optional(), // Array of athlete IDs (used in creation)
     athleteId: z.string().optional(), // Single athlete ID (stored in database)
+    // Audience for tailored AI coaching insights language
+    audience: z.enum(['coach', 'athlete', 'parent']).optional(),
   }),
   isTemplate: z.boolean().default(false),
 });
@@ -2217,6 +2219,8 @@ export const updateReportSchema = z.object({
     // Individual report athlete identifiers
     athleteIds: z.array(z.string()).optional(), // Array of athlete IDs (used in creation)
     athleteId: z.string().optional(), // Single athlete ID (stored in database)
+    // Audience for tailored AI coaching insights language
+    audience: z.enum(['coach', 'athlete', 'parent']).optional(),
   }).optional(),
   isTemplate: z.boolean().optional(),
 });

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -88,7 +88,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
     watch,
     setValue,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, dirtyFields },
   } = useForm<ReportFormData>({
     resolver: zodResolver(reportConfigSchema),
     defaultValues: {
@@ -117,10 +117,12 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
     console.log('[ReportWizard] State changed - step:', step, 'reportType:', reportType);
   }, [step, reportType]);
 
-  // Default audience based on report type
+  // Default audience based on report type — only if user hasn't manually chosen
   useEffect(() => {
-    setValue("audience", reportType === "individual" ? "parent" : "coach");
-  }, [reportType, setValue]);
+    if (!dirtyFields.audience) {
+      setValue("audience", reportType === "individual" ? "parent" : "coach");
+    }
+  }, [reportType, setValue, dirtyFields.audience]);
   const timeframeType = watch("timeframeType");
   const selectedMetrics = watch("metrics");
   const enableCompositeIndex = watch("enableCompositeIndex");

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -112,11 +112,6 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
   const reportType = watch("reportType");
   const reportName = watch("name");
 
-  // Debug logging
-  useEffect(() => {
-    console.log('[ReportWizard] State changed - step:', step, 'reportType:', reportType);
-  }, [step, reportType]);
-
   // Default audience based on report type — only if user hasn't manually chosen
   useEffect(() => {
     if (!dirtyFields.audience) {
@@ -173,11 +168,9 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
 
   const handleNext = (e?: React.MouseEvent) => {
     e?.preventDefault();
-    console.log('[ReportWizard] handleNext - current step:', step, 'reportType:', reportType);
 
     // Validate report name on step 3 before progressing
     if (step === 3 && (!reportName || reportName.trim() === "")) {
-      console.log('[ReportWizard] Cannot proceed from step 3 - report name is required');
       return;
     }
 
@@ -188,7 +181,6 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
       } else {
         setStep(step + 1);
       }
-      console.log('[ReportWizard] Moving to step:', step + 1);
     }
   };
 
@@ -204,31 +196,21 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
   };
 
   const onSubmit = async (data: ReportFormData) => {
-    console.log('[ReportWizard] onSubmit called - step:', step, 'reportType:', reportType);
-    console.log('[ReportWizard] Form data:', JSON.stringify(data, null, 2));
-    console.log('[ReportWizard] athleteIds:', data.athleteIds);
-    console.log('[ReportWizard] athleteIds length:', data.athleteIds?.length);
-
     // Prevent submission if not on final step
     if (step !== totalSteps) {
-      console.error('[ReportWizard] Form submitted prematurely on step', step, '- blocking submission');
       return;
     }
 
     if (!organizationContext) {
-      console.log('[ReportWizard] No organizationContext - aborting');
       return;
     }
 
     // Extra validation for individual reports
     if (data.reportType === "individual") {
       if (!data.athleteIds || data.athleteIds.length === 0) {
-        console.error('[ReportWizard] Individual report submitted with no athletes!');
-        console.error('[ReportWizard] This should have been caught by Zod validation');
         // The Zod schema should have prevented this, but double-check
         return;
       }
-      console.log('[ReportWizard] Individual report has', data.athleteIds.length, 'athletes');
     }
 
     const config: any = {
@@ -382,10 +364,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
                 organizationId={organizationContext!}
                 selectedAthleteIds={watch("athleteIds") || []}
                 onSelectionChange={(ids) => {
-                  console.log('[ReportWizard] Athlete selection changed:', ids);
-                  console.log('[ReportWizard] Setting athleteIds to:', ids);
                   setValue("athleteIds", ids);
-                  console.log('[ReportWizard] Current form value:', watch("athleteIds"));
                 }}
               />
 
@@ -787,7 +766,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
               </Label>
               <RadioGroup
                 value={watch("audience")}
-                onValueChange={(value) => setValue("audience", value as "coach" | "athlete" | "parent")}
+                onValueChange={(value) => setValue("audience", value as "coach" | "athlete" | "parent", { shouldDirty: true })}
               >
                 <div className="flex items-center space-x-2 border rounded-lg p-3 cursor-pointer hover:bg-accent">
                   <RadioGroupItem value="coach" id="audience-coach" />

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -113,10 +113,13 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
   const reportType = watch("reportType");
   const reportName = watch("name");
 
-  // Default audience based on report type — only if user hasn't manually chosen
+  // Default audience based on report type — reset to coach for team reports
+  // since athlete/parent audiences only make sense for individual reports
   useEffect(() => {
-    if (!dirtyFields.audience) {
-      setValue("audience", reportType === "individual" ? "parent" : "coach");
+    if (reportType === "team") {
+      setValue("audience", "coach");
+    } else if (!dirtyFields.audience) {
+      setValue("audience", "parent");
     }
   }, [reportType, setValue, dirtyFields.audience]);
   const timeframeType = watch("timeframeType");
@@ -799,7 +802,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
                         </div>
                       </Label>
                     </div>
-                  </>
+                  <>
                 )}
               </RadioGroup>
             </div>

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/components/ui/select";
 import { Progress } from "@/components/ui/progress";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { ChevronLeft, ChevronRight, Layers, List } from "lucide-react";
+import { ChevronLeft, ChevronRight, Layers, List, Users } from "lucide-react";
 import { TeamAthleteSelector } from "@/components/ui/team-athlete-selector";
 import type { OrganizationBenchmarkWithDetails } from "@shared/schema";
 import { useContextualLabels } from "@/hooks/useContextualLabels";
@@ -52,6 +52,7 @@ const reportConfigSchema = z.object({
   teamIds: z.array(z.string()).optional(),
   gender: z.string().optional(),
   positions: z.array(z.string()).optional(),
+  audience: z.enum(["coach", "athlete", "parent"]).default("coach"),
   enableCompositeIndex: z.boolean().default(false),
   compositeWeights: z.record(z.string(), z.number()).optional(),
 }).superRefine((data, ctx) => {
@@ -92,6 +93,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
     resolver: zodResolver(reportConfigSchema),
     defaultValues: {
       reportType: "team",
+      audience: "coach",
       athleteIds: [],
       timeframeType: "preset",
       timeframePreset: "all_time",
@@ -114,6 +116,11 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
   useEffect(() => {
     console.log('[ReportWizard] State changed - step:', step, 'reportType:', reportType);
   }, [step, reportType]);
+
+  // Default audience based on report type
+  useEffect(() => {
+    setValue("audience", reportType === "individual" ? "parent" : "coach");
+  }, [reportType, setValue]);
   const timeframeType = watch("timeframeType");
   const selectedMetrics = watch("metrics");
   const enableCompositeIndex = watch("enableCompositeIndex");
@@ -231,6 +238,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
       },
       metrics: data.metrics,
       athleteIds: data.athleteIds,
+      audience: data.audience,
     };
 
     // Handle benchmarks - either from set or individual selection
@@ -768,7 +776,48 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
             </div>
           )}
 
-          {/* Step 8: Composite Index (Team Reports Only) */}
+          {/* Step 8: Audience + Composite Index (Team Reports) / Audience + Review (Individual) */}
+          {step === 8 && (
+            <div className="space-y-4 mb-4">
+              <Label className="flex items-center gap-2">
+                <Users className="h-4 w-4" />
+                Who will read this report?
+              </Label>
+              <RadioGroup
+                value={watch("audience")}
+                onValueChange={(value) => setValue("audience", value as "coach" | "athlete" | "parent")}
+              >
+                <div className="flex items-center space-x-2 border rounded-lg p-3 cursor-pointer hover:bg-accent">
+                  <RadioGroupItem value="coach" id="audience-coach" />
+                  <Label htmlFor="audience-coach" className="cursor-pointer flex-1">
+                    <div className="font-semibold">Coach</div>
+                    <div className="text-sm text-muted-foreground">
+                      Direct, objective coaching language with actionable training recommendations
+                    </div>
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2 border rounded-lg p-3 cursor-pointer hover:bg-accent">
+                  <RadioGroupItem value="athlete" id="audience-athlete" />
+                  <Label htmlFor="audience-athlete" className="cursor-pointer flex-1">
+                    <div className="font-semibold">Athlete</div>
+                    <div className="text-sm text-muted-foreground">
+                      Motivating "you" language — honest, specific, and to the point
+                    </div>
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2 border rounded-lg p-3 cursor-pointer hover:bg-accent">
+                  <RadioGroupItem value="parent" id="audience-parent" />
+                  <Label htmlFor="audience-parent" className="cursor-pointer flex-1">
+                    <div className="font-semibold">Parent</div>
+                    <div className="text-sm text-muted-foreground">
+                      Clear non-technical language explaining what the numbers mean for their child
+                    </div>
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+          )}
+
           {step === 8 && reportType === "team" && (
             <div className="space-y-4">
               <Label>Composite Index (Optional)</Label>

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -33,6 +33,7 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { ChevronLeft, ChevronRight, Layers, List, Users } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
 import { TeamAthleteSelector } from "@/components/ui/team-athlete-selector";
 import type { OrganizationBenchmarkWithDetails } from "@shared/schema";
 import { useContextualLabels } from "@/hooks/useContextualLabels";
@@ -777,30 +778,36 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
                     </div>
                   </Label>
                 </div>
-                <div className="flex items-center space-x-2 border rounded-lg p-3 cursor-pointer hover:bg-accent">
-                  <RadioGroupItem value="athlete" id="audience-athlete" />
-                  <Label htmlFor="audience-athlete" className="cursor-pointer flex-1">
-                    <div className="font-semibold">Athlete</div>
-                    <div className="text-sm text-muted-foreground">
-                      Motivating "you" language — honest, specific, and to the point
+                {/* Athlete and Parent audiences only apply to individual reports */}
+                {reportType === "individual" && (
+                  <>
+                    <div className="flex items-center space-x-2 border rounded-lg p-3 cursor-pointer hover:bg-accent">
+                      <RadioGroupItem value="athlete" id="audience-athlete" />
+                      <Label htmlFor="audience-athlete" className="cursor-pointer flex-1">
+                        <div className="font-semibold">Athlete</div>
+                        <div className="text-sm text-muted-foreground">
+                          Motivating "you" language — honest, specific, and to the point
+                        </div>
+                      </Label>
                     </div>
-                  </Label>
-                </div>
-                <div className="flex items-center space-x-2 border rounded-lg p-3 cursor-pointer hover:bg-accent">
-                  <RadioGroupItem value="parent" id="audience-parent" />
-                  <Label htmlFor="audience-parent" className="cursor-pointer flex-1">
-                    <div className="font-semibold">Parent</div>
-                    <div className="text-sm text-muted-foreground">
-                      Clear non-technical language explaining what the numbers mean for their child
+                    <div className="flex items-center space-x-2 border rounded-lg p-3 cursor-pointer hover:bg-accent">
+                      <RadioGroupItem value="parent" id="audience-parent" />
+                      <Label htmlFor="audience-parent" className="cursor-pointer flex-1">
+                        <div className="font-semibold">Parent</div>
+                        <div className="text-sm text-muted-foreground">
+                          Clear non-technical language explaining what the numbers mean for their child
+                        </div>
+                      </Label>
                     </div>
-                  </Label>
-                </div>
+                  </>
+                )}
               </RadioGroup>
             </div>
           )}
 
           {step === 8 && reportType === "team" && (
             <div className="space-y-4">
+              <Separator />
               <Label>Composite Index (Optional)</Label>
               <p className="text-sm text-muted-foreground mb-4">
                 Create a weighted composite score across multiple metrics to rank athletes
@@ -864,6 +871,14 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
                 </p>
                 <p className="text-sm">
                   <strong>Metrics:</strong> {selectedMetrics.length} selected
+                </p>
+                <p className="text-sm">
+                  <strong>Audience:</strong>{" "}
+                  {watch("audience") === "coach"
+                    ? "Coach"
+                    : watch("audience") === "athlete"
+                    ? "Athlete"
+                    : "Parent"}
                 </p>
                 <p className="text-sm text-muted-foreground">
                   Click "Create Report" to finish

--- a/packages/web/src/types/report-types.ts
+++ b/packages/web/src/types/report-types.ts
@@ -60,6 +60,7 @@ export interface TeamReportConfig {
   metrics: string[];
   filters?: ReportFilters;
   includeCompositeIndex?: boolean;
+  audience?: 'coach' | 'athlete' | 'parent';
   benchmarks?: {
     site?: string[]; // Site benchmark IDs
     custom?: string[]; // Custom benchmark IDs
@@ -80,6 +81,7 @@ export interface IndividualReportConfig {
   athleteIds?: string[];
   timeframe: TimeframeConfig;
   metrics: string[];
+  audience?: 'coach' | 'athlete' | 'parent';
   benchmarks?: {
     site?: string[]; // Site benchmark IDs
     custom?: string[]; // Custom benchmark IDs


### PR DESCRIPTION
## Summary
- Adds audience selection (coach/athlete/parent) to the Report Wizard so AI insights adapt tone and language
- AI insights service now accepts an `audience` parameter and adjusts prompt framing accordingly (technical for coaches, motivational for athletes, accessible for parents)
- Report route passes audience through to the AI insights pipeline

## Test plan
- [ ] Open Report Wizard and verify the audience selector appears (coach/athlete/parent)
- [ ] Generate a report with "coach" audience — insights should use technical language
- [ ] Generate a report with "parent" audience — insights should be accessible and non-jargon
- [ ] Generate a report with "athlete" audience — insights should be motivational
- [ ] Verify default behavior when no audience is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)