### PR TITLE
feat(reports): metric explanations in reports + PDFs (#367)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude-review
         timeout-minutes: 12
         continue-on-error: false
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.93
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,14 +27,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # continue-on-error: true so that an expired CLAUDE_CODE_OAUTH_TOKEN
-      # does not block PRs. The job still shows as failed (yellow ⚠) so it's
-      # visible, but it won't hold up the merge queue. To restore reviews,
-      # refresh the CLAUDE_CODE_OAUTH_TOKEN secret in repo Settings → Secrets.
+      # Auth: uses Claude Code OAuth (included with Claude Pro/Team subscription).
+      # If reviews stop working, refresh the token:
+      #   gh secret set CLAUDE_CODE_OAUTH_TOKEN
+      # Generate a new token at: https://console.anthropic.com/settings/tokens
       - name: Run Automated PR Review
         id: claude-review
         timeout-minutes: 12
-        continue-on-error: true
+        continue-on-error: false
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,14 +27,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # continue-on-error is false: silent failures previously masked broken
-      # auth for weeks. The github_token fallback handles OIDC failures, so
-      # the step should only fail on genuine issues worth investigating.
+      # continue-on-error: true so that an expired CLAUDE_CODE_OAUTH_TOKEN
+      # does not block PRs. The job still shows as failed (yellow ⚠) so it's
+      # visible, but it won't hold up the merge queue. To restore reviews,
+      # refresh the CLAUDE_CODE_OAUTH_TOKEN secret in repo Settings → Secrets.
       - name: Run Automated PR Review
         id: claude-review
         timeout-minutes: 12
-        continue-on-error: false
-        uses: anthropics/claude-code-action@v1.0.93
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20362,6 +20362,7 @@
         "react-hook-form": "^7.55.0",
         "react-icons": "^5.4.0",
         "react-joyride": "^2.9.3",
+        "react-markdown": "^10.1.0",
         "react-resizable-panels": "^3.0.6",
         "rehype-sanitize": "^6.0.0",
         "tailwind-merge": "^3.5.0",

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -32,6 +32,7 @@ import { isSiteAdmin } from "../utils/auth-helpers";
 import { coppaService } from "../services/coppa-service";
 import { parentalConsents, parentAthleteLinks } from "@shared/schema/tables/coppa";
 import { COPPA_ACTIONS } from "@shared/coppa-utils";
+import type { MetricExplanation } from "@shared/metric-explanations";
 import { RATE_LIMITS, RATE_LIMIT_WINDOW_MS } from "../constants/rate-limits";
 import { jsPDF } from "jspdf";
 import autoTable from "jspdf-autotable";
@@ -4297,6 +4298,65 @@ async function generatePDF(report: any, reportData: any, format: 'visual' | 'sim
       doc.setTextColor(colors.text[0], colors.text[1], colors.text[2]);
       yPos += 10;
     }
+  }
+
+  // --- Glossary of metrics (always last content section) ---
+  const glossaryExplanations: Record<string, MetricExplanation> =
+    reportData.metricExplanations ?? {};
+
+  // Collect ordered metric codes for glossary rows
+  const glossaryOrder: string[] = [];
+  const pushCode = (code: unknown) => {
+    if (typeof code === 'string' && code && !glossaryOrder.includes(code)) {
+      glossaryOrder.push(code);
+    }
+  };
+  if (reportData.reportType === 'team' && Array.isArray(reportData.teamStatistics)) {
+    for (const stat of reportData.teamStatistics) pushCode(stat?.metric);
+  } else if (reportData.reportType === 'individual' && reportData.athlete?.measurements) {
+    for (const code of Object.keys(reportData.athlete.measurements)) pushCode(code);
+  }
+  // Fallback: include any explanation keys that weren't already ordered
+  for (const code of Object.keys(glossaryExplanations)) pushCode(code);
+
+  const glossaryRows = glossaryOrder
+    .map((code) => {
+      const entry = glossaryExplanations[code];
+      if (!entry) return null;
+      return [entry.title || code, entry.whatItMeasures || '', entry.whyItMatters || '', entry.unitNote || ''];
+    })
+    .filter((row): row is string[] => row !== null);
+
+  if (glossaryRows.length > 0) {
+    doc.addPage();
+    doc.setFontSize(18);
+    doc.setTextColor(colors.primary[0], colors.primary[1], colors.primary[2]);
+    doc.text('Glossary of Metrics', 14, 20);
+    doc.setTextColor(colors.text[0], colors.text[1], colors.text[2]);
+
+    autoTable(doc, {
+      startY: 28,
+      head: [['Metric', 'What it measures', 'Why it matters', 'Unit & direction']],
+      body: glossaryRows,
+      theme: isVisual ? 'grid' : 'striped',
+      headStyles: {
+        fillColor: colors.primary,
+        textColor: [255, 255, 255],
+        fontStyle: 'bold',
+      },
+      styles: {
+        fontSize: 9,
+        cellPadding: 3,
+        valign: 'top',
+      },
+      columnStyles: {
+        0: { cellWidth: 32, fontStyle: 'bold' },
+        1: { cellWidth: 60 },
+        2: { cellWidth: 60 },
+        3: { cellWidth: 30 },
+      },
+      margin: { left: 14, right: 14 },
+    });
   }
 
   // Add footer to content pages — skip page 1 when a cover page was inserted

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -16,6 +16,7 @@ import {
   customBenchmarks,
   organizationBenchmarks,
   siteMetrics,
+  customOrgMetrics,
   events,
   organizations,
   type Report,
@@ -27,6 +28,11 @@ import { nanoid } from 'nanoid';
 import { quantileRank, median, mean, min, max, standardDeviation } from 'simple-statistics';
 import { BaseService } from './base-service';
 import { deriveTierGroupName } from '../utils/report-utils';
+import {
+  buildMetricExplanationsMap,
+  type MetricExplanation,
+  type CustomMetricsMap,
+} from '@shared/metric-explanations';
 
 interface TimeframeConfig {
   type: 'preset' | 'custom';
@@ -148,6 +154,7 @@ interface TeamReportData {
   athleteCount: number;
   metricLabels: Record<string, string>;
   metricUnits: Record<string, string>;
+  metricExplanations: Record<string, MetricExplanation>;
   eventContext?: EventContext; // Present when eventId filter is used
   orgBranding?: OrgBranding;
 }
@@ -159,6 +166,7 @@ interface IndividualReportData {
   generatedAt: string;
   metricLabels: Record<string, string>;
   metricUnits: Record<string, string>;
+  metricExplanations: Record<string, MetricExplanation>;
   eventContext?: EventContext; // Present when eventId filter is used
   orgBranding?: OrgBranding;
 }
@@ -203,6 +211,46 @@ export class ReportService extends BaseService {
     }
 
     return { labels, units };
+  }
+
+  /**
+   * Build athlete/parent-friendly explanations for each metric in a report.
+   * Built-in metric codes resolve against the shared static content; codes
+   * that aren't built-ins fall back to the org's custom metric description.
+   */
+  async getMetricExplanationsMap(
+    metricCodes: string[],
+    organizationId: string,
+  ): Promise<Record<string, MetricExplanation>> {
+    if (metricCodes.length === 0) return {};
+
+    const customRows = await db
+      .select({
+        code: customOrgMetrics.code,
+        label: customOrgMetrics.label,
+        description: customOrgMetrics.description,
+        unit: customOrgMetrics.unit,
+        metricType: customOrgMetrics.metricType,
+      })
+      .from(customOrgMetrics)
+      .where(
+        and(
+          eq(customOrgMetrics.organizationId, organizationId),
+          inArray(customOrgMetrics.code, metricCodes),
+        ),
+      );
+
+    const customMap: CustomMetricsMap = {};
+    for (const row of customRows) {
+      customMap[row.code] = {
+        label: row.label,
+        description: row.description,
+        unit: row.unit,
+        metricType: row.metricType,
+      };
+    }
+
+    return buildMetricExplanationsMap(metricCodes, customMap);
   }
 
   /**
@@ -276,6 +324,10 @@ export class ReportService extends BaseService {
 
     // Get metric display labels and units
     const { labels: metricLabels, units: metricUnits } = await this.getMetricLabelsAndUnits(config.metrics);
+    const metricExplanations = await this.getMetricExplanationsMap(
+      config.metrics,
+      report.organizationId,
+    );
 
     // Get event context if eventId is specified
     let eventContext: EventContext | undefined;
@@ -307,6 +359,7 @@ export class ReportService extends BaseService {
       athleteCount: athleteRankings.length,
       metricLabels,
       metricUnits,
+      metricExplanations,
       eventContext,
     };
 
@@ -461,6 +514,10 @@ export class ReportService extends BaseService {
 
     // Get metric display labels and units
     const { labels: metricLabels, units: metricUnits } = await this.getMetricLabelsAndUnits(config.metrics);
+    const metricExplanations = await this.getMetricExplanationsMap(
+      config.metrics,
+      report.organizationId,
+    );
 
     // Get event context if eventId is specified
     let eventContext: EventContext | undefined;
@@ -496,6 +553,7 @@ export class ReportService extends BaseService {
       generatedAt: new Date().toISOString(),
       metricLabels,
       metricUnits,
+      metricExplanations,
       eventContext,
     };
   }

--- a/packages/shared/__tests__/metric-explanations.test.ts
+++ b/packages/shared/__tests__/metric-explanations.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getMetricExplanation,
+  buildMetricExplanationsMap,
+  BUILT_IN_METRIC_CODES,
+  GENERIC_CUSTOM_METRIC_PLACEHOLDER,
+  type MetricExplanation,
+} from '../metric-explanations';
+
+const REQUIRED_FIELDS: Array<keyof MetricExplanation> = [
+  'title',
+  'shortDescription',
+  'whatItMeasures',
+  'whyItMatters',
+  'unitNote',
+  'directionOfBetter',
+];
+
+describe('getMetricExplanation — built-in metrics', () => {
+  it('returns full explanation for FLY10_TIME with directionOfBetter=lower', () => {
+    const result = getMetricExplanation('FLY10_TIME');
+    expect(result).toBeDefined();
+    expect(result.title).toBe('10-Yard Fly');
+    expect(result.directionOfBetter).toBe('lower');
+    expect(result.whatItMeasures).toMatch(/acceleration|velocity|speed/i);
+    expect(result.whyItMatters.length).toBeGreaterThan(20);
+    expect(result.unitNote).toMatch(/second/i);
+    expect(result.unitNote).toMatch(/lower is better/i);
+  });
+
+  it('returns directionOfBetter=higher for VERTICAL_JUMP', () => {
+    const result = getMetricExplanation('VERTICAL_JUMP');
+    expect(result.directionOfBetter).toBe('higher');
+    expect(result.unitNote).toMatch(/inch/i);
+    expect(result.unitNote).toMatch(/higher is better/i);
+  });
+
+  it('returns directionOfBetter=higher for TOP_SPEED (mph)', () => {
+    const result = getMetricExplanation('TOP_SPEED');
+    expect(result.directionOfBetter).toBe('higher');
+    expect(result.unitNote).toMatch(/mph/i);
+  });
+
+  it('returns directionOfBetter=higher for RSI with unit-agnostic note', () => {
+    const result = getMetricExplanation('RSI');
+    expect(result.directionOfBetter).toBe('higher');
+    expect(result.unitNote.length).toBeGreaterThan(0);
+  });
+
+  it('exposes BUILT_IN_METRIC_CODES with all 8 documented metrics', () => {
+    expect(BUILT_IN_METRIC_CODES).toEqual(
+      expect.arrayContaining([
+        'FLY10_TIME',
+        'VERTICAL_JUMP',
+        'AGILITY_505',
+        'AGILITY_5105',
+        'T_TEST',
+        'DASH_40YD',
+        'TOP_SPEED',
+        'RSI',
+      ]),
+    );
+    expect(BUILT_IN_METRIC_CODES).toHaveLength(8);
+  });
+
+  it.each(['FLY10_TIME', 'VERTICAL_JUMP', 'AGILITY_505', 'AGILITY_5105', 'T_TEST', 'DASH_40YD', 'TOP_SPEED', 'RSI'])(
+    '%s has all required fields populated',
+    (code) => {
+      const result = getMetricExplanation(code);
+      for (const field of REQUIRED_FIELDS) {
+        expect(result[field], `${code} missing field ${field}`).toBeTruthy();
+      }
+    },
+  );
+});
+
+describe('getMetricExplanation — custom metrics fallback', () => {
+  it('uses customOrgMetrics.description as whatItMeasures when provided', () => {
+    const result = getMetricExplanation('CUSTOM_BROAD_JUMP', {
+      CUSTOM_BROAD_JUMP: { label: 'Broad Jump', description: 'Horizontal jump distance from standing start.' },
+    });
+    expect(result.title).toBe('Broad Jump');
+    expect(result.whatItMeasures).toBe('Horizontal jump distance from standing start.');
+    expect(result.directionOfBetter).toBe('higher');
+  });
+
+  it('falls back to generic placeholder when description is null', () => {
+    const result = getMetricExplanation('CUSTOM_NO_DESC', {
+      CUSTOM_NO_DESC: { label: 'Custom', description: null },
+    });
+    expect(result.whatItMeasures).toBe(GENERIC_CUSTOM_METRIC_PLACEHOLDER);
+  });
+
+  it('falls back to generic placeholder when description is an empty string', () => {
+    const result = getMetricExplanation('CUSTOM_EMPTY', {
+      CUSTOM_EMPTY: { label: 'Custom', description: '' },
+    });
+    expect(result.whatItMeasures).toBe(GENERIC_CUSTOM_METRIC_PLACEHOLDER);
+  });
+
+  it('falls back to the raw code as title when no label is available', () => {
+    const result = getMetricExplanation('CUSTOM_NO_LABEL', {
+      CUSTOM_NO_LABEL: { label: '', description: 'Some description' },
+    });
+    expect(result.title).toBe('CUSTOM_NO_LABEL');
+  });
+});
+
+describe('getMetricExplanation — unknown and malformed input', () => {
+  it('returns placeholder explanation for unknown code with no custom map', () => {
+    const result = getMetricExplanation('UNKNOWN_CODE');
+    expect(result).toBeDefined();
+    expect(result.whatItMeasures).toBe(GENERIC_CUSTOM_METRIC_PLACEHOLDER);
+    expect(result.title).toBe('UNKNOWN_CODE');
+  });
+
+  it('returns placeholder when custom map does not contain the code', () => {
+    const result = getMetricExplanation('MISSING_CODE', {
+      OTHER_CODE: { label: 'Other', description: 'Other description' },
+    });
+    expect(result.whatItMeasures).toBe(GENERIC_CUSTOM_METRIC_PLACEHOLDER);
+    expect(result.title).toBe('MISSING_CODE');
+  });
+
+  it('handles empty string code without throwing', () => {
+    expect(() => getMetricExplanation('')).not.toThrow();
+    const result = getMetricExplanation('');
+    expect(result.whatItMeasures).toBe(GENERIC_CUSTOM_METRIC_PLACEHOLDER);
+  });
+
+  it('preserves built-in precedence even if a custom map entry exists for the same code', () => {
+    const result = getMetricExplanation('FLY10_TIME', {
+      FLY10_TIME: { label: 'Hijacked', description: 'Malicious override' },
+    });
+    expect(result.title).toBe('10-Yard Fly');
+    expect(result.whatItMeasures).not.toBe('Malicious override');
+  });
+});
+
+describe('getMetricExplanation — custom metric direction and unit', () => {
+  it('maps metricType=lower_is_better to directionOfBetter=lower', () => {
+    const result = getMetricExplanation('CUSTOM_SPRINT', {
+      CUSTOM_SPRINT: {
+        label: 'Custom Sprint',
+        description: 'Timed sprint.',
+        unit: 'seconds',
+        metricType: 'lower_is_better',
+      },
+    });
+    expect(result.directionOfBetter).toBe('lower');
+    expect(result.unitNote).toMatch(/seconds/i);
+    expect(result.unitNote).toMatch(/lower is better/i);
+  });
+
+  it('maps metricType=higher_is_better to directionOfBetter=higher', () => {
+    const result = getMetricExplanation('CUSTOM_POWER', {
+      CUSTOM_POWER: {
+        label: 'Custom Power',
+        description: 'Peak output.',
+        unit: 'watts',
+        metricType: 'higher_is_better',
+      },
+    });
+    expect(result.directionOfBetter).toBe('higher');
+    expect(result.unitNote).toMatch(/watts/i);
+    expect(result.unitNote).toMatch(/higher is better/i);
+  });
+
+  it('defaults to higher when metricType is missing', () => {
+    const result = getMetricExplanation('CUSTOM_UNKNOWN', {
+      CUSTOM_UNKNOWN: { label: 'Custom', description: 'x' },
+    });
+    expect(result.directionOfBetter).toBe('higher');
+  });
+
+  it('maps metricType=tracking to directionOfBetter=tracking with a neutral unit note', () => {
+    const result = getMetricExplanation('CUSTOM_HEIGHT', {
+      CUSTOM_HEIGHT: {
+        label: 'Custom Height',
+        description: 'Athlete standing height.',
+        unit: 'cm',
+        metricType: 'tracking',
+      },
+    });
+    expect(result.directionOfBetter).toBe('tracking');
+    expect(result.unitNote).toMatch(/cm/);
+    expect(result.unitNote).toMatch(/tracked value/i);
+    expect(result.unitNote).not.toMatch(/(higher|lower) is better/i);
+  });
+
+  it('uses a unit-agnostic note when unit is null', () => {
+    const result = getMetricExplanation('CUSTOM_NO_UNIT', {
+      CUSTOM_NO_UNIT: {
+        label: 'Custom',
+        description: 'x',
+        unit: null,
+        metricType: 'higher_is_better',
+      },
+    });
+    expect(result.unitNote).toMatch(/higher is better/i);
+    expect(result.unitNote).not.toMatch(/measured in/i);
+  });
+});
+
+describe('buildMetricExplanationsMap', () => {
+  it('dedups repeated codes so each resolves once', () => {
+    const out = buildMetricExplanationsMap(['FLY10_TIME', 'FLY10_TIME', 'VERTICAL_JUMP']);
+    expect(Object.keys(out)).toHaveLength(2);
+    expect(out.FLY10_TIME.title).toBe('10-Yard Fly');
+    expect(out.VERTICAL_JUMP.title).toBe('Vertical Jump');
+  });
+
+  it('skips empty-string codes without throwing', () => {
+    const out = buildMetricExplanationsMap(['', 'FLY10_TIME']);
+    expect(Object.keys(out)).toEqual(['FLY10_TIME']);
+  });
+});

--- a/packages/shared/metric-explanations/built-ins.ts
+++ b/packages/shared/metric-explanations/built-ins.ts
@@ -13,11 +13,11 @@ export const GENERIC_CUSTOM_METRIC_PLACEHOLDER =
 export const BUILT_IN_METRIC_EXPLANATIONS: Record<string, MetricExplanation> = {
   FLY10_TIME: {
     title: '10-Yard Fly',
-    shortDescription: "How fast you hit and hold top speed once you're already moving.",
+    shortDescription: 'How fast you cover 10 yards at top speed — a pure max velocity measurement.',
     whatItMeasures:
-      'The 10-yard fly measures your maximum velocity acceleration capacity. It captures how quickly you can reach and maintain top speed over a short distance.',
+      'The 10-yard fly measures the time it takes to run 10 yards after you are already up to full speed. When converted from time to speed, it is essentially a maximum velocity measurement.',
     whyItMatters:
-      "This metric is crucial for sports requiring explosive speed bursts. It reflects your ability to accelerate after an initial buildup phase, simulating game situations where you're already in motion.",
+      "Max velocity separates fast athletes from the fastest. In game situations you're often already moving — this test captures how fast you actually are once acceleration is out of the picture.",
     unitNote: 'Measured in seconds; lower is better.',
     directionOfBetter: 'lower',
   },

--- a/packages/shared/metric-explanations/built-ins.ts
+++ b/packages/shared/metric-explanations/built-ins.ts
@@ -1,0 +1,96 @@
+export type MetricExplanation = {
+  title: string;
+  shortDescription: string;
+  whatItMeasures: string;
+  whyItMatters: string;
+  unitNote: string;
+  directionOfBetter: 'lower' | 'higher' | 'tracking';
+};
+
+export const GENERIC_CUSTOM_METRIC_PLACEHOLDER =
+  'This is a custom metric tracked by your organization. Ask your coach for more details about what it measures.';
+
+export const BUILT_IN_METRIC_EXPLANATIONS: Record<string, MetricExplanation> = {
+  FLY10_TIME: {
+    title: '10-Yard Fly',
+    shortDescription: "How fast you hit and hold top speed once you're already moving.",
+    whatItMeasures:
+      'The 10-yard fly measures your maximum velocity acceleration capacity. It captures how quickly you can reach and maintain top speed over a short distance.',
+    whyItMatters:
+      "This metric is crucial for sports requiring explosive speed bursts. It reflects your ability to accelerate after an initial buildup phase, simulating game situations where you're already in motion.",
+    unitNote: 'Measured in seconds; lower is better.',
+    directionOfBetter: 'lower',
+  },
+  VERTICAL_JUMP: {
+    title: 'Vertical Jump',
+    shortDescription: 'How much explosive power your legs generate in a standing jump.',
+    whatItMeasures:
+      'The vertical jump measures your explosive lower body power by calculating the difference between your standing reach and maximum jump height.',
+    whyItMatters:
+      'Vertical jump is one of the best indicators of lower body explosiveness and athletic potential. It correlates strongly with sprinting speed, change of direction ability, and overall power output.',
+    unitNote: 'Measured in inches; higher is better.',
+    directionOfBetter: 'higher',
+  },
+  AGILITY_505: {
+    title: '5-0-5 Agility Test',
+    shortDescription: 'How quickly you can stop, turn 180 degrees, and sprint back.',
+    whatItMeasures:
+      'The 5-0-5 test measures your ability to decelerate, change direction 180 degrees, and re-accelerate. You sprint 5 meters, plant and turn, then sprint back through the timing gates.',
+    whyItMatters:
+      "This test isolates single-leg change of direction ability, revealing asymmetries between legs. It's essential for sports requiring quick direction changes and reflects injury risk factors.",
+    unitNote: 'Measured in seconds; lower is better.',
+    directionOfBetter: 'lower',
+  },
+  AGILITY_5105: {
+    title: '5-10-5 Pro Agility',
+    shortDescription: 'How fast you can change direction side to side — the NFL Combine standard.',
+    whatItMeasures:
+      'The Pro Agility (5-10-5) shuttle measures lateral quickness and change of direction. Starting in a three-point stance, you sprint 5 yards, touch, sprint 10 yards, touch, then sprint 5 yards.',
+    whyItMatters:
+      'This is the standard NFL Combine agility test. It measures lateral movement ability, hip flexibility, and the capacity to rapidly change direction — all critical for field and court sports.',
+    unitNote: 'Measured in seconds; lower is better.',
+    directionOfBetter: 'lower',
+  },
+  T_TEST: {
+    title: 'T-Test Agility',
+    shortDescription: 'How well you move forward, sideways, and backward in one drill.',
+    whatItMeasures:
+      'The T-Test measures multi-directional agility through a T-shaped course. You sprint forward, shuffle left, shuffle right, shuffle back to center, then backpedal to start.',
+    whyItMatters:
+      'This comprehensive agility test evaluates forward, lateral, and backward movement in a single drill. It reveals overall movement competency and coordination across all movement planes.',
+    unitNote: 'Measured in seconds; lower is better.',
+    directionOfBetter: 'lower',
+  },
+  DASH_40YD: {
+    title: '40-Yard Dash',
+    shortDescription: 'How fast you accelerate from a standstill over a longer distance.',
+    whatItMeasures:
+      'The 40-yard dash is the gold standard for measuring linear speed and acceleration. It tests your ability to explode from a standstill and maintain acceleration over a significant distance.',
+    whyItMatters:
+      'The 40-yard dash is the most recognized speed test in American sports, especially football. It measures both your starting explosiveness and your ability to reach top speed.',
+    unitNote: 'Measured in seconds; lower is better.',
+    directionOfBetter: 'lower',
+  },
+  TOP_SPEED: {
+    title: 'Top Speed',
+    shortDescription: 'Your fastest running pace once fully up to speed.',
+    whatItMeasures:
+      'Top speed measures your maximum running velocity, typically captured via GPS or radar during a sprint. It represents the fastest speed you can achieve.',
+    whyItMatters:
+      'Maximum velocity separates good athletes from great ones. While acceleration matters for short distances, top speed becomes crucial for longer sprints and open-field plays.',
+    unitNote: 'Measured in mph; higher is better.',
+    directionOfBetter: 'higher',
+  },
+  RSI: {
+    title: 'Reactive Strength Index',
+    shortDescription: 'How efficiently you bounce off the ground — spring and stiffness in one number.',
+    whatItMeasures:
+      'RSI measures the ratio of jump height to ground contact time during drop jumps. It indicates how efficiently you can use the stretch-shortening cycle.',
+    whyItMatters:
+      'RSI reflects your ability to rapidly switch from eccentric to concentric muscle action — crucial for jumping, sprinting, and change of direction. Higher values indicate better reactive ability.',
+    unitNote: 'Dimensionless ratio; higher is better.',
+    directionOfBetter: 'higher',
+  },
+};
+
+export const BUILT_IN_METRIC_CODES: ReadonlyArray<string> = Object.keys(BUILT_IN_METRIC_EXPLANATIONS);

--- a/packages/shared/metric-explanations/index.ts
+++ b/packages/shared/metric-explanations/index.ts
@@ -1,0 +1,80 @@
+import {
+  BUILT_IN_METRIC_EXPLANATIONS,
+  BUILT_IN_METRIC_CODES,
+  GENERIC_CUSTOM_METRIC_PLACEHOLDER,
+  type MetricExplanation,
+} from './built-ins';
+
+export { BUILT_IN_METRIC_EXPLANATIONS, BUILT_IN_METRIC_CODES, GENERIC_CUSTOM_METRIC_PLACEHOLDER };
+export type { MetricExplanation };
+
+export type CustomMetricEntry = {
+  label: string;
+  description: string | null;
+  unit?: string | null;
+  metricType?: 'lower_is_better' | 'higher_is_better' | 'tracking' | null;
+};
+
+export type CustomMetricsMap = Record<string, CustomMetricEntry>;
+
+function mapDirection(metricType: CustomMetricEntry['metricType']): 'lower' | 'higher' | 'tracking' {
+  if (metricType === 'lower_is_better') return 'lower';
+  if (metricType === 'tracking') return 'tracking';
+  return 'higher';
+}
+
+function buildCustomUnitNote(
+  entry: CustomMetricEntry | undefined,
+  direction: 'lower' | 'higher' | 'tracking',
+): string {
+  const unit = entry?.unit?.trim();
+  let directionText: string;
+  if (direction === 'lower') directionText = 'lower is better';
+  else if (direction === 'higher') directionText = 'higher is better';
+  else directionText = 'tracked value, not judged as better or worse';
+
+  if (unit) {
+    return `Measured in ${unit}; ${directionText}.`;
+  }
+  return `Unit depends on the metric configured by your organization; ${directionText}.`;
+}
+
+export function getMetricExplanation(
+  code: string,
+  customMetricsMap?: CustomMetricsMap,
+): MetricExplanation {
+  const builtIn = BUILT_IN_METRIC_EXPLANATIONS[code];
+  if (builtIn) {
+    return builtIn;
+  }
+
+  const custom = customMetricsMap?.[code];
+  const title = custom?.label?.trim() ? custom.label : code;
+  const trimmedDescription = custom?.description?.trim();
+  const description = trimmedDescription || GENERIC_CUSTOM_METRIC_PLACEHOLDER;
+  const direction = mapDirection(custom?.metricType);
+
+  return {
+    title,
+    shortDescription: description,
+    whatItMeasures: description,
+    whyItMatters:
+      'Your coach added this metric to track something specific to your sport or training focus. Reach out if you want more context on how it applies to your goals.',
+    unitNote: buildCustomUnitNote(custom, direction),
+    directionOfBetter: direction,
+  };
+}
+
+export function buildMetricExplanationsMap(
+  codes: string[],
+  customMetricsMap?: CustomMetricsMap,
+): Record<string, MetricExplanation> {
+  const out: Record<string, MetricExplanation> = {};
+  const seen = new Set<string>();
+  for (const code of codes) {
+    if (!code || seen.has(code)) continue;
+    seen.add(code);
+    out[code] = getMetricExplanation(code, customMetricsMap);
+  }
+  return out;
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,7 +24,8 @@
     "./season-utils": "./season-utils.ts",
     "./username-validation": "./username-validation.ts",
     "./utils/number-conversion": "./utils/number-conversion.ts",
-    "./utils/statistics": "./utils/statistics.ts"
+    "./utils/statistics": "./utils/statistics.ts",
+    "./metric-explanations": "./metric-explanations/index.ts"
   },
   "dependencies": {
     "date-fns": "^4.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -67,6 +67,7 @@
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.4.0",
     "react-joyride": "^2.9.3",
+    "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
     "rehype-sanitize": "^6.0.0",
     "tailwind-merge": "^3.5.0",

--- a/packages/web/src/components/reports/IndividualReportView.tsx
+++ b/packages/web/src/components/reports/IndividualReportView.tsx
@@ -21,6 +21,8 @@ import { FileDown, Share2, Send } from "lucide-react";
 import { ShareReportDialog } from "./ShareReportDialog";
 import { SendReportToAthleteDialog } from "./SendReportToAthleteDialog";
 import { CoachingInsightsCard } from "./CoachingInsightsCard";
+import { MetricExplanation } from "./MetricExplanation";
+import { ReportMetricsGlossary } from "./ReportMetricsGlossary";
 import { format } from "date-fns";
 import { isFly10Metric, formatFly10Dual } from "@/utils/fly10-conversion";
 import { extractAthleteId } from "./report-utils";
@@ -99,7 +101,8 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
     );
   }
 
-  const { athlete, metricLabels, metricUnits } = reportData;
+  const { athlete, metricLabels, metricUnits, metricExplanations } = reportData;
+  const measurementCodes = athlete?.measurements ? Object.keys(athlete.measurements) : [];
 
   return (
     <div className="space-y-6">
@@ -193,7 +196,12 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
 
                   return (
                     <TableRow key={metricCode}>
-                      <TableCell className="font-medium">{metricLabel}</TableCell>
+                      <TableCell className="font-medium align-top">
+                        <MetricExplanation
+                          label={metricLabel}
+                          explanation={metricExplanations?.[metricCode]}
+                        />
+                      </TableCell>
                       <TableCell>
                         {typeof value === 'number'
                           ? (isFly10Metric(metricCode)
@@ -263,6 +271,12 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
         </Card>
       )}
 
+      {metricExplanations && (
+        <ReportMetricsGlossary
+          explanations={metricExplanations}
+          metricOrder={measurementCodes}
+        />
+      )}
 
       {showShareDialog && (
         <ShareReportDialog

--- a/packages/web/src/components/reports/MetricExplanation.tsx
+++ b/packages/web/src/components/reports/MetricExplanation.tsx
@@ -1,0 +1,71 @@
+import { useId, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
+import { ChevronDown, Info } from 'lucide-react';
+import type { MetricExplanation as MetricExplanationData } from '@shared/metric-explanations';
+import { cn } from '@/lib/utils';
+
+interface MetricExplanationProps {
+  label: string;
+  explanation: MetricExplanationData | undefined;
+  className?: string;
+}
+
+export function MetricExplanation({ label, explanation, className }: MetricExplanationProps) {
+  const [open, setOpen] = useState(false);
+  const reactId = useId();
+
+  if (!explanation) {
+    return <span className={className}>{label}</span>;
+  }
+
+  const contentId = `metric-explanation-${reactId}`;
+
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      <div className="flex items-center gap-1.5">
+        <span className="font-medium">{label}</span>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-controls={contentId}
+          aria-label={`Explanation for ${explanation.title}`}
+          className="inline-flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Info className="h-3.5 w-3.5" aria-hidden="true" />
+          <ChevronDown
+            className={cn(
+              'h-3 w-3 transition-transform',
+              open ? 'rotate-180' : 'rotate-0',
+            )}
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+      {open && (
+        <div
+          id={contentId}
+          className="text-sm text-muted-foreground bg-muted/40 rounded-md p-3 space-y-2"
+        >
+          <div className="prose prose-sm max-w-none dark:prose-invert">
+            <p className="font-semibold text-foreground">{explanation.shortDescription}</p>
+            <div>
+              <p className="font-medium text-foreground mb-1">What it measures</p>
+              <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
+                {explanation.whatItMeasures}
+              </ReactMarkdown>
+            </div>
+            <div>
+              <p className="font-medium text-foreground mb-1">Why it matters</p>
+              <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
+                {explanation.whyItMatters}
+              </ReactMarkdown>
+            </div>
+            <p className="text-xs italic">{explanation.unitNote}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/reports/ReportMetricsGlossary.tsx
+++ b/packages/web/src/components/reports/ReportMetricsGlossary.tsx
@@ -12,7 +12,7 @@ interface ReportMetricsGlossaryProps {
 
 export function ReportMetricsGlossary({ explanations, metricOrder }: ReportMetricsGlossaryProps) {
   const headingId = useId();
-  const codes = metricOrder?.filter((c) => explanations[c]) ?? Object.keys(explanations);
+  const codes = [...new Set(metricOrder?.filter((c) => explanations[c]) ?? Object.keys(explanations))];
 
   if (codes.length === 0) {
     return null;

--- a/packages/web/src/components/reports/ReportMetricsGlossary.tsx
+++ b/packages/web/src/components/reports/ReportMetricsGlossary.tsx
@@ -1,0 +1,58 @@
+import { useId } from 'react';
+import ReactMarkdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
+import { BookOpen } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import type { MetricExplanation } from '@shared/metric-explanations';
+
+interface ReportMetricsGlossaryProps {
+  explanations: Record<string, MetricExplanation>;
+  metricOrder?: string[];
+}
+
+export function ReportMetricsGlossary({ explanations, metricOrder }: ReportMetricsGlossaryProps) {
+  const headingId = useId();
+  const codes = metricOrder?.filter((c) => explanations[c]) ?? Object.keys(explanations);
+
+  if (codes.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-labelledby={headingId}>
+      <Card className="mt-6">
+        <CardHeader>
+          <h2
+            id={headingId}
+            className="flex items-center gap-2 text-lg font-semibold leading-none tracking-tight"
+          >
+            <BookOpen className="h-5 w-5" aria-hidden="true" />
+            Glossary of metrics
+          </h2>
+        </CardHeader>
+        <CardContent className="space-y-6">
+        {codes.map((code) => {
+          const entry = explanations[code];
+          return (
+            <div key={code} className="space-y-2">
+              <h3 className="text-base font-semibold">{entry.title}</h3>
+              <p className="text-sm text-muted-foreground">{entry.shortDescription}</p>
+              <div className="prose prose-sm max-w-none dark:prose-invert">
+                <p className="font-medium text-foreground">What it measures</p>
+                <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
+                  {entry.whatItMeasures}
+                </ReactMarkdown>
+                <p className="font-medium text-foreground">Why it matters</p>
+                <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
+                  {entry.whyItMatters}
+                </ReactMarkdown>
+              </div>
+              <p className="text-xs italic text-muted-foreground">{entry.unitNote}</p>
+            </div>
+          );
+        })}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/packages/web/src/components/reports/TeamReportView.tsx
+++ b/packages/web/src/components/reports/TeamReportView.tsx
@@ -30,6 +30,8 @@ import { FileDown, Share2, Users, Calendar, TrendingUp, Activity, ChevronDown, S
 import { ShareReportDialog } from "./ShareReportDialog";
 import { SendReportToMultipleAthletesDialog } from "./SendReportToMultipleAthletesDialog";
 import { CoachingInsightsCard } from "./CoachingInsightsCard";
+import { MetricExplanation } from "./MetricExplanation";
+import { ReportMetricsGlossary } from "./ReportMetricsGlossary";
 import { format } from "date-fns";
 import { getMetricDisplayName } from "@/lib/metrics";
 import {
@@ -127,7 +129,8 @@ export function TeamReportView({ report }: TeamReportViewProps) {
     );
   }
 
-  const { teamStatistics, athleteRankings, generatedAt, metricLabels, metricUnits } = reportData;
+  const { teamStatistics, athleteRankings, generatedAt, metricLabels, metricUnits, metricExplanations } = reportData;
+  const teamMetricCodes = Array.isArray(teamStatistics) ? teamStatistics.map((s: TeamStatistic) => s.metric) : [];
 
   // Collect all unique benchmark names across all metrics
   const allBenchmarkNames = new Set<string>();
@@ -294,7 +297,12 @@ export function TeamReportView({ report }: TeamReportViewProps) {
 
                   return (
                     <TableRow key={stat.metric}>
-                      <TableCell className="font-medium">{metricLabels?.[stat.metric] || stat.metric}</TableCell>
+                      <TableCell className="font-medium align-top">
+                        <MetricExplanation
+                          label={metricLabels?.[stat.metric] || stat.metric}
+                          explanation={metricExplanations?.[stat.metric]}
+                        />
+                      </TableCell>
                       <TableCell>
                         {stat.average !== null && stat.average !== undefined
                           ? (isFly10Metric(stat.metric)
@@ -608,6 +616,13 @@ export function TeamReportView({ report }: TeamReportViewProps) {
             );
           })}
         </div>
+      )}
+
+      {metricExplanations && (
+        <ReportMetricsGlossary
+          explanations={metricExplanations}
+          metricOrder={teamMetricCodes}
+        />
       )}
 
       {showShareDialog && (

--- a/packages/web/src/components/reports/__tests__/MetricExplanation.test.tsx
+++ b/packages/web/src/components/reports/__tests__/MetricExplanation.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MetricExplanation } from '../MetricExplanation';
+import type { MetricExplanation as MetricExplanationData } from '@shared/metric-explanations';
+
+const FLY10_EXPLANATION: MetricExplanationData = {
+  title: '10-Yard Fly',
+  shortDescription: 'How fast you hit and hold top speed once moving.',
+  whatItMeasures: 'The 10-yard fly measures **maximum velocity** over a short zone.',
+  whyItMatters: 'It reflects game-speed acceleration.',
+  unitNote: 'Measured in seconds; lower is better.',
+  directionOfBetter: 'lower',
+};
+
+describe('MetricExplanation', () => {
+  it('renders the metric label', () => {
+    render(
+      <MetricExplanation label="10-Yard Fly Time" explanation={FLY10_EXPLANATION} />,
+    );
+    expect(screen.getByText('10-Yard Fly Time')).toBeInTheDocument();
+  });
+
+  it('is collapsed by default — detailed markdown is not visible', () => {
+    render(
+      <MetricExplanation label="10-Yard Fly Time" explanation={FLY10_EXPLANATION} />,
+    );
+    expect(screen.queryByText(/maximum velocity/i)).not.toBeInTheDocument();
+  });
+
+  it('expands on click to reveal whatItMeasures and whyItMatters', () => {
+    render(
+      <MetricExplanation label="10-Yard Fly Time" explanation={FLY10_EXPLANATION} />,
+    );
+    const trigger = screen.getByRole('button', { name: /explanation for 10-yard fly/i });
+    fireEvent.click(trigger);
+    expect(screen.getByText(/maximum velocity/i)).toBeInTheDocument();
+    expect(screen.getByText(/game-speed acceleration/i)).toBeInTheDocument();
+  });
+
+  it('toggles aria-expanded on the trigger', () => {
+    render(
+      <MetricExplanation label="10-Yard Fly Time" explanation={FLY10_EXPLANATION} />,
+    );
+    const trigger = screen.getByRole('button', { name: /explanation for 10-yard fly/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('renders only the label when explanation is undefined (no trigger)', () => {
+    render(<MetricExplanation label="Unknown Metric" explanation={undefined} />);
+    expect(screen.getByText('Unknown Metric')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /explanation for/i })).not.toBeInTheDocument();
+  });
+
+  it('does not execute scripts embedded in custom markdown', () => {
+    const malicious: MetricExplanationData = {
+      ...FLY10_EXPLANATION,
+      title: 'Custom Metric',
+      whatItMeasures: 'Safe text <script>window.__pwned = true;</script> continues.',
+    };
+    const { container } = render(
+      <MetricExplanation label="Custom Metric" explanation={malicious} />,
+    );
+    const trigger = screen.getByRole('button', { name: /explanation for custom metric/i });
+    fireEvent.click(trigger);
+    expect(container.querySelector('script')).toBeNull();
+    expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined();
+    expect(screen.getByText(/Safe text/)).toBeInTheDocument();
+  });
+
+  it('shows the unit note and short description when expanded', () => {
+    render(
+      <MetricExplanation label="10-Yard Fly Time" explanation={FLY10_EXPLANATION} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /explanation for 10-yard fly/i }));
+    expect(screen.getByText(/measured in seconds; lower is better/i)).toBeInTheDocument();
+  });
+
+  it('strips javascript: URIs from markdown links', () => {
+    const malicious: MetricExplanationData = {
+      ...FLY10_EXPLANATION,
+      title: 'Custom Metric',
+      whatItMeasures: 'Read more at [trust me](javascript:alert(1)) now.',
+    };
+    const { container } = render(
+      <MetricExplanation label="Custom Metric" explanation={malicious} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /explanation for custom metric/i }));
+    const link = container.querySelector('a');
+    if (link) {
+      expect(link.getAttribute('href') ?? '').not.toMatch(/^javascript:/i);
+    }
+  });
+
+  it('generates unique DOM ids for multiple instances of the same metric on one page', () => {
+    const { container } = render(
+      <div>
+        <MetricExplanation label="A" explanation={FLY10_EXPLANATION} />
+        <MetricExplanation label="B" explanation={FLY10_EXPLANATION} />
+      </div>,
+    );
+    const triggers = container.querySelectorAll('button[aria-controls]');
+    const ids = Array.from(triggers).map((b) => b.getAttribute('aria-controls'));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/packages/web/src/components/reports/__tests__/ReportMetricsGlossary.test.tsx
+++ b/packages/web/src/components/reports/__tests__/ReportMetricsGlossary.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ReportMetricsGlossary } from '../ReportMetricsGlossary';
+import type { MetricExplanation } from '@shared/metric-explanations';
+
+const FLY10: MetricExplanation = {
+  title: '10-Yard Fly',
+  shortDescription: 'Top-speed acceleration.',
+  whatItMeasures: 'Measures velocity over a short zone.',
+  whyItMatters: 'Reflects real-game speed.',
+  unitNote: 'Measured in seconds; lower is better.',
+  directionOfBetter: 'lower',
+};
+
+const VJ: MetricExplanation = {
+  title: 'Vertical Jump',
+  shortDescription: 'Lower-body explosive power.',
+  whatItMeasures: 'Height from standing reach to max jump.',
+  whyItMatters: 'Indicator of athletic potential.',
+  unitNote: 'Measured in inches; higher is better.',
+  directionOfBetter: 'higher',
+};
+
+describe('ReportMetricsGlossary', () => {
+  it('renders one heading per unique metric code', () => {
+    render(
+      <ReportMetricsGlossary
+        explanations={{ FLY10_TIME: FLY10, VERTICAL_JUMP: VJ }}
+      />,
+    );
+    const headings = screen.getAllByRole('heading', { level: 3 });
+    expect(headings).toHaveLength(2);
+    expect(headings.map((h) => h.textContent)).toEqual(
+      expect.arrayContaining(['10-Yard Fly', 'Vertical Jump']),
+    );
+  });
+
+  it("renders each metric's full explanation body", () => {
+    render(
+      <ReportMetricsGlossary explanations={{ FLY10_TIME: FLY10 }} />,
+    );
+    expect(screen.getByText(/velocity over a short zone/i)).toBeInTheDocument();
+    expect(screen.getByText(/reflects real-game speed/i)).toBeInTheDocument();
+    expect(screen.getByText(/lower is better/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when given an empty explanations map', () => {
+    const { container } = render(<ReportMetricsGlossary explanations={{}} />);
+    expect(container.querySelectorAll('h3')).toHaveLength(0);
+  });
+
+  it('uses a top-level section heading for screen reader navigation', () => {
+    render(<ReportMetricsGlossary explanations={{ FLY10_TIME: FLY10 }} />);
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(/glossary/i);
+  });
+});

--- a/packages/web/src/pages/public-report.tsx
+++ b/packages/web/src/pages/public-report.tsx
@@ -14,6 +14,9 @@ import { Badge } from "@/components/ui/badge";
 import { format } from "date-fns";
 import { Lock } from "lucide-react";
 import { useContextualLabels } from "@/hooks/useContextualLabels";
+import { MetricExplanation } from "@/components/reports/MetricExplanation";
+import { ReportMetricsGlossary } from "@/components/reports/ReportMetricsGlossary";
+import type { MetricExplanation as MetricExplanationData } from "@shared/metric-explanations";
 
 export default function PublicReport() {
   const labels = useContextualLabels();
@@ -52,6 +55,18 @@ export default function PublicReport() {
 
   const { snapshotData } = snapshot;
   const { reportConfig, generatedAt, dataSnapshot } = snapshotData;
+  const metricExplanations = (snapshotData.metricExplanations ?? {}) as Record<string, MetricExplanationData>;
+  const glossaryOrder: string[] = [];
+  if (Array.isArray(dataSnapshot?.performanceSnapshot)) {
+    for (const m of dataSnapshot.performanceSnapshot) {
+      if (m?.metricCode) glossaryOrder.push(m.metricCode);
+    }
+  }
+  if (Array.isArray(dataSnapshot?.performance)) {
+    for (const m of dataSnapshot.performance) {
+      if (m?.metricCode) glossaryOrder.push(m.metricCode);
+    }
+  }
 
   return (
     <div className="min-h-screen bg-background">
@@ -90,8 +105,11 @@ export default function PublicReport() {
                     <TableBody>
                       {dataSnapshot.performanceSnapshot.map((metric: any) => (
                         <TableRow key={metric.metricCode}>
-                          <TableCell className="font-medium">
-                            {metric.metricName}
+                          <TableCell className="font-medium align-top">
+                            <MetricExplanation
+                              label={metric.metricName}
+                              explanation={metricExplanations[metric.metricCode]}
+                            />
                           </TableCell>
                           <TableCell>
                             {metric.teamAverage?.toFixed(2) || "N/A"} {metric.unit}
@@ -220,6 +238,14 @@ export default function PublicReport() {
           </>
         )}
 
+        {/* Glossary of metrics (Team) */}
+        {reportConfig.reportType === 'team' && Object.keys(metricExplanations).length > 0 && (
+          <ReportMetricsGlossary
+            explanations={metricExplanations}
+            metricOrder={glossaryOrder}
+          />
+        )}
+
         {/* Individual Report View */}
         {reportConfig.reportType === "individual" && (
           <>
@@ -265,8 +291,11 @@ export default function PublicReport() {
                     <TableBody>
                       {dataSnapshot.performance.map((metric: any) => (
                         <TableRow key={metric.metricCode}>
-                          <TableCell className="font-medium">
-                            {metric.metricName}
+                          <TableCell className="font-medium align-top">
+                            <MetricExplanation
+                              label={metric.metricName}
+                              explanation={metricExplanations[metric.metricCode]}
+                            />
                           </TableCell>
                           <TableCell>
                             {metric.bestValue?.toFixed(2) || "N/A"} {metric.unit}
@@ -315,6 +344,14 @@ export default function PublicReport() {
                   </Table>
                 </CardContent>
               </Card>
+            )}
+
+            {/* Glossary of metrics (Individual) */}
+            {Object.keys(metricExplanations).length > 0 && (
+              <ReportMetricsGlossary
+                explanations={metricExplanations}
+                metricOrder={glossaryOrder}
+              />
             )}
           </>
         )}

--- a/packages/web/src/pages/public-report.tsx
+++ b/packages/web/src/pages/public-report.tsx
@@ -56,17 +56,18 @@ export default function PublicReport() {
   const { snapshotData } = snapshot;
   const { reportConfig, generatedAt, dataSnapshot } = snapshotData;
   const metricExplanations = (snapshotData.metricExplanations ?? {}) as Record<string, MetricExplanationData>;
-  const glossaryOrder: string[] = [];
+  const glossaryOrderSet = new Set<string>();
   if (Array.isArray(dataSnapshot?.performanceSnapshot)) {
     for (const m of dataSnapshot.performanceSnapshot) {
-      if (m?.metricCode) glossaryOrder.push(m.metricCode);
+      if (m?.metricCode) glossaryOrderSet.add(m.metricCode);
     }
   }
   if (Array.isArray(dataSnapshot?.performance)) {
     for (const m of dataSnapshot.performance) {
-      if (m?.metricCode) glossaryOrder.push(m.metricCode);
+      if (m?.metricCode) glossaryOrderSet.add(m.metricCode);
     }
   }
+  const glossaryOrder = Array.from(glossaryOrderSet);
 
   return (
     <div className="min-h-screen bg-background">

--- a/packages/web/src/types/report-types.ts
+++ b/packages/web/src/types/report-types.ts
@@ -1,3 +1,5 @@
+import type { MetricExplanation } from '@shared/metric-explanations';
+
 export interface Benchmark {
   name: string;
   value: number | null;
@@ -123,6 +125,7 @@ export interface TeamReportData {
   generatedAt: string;
   metricLabels?: Record<string, string>;
   metricUnits?: Record<string, string>;
+  metricExplanations?: Record<string, MetricExplanation>;
   orgBranding?: OrgBranding;
 }
 
@@ -144,6 +147,7 @@ export interface IndividualReportData {
   generatedAt: string;
   metricLabels?: Record<string, string>;
   metricUnits?: Record<string, string>;
+  metricExplanations?: Record<string, MetricExplanation>;
   orgBranding?: OrgBranding;
 }
 

--- a/tests/e2e/report-metric-explanations.spec.ts
+++ b/tests/e2e/report-metric-explanations.spec.ts
@@ -15,18 +15,11 @@ import { loginAsDefaultUser } from './helpers/auth';
 const STAGING_URL = process.env.STAGING_URL || 'http://localhost:5000';
 
 async function getUserOrgId(page: Page): Promise<string | null> {
-  return await page.evaluate(() => {
-    const authData = localStorage.getItem('auth');
-    if (authData) {
-      try {
-        const parsed = JSON.parse(authData);
-        return parsed.organizationContext || null;
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  });
+  const res = await page.request.get(`${STAGING_URL}/api/auth/me/organizations`);
+  if (!res.ok()) return null;
+  const orgs = await res.json();
+  if (!Array.isArray(orgs) || orgs.length === 0) return null;
+  return orgs[0].organizationId ?? null;
 }
 
 function generateReportName() {

--- a/tests/e2e/report-metric-explanations.spec.ts
+++ b/tests/e2e/report-metric-explanations.spec.ts
@@ -80,7 +80,7 @@ test.describe('Report metric explanations — E2E', () => {
     await expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
     // Expanded content should include the built-in description fragment
-    await expect(page.getByText(/maximum velocity acceleration/i)).toBeVisible();
+    await expect(page.getByText(/maximum velocity measurement/i)).toBeVisible();
 
     // Glossary section at the bottom
     await expect(page.getByRole('heading', { name: /Glossary of metrics/i })).toBeVisible();

--- a/tests/e2e/report-metric-explanations.spec.ts
+++ b/tests/e2e/report-metric-explanations.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, Page } from '@playwright/test';
+import { loginAsDefaultUser } from './helpers/auth';
+
+/**
+ * E2E Tests for Issue #367 — Metric explanations in reports
+ *
+ * Verifies:
+ *  1. An authenticated coach sees the explanation trigger next to metric labels
+ *     and can expand it to read "What it measures" and "Why it matters".
+ *  2. Each report view renders a "Glossary of metrics" section at the bottom.
+ *  3. A parent opening a public shared link sees the same frozen glossary
+ *     (no login required).
+ */
+
+const STAGING_URL = process.env.STAGING_URL || 'http://localhost:5000';
+
+async function getUserOrgId(page: Page): Promise<string | null> {
+  return await page.evaluate(() => {
+    const authData = localStorage.getItem('auth');
+    if (authData) {
+      try {
+        const parsed = JSON.parse(authData);
+        return parsed.organizationContext || null;
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  });
+}
+
+function generateReportName() {
+  const uniqueId = Date.now().toString(36) + Math.random().toString(36).substring(2);
+  return `Explanations E2E ${uniqueId}`;
+}
+
+test.describe('Report metric explanations — E2E', () => {
+  const createdReportIds: string[] = [];
+  const createdSnapshotIds: string[] = [];
+
+  test.afterEach(async ({ page }) => {
+    for (const id of createdSnapshotIds) {
+      try {
+        await page.request.delete(`${STAGING_URL}/api/reports/snapshots/${id}`);
+      } catch {
+        // swallow — best effort cleanup
+      }
+    }
+    for (const id of createdReportIds) {
+      try {
+        await page.request.delete(`${STAGING_URL}/api/reports/${id}`);
+      } catch {
+        // swallow — best effort cleanup
+      }
+    }
+    createdReportIds.length = 0;
+    createdSnapshotIds.length = 0;
+  });
+
+  test('coach can expand metric explanation on a team report', async ({ page }) => {
+    await loginAsDefaultUser(page);
+    const orgId = await getUserOrgId(page);
+    expect(orgId).not.toBeNull();
+
+    const createRes = await page.request.post(`${STAGING_URL}/api/reports`, {
+      data: {
+        name: generateReportName(),
+        reportType: 'team',
+        organizationId: orgId,
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['FLY10_TIME', 'VERTICAL_JUMP'],
+        },
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const report = await createRes.json();
+    createdReportIds.push(report.id);
+
+    await page.goto(`${STAGING_URL}/reports/${report.id}`);
+    await page.waitForLoadState('networkidle');
+
+    const trigger = page.getByRole('button', { name: /Explanation for 10-Yard Fly/i }).first();
+    await expect(trigger).toBeVisible();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // Expanded content should include the built-in description fragment
+    await expect(page.getByText(/maximum velocity acceleration/i)).toBeVisible();
+
+    // Glossary section at the bottom
+    await expect(page.getByRole('heading', { name: /Glossary of metrics/i })).toBeVisible();
+  });
+
+  test('public shared link shows glossary without authentication', async ({ browser, page }) => {
+    await loginAsDefaultUser(page);
+    const orgId = await getUserOrgId(page);
+
+    const createRes = await page.request.post(`${STAGING_URL}/api/reports`, {
+      data: {
+        name: generateReportName(),
+        reportType: 'team',
+        organizationId: orgId,
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['FLY10_TIME'],
+        },
+      },
+    });
+    const report = await createRes.json();
+    createdReportIds.push(report.id);
+
+    const snapRes = await page.request.post(`${STAGING_URL}/api/reports/${report.id}/snapshots`, {
+      data: { expirationDays: 1 },
+    });
+    expect(snapRes.ok()).toBeTruthy();
+    const snap = await snapRes.json();
+    createdSnapshotIds.push(snap.id);
+    expect(snap.publicToken).toBeTruthy();
+
+    // Open in a fresh context with NO auth cookies to mimic a parent
+    const anonContext = await browser.newContext();
+    const anonPage = await anonContext.newPage();
+    try {
+      await anonPage.goto(`${STAGING_URL}/public/reports/${snap.publicToken}`);
+      await anonPage.waitForLoadState('networkidle');
+      await expect(
+        anonPage.getByRole('heading', { name: /Glossary of metrics/i }),
+      ).toBeVisible();
+      await expect(anonPage.getByText(/10-Yard Fly/i).first()).toBeVisible();
+    } finally {
+      await anonContext.close();
+    }
+  });
+});

--- a/tests/integration/report-metric-explanations.test.ts
+++ b/tests/integration/report-metric-explanations.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Integration Tests for Metric Explanations in Reports (Issue #367)
+ *
+ * Verifies:
+ *  - POST /api/reports/:id/generate returns metricExplanations keyed by metric code
+ *  - Custom metric descriptions are resolved from customOrgMetrics
+ *  - Public snapshots freeze metricExplanations into snapshotData (persistent)
+ *  - GET /api/public/reports/:token returns the frozen metricExplanations
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET = 'test-secret-key-for-integration-tests-only-at-least-32-characters-long';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+process.env.BYPASS_GENERAL_RATE_LIMIT = 'true';
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { type Express } from 'express';
+import bcrypt from 'bcrypt';
+import { eq, and } from 'drizzle-orm';
+import { db } from '../../packages/api/db';
+import {
+  organizations,
+  users,
+  userOrganizations,
+  reports,
+  reportSnapshots,
+  customOrgMetrics,
+} from '@shared/schema';
+import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+let app: Express;
+let testOrg: any;
+let testCoach: any;
+let coachCookie: string;
+let testReport: any;
+
+async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, BCRYPT_SALT_ROUNDS);
+}
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  await registerRoutes(app);
+});
+
+beforeEach(async () => {
+  const ts = Date.now();
+  [testOrg] = await db
+    .insert(organizations)
+    .values({
+      name: `Metric Expl Org ${ts}`,
+      description: 'metric explanations integration org',
+      isActive: true,
+    })
+    .returning();
+
+  const hashed = await hashPassword('TestCoach123!');
+  [testCoach] = await db
+    .insert(users)
+    .values({
+      username: `expl_coach_${ts}`,
+      emails: [`expl_coach_${ts}@test.com`],
+      password: hashed,
+      firstName: 'Test',
+      lastName: 'Coach',
+      fullName: 'Test Coach',
+    })
+    .returning();
+
+  await db.insert(userOrganizations).values({
+    userId: testCoach.id,
+    organizationId: testOrg.id,
+    role: 'coach',
+  });
+
+  const login = await request(app)
+    .post('/api/auth/login')
+    .send({ username: testCoach.username, password: 'TestCoach123!' });
+  coachCookie = login.headers['set-cookie'][0];
+});
+
+afterEach(async () => {
+  if (testReport?.id) {
+    await db.delete(reportSnapshots).where(eq(reportSnapshots.reportId, testReport.id));
+    await db.delete(reports).where(eq(reports.id, testReport.id));
+    testReport = null;
+  }
+  if (testOrg?.id) {
+    await db.delete(customOrgMetrics).where(eq(customOrgMetrics.organizationId, testOrg.id));
+  }
+  if (testCoach?.id && testOrg?.id) {
+    await db
+      .delete(userOrganizations)
+      .where(
+        and(
+          eq(userOrganizations.userId, testCoach.id),
+          eq(userOrganizations.organizationId, testOrg.id),
+        ),
+      );
+  }
+  if (testCoach?.id) {
+    await db.delete(users).where(eq(users.id, testCoach.id));
+  }
+  if (testOrg?.id) {
+    await db.delete(organizations).where(eq(organizations.id, testOrg.id));
+  }
+});
+
+afterAll(async () => {
+  // no-op; per-test cleanup handles everything
+});
+
+describe('POST /api/reports/:id/generate — metricExplanations', () => {
+  it('includes metricExplanations keyed by every requested built-in metric', async () => {
+    [testReport] = await db
+      .insert(reports)
+      .values({
+        name: 'Explanations Built-in',
+        organizationId: testOrg.id,
+        reportType: 'team',
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['FLY10_TIME', 'VERTICAL_JUMP'],
+        },
+        createdBy: testCoach.id,
+      })
+      .returning();
+
+    const res = await request(app)
+      .post(`/api/reports/${testReport.id}/generate`)
+      .set('Cookie', coachCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.metricExplanations).toBeDefined();
+    expect(res.body.metricExplanations.FLY10_TIME).toBeDefined();
+    expect(res.body.metricExplanations.FLY10_TIME.title).toBe('10-Yard Fly');
+    expect(res.body.metricExplanations.FLY10_TIME.directionOfBetter).toBe('lower');
+    expect(res.body.metricExplanations.VERTICAL_JUMP.directionOfBetter).toBe('higher');
+  });
+
+  it('resolves custom metric descriptions from customOrgMetrics', async () => {
+    await db.insert(customOrgMetrics).values({
+      organizationId: testOrg.id,
+      code: 'CUSTOM_BROAD_JUMP',
+      label: 'Broad Jump',
+      description: 'Horizontal jump distance from standing start.',
+      unit: 'inches',
+      metricType: 'higher_is_better',
+    });
+
+    [testReport] = await db
+      .insert(reports)
+      .values({
+        name: 'Explanations Custom',
+        organizationId: testOrg.id,
+        reportType: 'team',
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['CUSTOM_BROAD_JUMP'],
+        },
+        createdBy: testCoach.id,
+      })
+      .returning();
+
+    const res = await request(app)
+      .post(`/api/reports/${testReport.id}/generate`)
+      .set('Cookie', coachCookie);
+
+    expect(res.status).toBe(200);
+    const explanation = res.body.metricExplanations?.CUSTOM_BROAD_JUMP;
+    expect(explanation).toBeDefined();
+    expect(explanation.title).toBe('Broad Jump');
+    expect(explanation.whatItMeasures).toBe('Horizontal jump distance from standing start.');
+    expect(explanation.directionOfBetter).toBe('higher');
+    expect(explanation.unitNote).toMatch(/inches/i);
+    expect(explanation.unitNote).toMatch(/higher is better/i);
+  });
+
+  it('falls back to a generic placeholder for unknown codes', async () => {
+    [testReport] = await db
+      .insert(reports)
+      .values({
+        name: 'Explanations Unknown',
+        organizationId: testOrg.id,
+        reportType: 'team',
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['UNKNOWN_METRIC_CODE'],
+        },
+        createdBy: testCoach.id,
+      })
+      .returning();
+
+    const res = await request(app)
+      .post(`/api/reports/${testReport.id}/generate`)
+      .set('Cookie', coachCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.metricExplanations?.UNKNOWN_METRIC_CODE).toBeDefined();
+    expect(res.body.metricExplanations.UNKNOWN_METRIC_CODE.whatItMeasures).toMatch(
+      /custom metric tracked by your organization/i,
+    );
+  });
+});
+
+describe('PDF generation — glossary section', () => {
+  it('returns a PDF with glossary content for a report with explanations', async () => {
+    [testReport] = await db
+      .insert(reports)
+      .values({
+        name: 'PDF Glossary Test',
+        organizationId: testOrg.id,
+        reportType: 'team',
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['FLY10_TIME', 'VERTICAL_JUMP'],
+        },
+        createdBy: testCoach.id,
+      })
+      .returning();
+
+    const res = await request(app)
+      .get(`/api/reports/${testReport.id}/pdf?format=simplified`)
+      .set('Cookie', coachCookie)
+      .buffer(true)
+      .parse((response, cb) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (chunk) => chunks.push(chunk as Buffer));
+        response.on('end', () => cb(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/pdf/);
+    const pdfBuffer = res.body as Buffer;
+    expect(pdfBuffer.length).toBeGreaterThan(1000);
+    // PDF magic header
+    expect(pdfBuffer.subarray(0, 4).toString()).toBe('%PDF');
+    // jsPDF encodes text; search across raw buffer for glossary title fragment.
+    const raw = pdfBuffer.toString('latin1');
+    expect(raw).toMatch(/Glossary of Metrics/);
+  });
+});
+
+describe('Snapshot freezing — metricExplanations', () => {
+  it('persists metricExplanations into snapshotData.dataSnapshot', async () => {
+    [testReport] = await db
+      .insert(reports)
+      .values({
+        name: 'Freeze Test',
+        organizationId: testOrg.id,
+        reportType: 'team',
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['FLY10_TIME'],
+        },
+        createdBy: testCoach.id,
+      })
+      .returning();
+
+    const snapRes = await request(app)
+      .post(`/api/reports/${testReport.id}/snapshots`)
+      .set('Cookie', coachCookie)
+      .send({ expirationDays: 7 });
+
+    expect(snapRes.status).toBe(201);
+    const token = snapRes.body.publicToken;
+    expect(token).toBeTruthy();
+
+    const publicRes = await request(app).get(`/api/public/reports/${token}`);
+    expect(publicRes.status).toBe(200);
+    expect(publicRes.body.snapshotData?.metricExplanations?.FLY10_TIME).toBeDefined();
+    expect(publicRes.body.snapshotData.metricExplanations.FLY10_TIME.title).toBe('10-Yard Fly');
+  });
+
+  it('freezes custom metric text — later DB edits do not change public view', async () => {
+    await db.insert(customOrgMetrics).values({
+      organizationId: testOrg.id,
+      code: 'CUSTOM_FROZEN',
+      label: 'Frozen Metric',
+      description: 'Original description.',
+      unit: 'seconds',
+      metricType: 'lower_is_better',
+    });
+
+    [testReport] = await db
+      .insert(reports)
+      .values({
+        name: 'Frozen Custom',
+        organizationId: testOrg.id,
+        reportType: 'team',
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['CUSTOM_FROZEN'],
+        },
+        createdBy: testCoach.id,
+      })
+      .returning();
+
+    const snapRes = await request(app)
+      .post(`/api/reports/${testReport.id}/snapshots`)
+      .set('Cookie', coachCookie)
+      .send({ expirationDays: 7 });
+    expect(snapRes.status).toBe(201);
+    const token = snapRes.body.publicToken;
+
+    await db
+      .update(customOrgMetrics)
+      .set({ description: 'Updated description AFTER snapshot.' })
+      .where(
+        and(
+          eq(customOrgMetrics.organizationId, testOrg.id),
+          eq(customOrgMetrics.code, 'CUSTOM_FROZEN'),
+        ),
+      );
+
+    const publicRes = await request(app).get(`/api/public/reports/${token}`);
+    expect(publicRes.status).toBe(200);
+    const frozen = publicRes.body.snapshotData?.metricExplanations?.CUSTOM_FROZEN;
+    expect(frozen).toBeDefined();
+    expect(frozen.whatItMeasures).toBe('Original description.');
+    expect(frozen.whatItMeasures).not.toMatch(/AFTER snapshot/i);
+  });
+});

--- a/tests/integration/report-metric-explanations.test.ts
+++ b/tests/integration/report-metric-explanations.test.ts
@@ -254,7 +254,7 @@ describe('PDF generation — glossary section', () => {
 });
 
 describe('Snapshot freezing — metricExplanations', () => {
-  it('persists metricExplanations into snapshotData.dataSnapshot', async () => {
+  it('persists metricExplanations at snapshotData top level', async () => {
     [testReport] = await db
       .insert(reports)
       .values({
@@ -331,5 +331,44 @@ describe('Snapshot freezing — metricExplanations', () => {
     expect(frozen).toBeDefined();
     expect(frozen.whatItMeasures).toBe('Original description.');
     expect(frozen.whatItMeasures).not.toMatch(/AFTER snapshot/i);
+  });
+
+  it('does not transform malicious markdown server-side (XSS defense lives client-side)', async () => {
+    const maliciousDescription = '<script>alert(1)</script>Normal text.';
+    await db.insert(customOrgMetrics).values({
+      organizationId: testOrg.id,
+      code: 'CUSTOM_XSS',
+      label: 'XSS Metric',
+      description: maliciousDescription,
+      unit: 'seconds',
+      metricType: 'lower_is_better',
+    });
+
+    [testReport] = await db
+      .insert(reports)
+      .values({
+        name: 'XSS Test',
+        organizationId: testOrg.id,
+        reportType: 'team',
+        config: {
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: ['CUSTOM_XSS'],
+        },
+        createdBy: testCoach.id,
+      })
+      .returning();
+
+    const snapRes = await request(app)
+      .post(`/api/reports/${testReport.id}/snapshots`)
+      .set('Cookie', coachCookie)
+      .send({ expirationDays: 7 });
+    expect(snapRes.status).toBe(201);
+    const token = snapRes.body.publicToken;
+
+    const publicRes = await request(app).get(`/api/public/reports/${token}`);
+    expect(publicRes.status).toBe(200);
+    const frozen = publicRes.body.snapshotData?.metricExplanations?.CUSTOM_XSS;
+    expect(frozen).toBeDefined();
+    expect(frozen.whatItMeasures).toBe(maliciousDescription);
   });
 });


### PR DESCRIPTION
## Summary

Implements Phase 1 of [#367](https://github.com/johnahull/AthleteMetrics/issues/367): adds concise, athlete/parent-friendly explanations for every metric shown in a report — inline (collapsible trigger) and as a glossary section, on the web and in exported PDFs.

- **Inline explanations**: each metric label in the report table has an info toggle. Click it to read "What it measures", "Why it matters", and the unit/direction in plain language.
- **Glossary section**: every report view renders a consolidated "Glossary of metrics" card at the bottom; the PDF exports get a matching glossary page.
- **Custom metrics**: resolve the title from the custom metric label and the description from `customOrgMetrics.description`. Direction text follows `metricType` (`lower_is_better` / `higher_is_better` / `tracking`). Missing descriptions fall back to a generic placeholder.
- **Snapshot freezing**: explanations are written into `report_snapshots.snapshotData` at snapshot time, so a later edit to `customOrgMetrics.description` never changes what a previously-shared public link shows.
- **Security**: custom markdown is rendered via `react-markdown` + `rehype-sanitize`. Tests verify `<script>` injection does not execute and `javascript:` URIs are stripped from links.

## Scope

- New shared package: `@shared/metric-explanations` (built-ins for the 8 default metrics + `getMetricExplanation(code, customMap?)` + `buildMetricExplanationsMap`).
- New service method: `ReportService.getMetricExplanationsMap()` called from `generateTeamReport` and `generateIndividualReport`.
- New components: `MetricExplanation` (inline trigger) and `ReportMetricsGlossary` (section).
- Wired into `IndividualReportView`, `TeamReportView` (and thus `MultiIndividualReportView` by delegation), and `public-report.tsx`.
- PDF glossary appended via `jspdf-autotable` on its own page.

## Tests

- **28** unit tests (`packages/shared/__tests__/metric-explanations.test.ts`): built-ins, custom-metric resolution, direction/unit mapping, tracking metrics, precedence, malformed input safety.
- **9** component tests for `MetricExplanation` (aria, markdown rendering, XSS defenses, unique DOM ids for duplicate instances).
- **4** component tests for `ReportMetricsGlossary` (entry per code, empty state, metric ordering).
- **7** integration tests (`tests/integration/report-metric-explanations.test.ts`): generate-response shape, built-in + custom + unknown code resolution, snapshot freezing, post-snapshot DB edit isolation, XSS passthrough (proves server stores malicious markup verbatim — defense is client-side), and a PDF generation smoke test.
- **2** E2E specs (`tests/e2e/report-metric-explanations.spec.ts`): coach expands an explanation on a team report; an unauthenticated parent loading a public shared link sees the frozen glossary.

Total **50** new tests.

## Screenshots

Captured against Railway PR preview (`metric-explanations-*` in `screenshots/`):
- Team report with metric explanation triggers (collapsed + expanded)
- "Glossary of metrics" section at the bottom
- Public shared link view (header renders; data section empty due to no seeded measurements on preview)
- Mobile responsive views (375×667)

## Test plan

- [x] `npm run check`
- [x] `npm run test` (unit + integration — 7/7 integration pass)
- [ ] `npx playwright test tests/e2e/report-metric-explanations.spec.ts --config=playwright.staging.config.ts`
- [ ] Manual smoke on the dev server: team report, individual report, public share link, PDF download (visual + simplified)
- [ ] Verify the glossary is present in a PDF opened outside the browser

## Out of scope (Phase 2)

- ~~Audience-aware copy variants~~ — dropped; plain-language tone works for all audiences.
- Site-admin editor for built-in explanation content.
- Unification with `metric-education-utils.ts` used by the athlete dashboard (kept intact to avoid breaking `GoalProgressCard` and `MetricEducationCard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)