### PR TITLE
fix(oauth): block new user creation when pending invitation exists

### DIFF
--- a/packages/api/__tests__/oauth-service-pending-invitation.test.ts
+++ b/packages/api/__tests__/oauth-service-pending-invitation.test.ts
@@ -1,0 +1,194 @@
+/**
+ * OAuth Service - Pending Invitation Guard
+ *
+ * Regression for the "Christian Hull" incident: when a user OAuths in before
+ * their pending invitation is accepted, a duplicate orphan account gets
+ * created because the original pending-athlete row often has no email.
+ *
+ * The fix: if a pending invitation exists for the OAuth email, block
+ * auto-provisioning a new OAuth user and ask the caller to accept the
+ * invitation first.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import crypto from "crypto";
+import { db } from "../db";
+import { users, invitations, organizations, accountLinkingTokens } from "@shared/schema";
+import { eq, inArray } from "drizzle-orm";
+import { OAuthService } from "../services/oauth-service";
+
+vi.mock("../services/email-service", () => ({
+  EmailService: vi.fn().mockImplementation(() => ({
+    sendAccountLinkingEmail: vi.fn().mockResolvedValue(true),
+  })),
+}));
+
+describe("OAuth Service - Pending Invitation Guard", () => {
+  let oauthService: OAuthService;
+  const timestamp = Date.now().toString();
+  const createdUserIds: string[] = [];
+  const createdInvitationIds: string[] = [];
+  const createdOrgIds: string[] = [];
+
+  beforeEach(() => {
+    oauthService = new OAuthService();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (createdInvitationIds.length > 0) {
+      await db.delete(invitations).where(inArray(invitations.id, createdInvitationIds));
+      createdInvitationIds.length = 0;
+    }
+    for (const userId of createdUserIds) {
+      await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.userId, userId));
+      await db.delete(users).where(eq(users.id, userId));
+    }
+    createdUserIds.length = 0;
+    if (createdOrgIds.length > 0) {
+      await db.delete(organizations).where(inArray(organizations.id, createdOrgIds));
+      createdOrgIds.length = 0;
+    }
+  });
+
+  async function createTestOrg(name: string): Promise<string> {
+    const [org] = await db
+      .insert(organizations)
+      .values({ name, orgType: "club" })
+      .returning();
+    createdOrgIds.push(org.id);
+    return org.id;
+  }
+
+  async function createPendingInvitation(email: string, organizationId: string): Promise<void> {
+    const [invite] = await db
+      .insert(invitations)
+      .values({
+        email,
+        firstName: "Pending",
+        lastName: "Athlete",
+        organizationId,
+        role: "athlete",
+        token: crypto.randomBytes(32).toString("hex"),
+        status: "pending",
+        isUsed: false,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      })
+      .returning();
+    createdInvitationIds.push(invite.id);
+  }
+
+  it("blocks new OAuth user creation when a pending invitation exists for the email", async () => {
+    const email = `pending-invite-${timestamp}@example.com`;
+    const orgId = await createTestOrg(`Pending Invite Org ${timestamp}`);
+    await createPendingInvitation(email, orgId);
+
+    const googleProfile = {
+      id: `google_id_${timestamp}`,
+      emails: [{ value: email, verified: true }],
+      name: { givenName: "Pending", familyName: "Athlete" },
+    };
+
+    const result = await oauthService.handleGoogleAuth(googleProfile);
+
+    expect(result.success).toBe(false);
+    expect(result.userId).toBeUndefined();
+    expect(result.error).toMatch(/invitation/i);
+
+    // Critical: verify NO duplicate user was created for this email.
+    const usersWithEmail = await db
+      .select()
+      .from(users)
+      .where(eq(users.oauthEmail, email));
+    expect(usersWithEmail).toHaveLength(0);
+
+    const usersWithProviderId = await db
+      .select()
+      .from(users)
+      .where(eq(users.googleId, googleProfile.id));
+    expect(usersWithProviderId).toHaveLength(0);
+  });
+
+  it("ignores cancelled invitations and proceeds with normal OAuth flow", async () => {
+    const email = `cancelled-invite-${timestamp}@example.com`;
+    const orgId = await createTestOrg(`Cancelled Invite Org ${timestamp}`);
+
+    // Create a cancelled invitation — it should not block OAuth
+    const [invite] = await db
+      .insert(invitations)
+      .values({
+        email,
+        organizationId: orgId,
+        role: "athlete",
+        token: crypto.randomBytes(32).toString("hex"),
+        status: "cancelled",
+        isUsed: false,
+        cancelledAt: new Date(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      })
+      .returning();
+    createdInvitationIds.push(invite.id);
+
+    const googleProfile = {
+      id: `google_cancelled_${timestamp}`,
+      emails: [{ value: email, verified: true }],
+      name: { givenName: "Cancelled", familyName: "User" },
+    };
+
+    const result = await oauthService.handleGoogleAuth(googleProfile);
+
+    // New OAuth user should be created — the cancelled invite doesn't block
+    expect(result.success).toBe(true);
+    expect(result.userId).toBeTruthy();
+    if (result.userId) createdUserIds.push(result.userId);
+  });
+
+  it("ignores expired invitations and proceeds with normal OAuth flow", async () => {
+    const email = `expired-invite-${timestamp}@example.com`;
+    const orgId = await createTestOrg(`Expired Invite Org ${timestamp}`);
+
+    const [invite] = await db
+      .insert(invitations)
+      .values({
+        email,
+        organizationId: orgId,
+        role: "athlete",
+        token: crypto.randomBytes(32).toString("hex"),
+        status: "pending",
+        isUsed: false,
+        expiresAt: new Date(Date.now() - 60 * 1000), // expired 1 minute ago
+      })
+      .returning();
+    createdInvitationIds.push(invite.id);
+
+    const googleProfile = {
+      id: `google_expired_${timestamp}`,
+      emails: [{ value: email, verified: true }],
+      name: { givenName: "Expired", familyName: "User" },
+    };
+
+    const result = await oauthService.handleGoogleAuth(googleProfile);
+
+    expect(result.success).toBe(true);
+    expect(result.userId).toBeTruthy();
+    if (result.userId) createdUserIds.push(result.userId);
+  });
+
+  it("matches pending invitations case-insensitively", async () => {
+    const canonicalEmail = `Case-Invite-${timestamp}@Example.com`;
+    const orgId = await createTestOrg(`Case Invite Org ${timestamp}`);
+    await createPendingInvitation(canonicalEmail, orgId);
+
+    // Google returns lowercased email — common real-world case
+    const googleProfile = {
+      id: `google_case_${timestamp}`,
+      emails: [{ value: canonicalEmail.toLowerCase(), verified: true }],
+      name: { givenName: "Case", familyName: "Test" },
+    };
+
+    const result = await oauthService.handleGoogleAuth(googleProfile);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invitation/i);
+  });
+});

--- a/packages/api/services/oauth-service.ts
+++ b/packages/api/services/oauth-service.ts
@@ -162,7 +162,23 @@ export class OAuthService extends BaseService {
         };
       }
 
-      // 3. New user - create account with OAuth
+      // 3. Block new-user creation if a pending invitation exists for this email.
+      // Otherwise OAuth creates an orphan account while the invitation quietly
+      // waits — producing two users with the same email.
+      const pendingInvitations = await this.storage.getPendingInvitationsByEmail(profile.email);
+      if (pendingInvitations.length > 0) {
+        console.warn('[OAuth] Blocked new OAuth user: pending invitation exists for email', {
+          email: profile.email,
+          invitationCount: pendingInvitations.length,
+          provider: profile.provider,
+        });
+        return {
+          success: false,
+          error: 'A pending invitation exists for this email. Please accept the invitation from your email first, then sign in.',
+        };
+      }
+
+      // 4. New user - create account with OAuth
       const newUser = await this.createOAuthUser(profile);
       return { success: true, userId: newUser.id };
 

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -126,6 +126,7 @@ export interface IStorage {
   getInvitation(token: string): Promise<Invitation | undefined>;
   getInvitationById(id: string): Promise<Invitation | undefined>;
   getInvitationByToken(token: string): Promise<Invitation | undefined>;
+  getPendingInvitationsByEmail(email: string): Promise<Invitation[]>;
   updateInvitation(id: string, invitation: Partial<Omit<Invitation, 'id' | 'createdAt'>>): Promise<Invitation>;
   acceptInvitation(token: string, userInfo: { email: string; username: string; password: string; firstName: string; lastName: string }): Promise<{ user: User }>;
 
@@ -1655,6 +1656,18 @@ export class DatabaseStorage implements IStorage {
     const [invitation] = await db.select().from(invitations)
       .where(eq(invitations.token, token));
     return invitation || undefined;
+  }
+
+  async getPendingInvitationsByEmail(email: string): Promise<Invitation[]> {
+    // Case-insensitive match: OAuth providers often lowercase emails while
+    // admins may enter invitations with mixed case.
+    return await db.select().from(invitations)
+      .where(and(
+        sql`LOWER(${invitations.email}) = LOWER(${email})`,
+        eq(invitations.isUsed, false),
+        isNull(invitations.cancelledAt),
+        gte(invitations.expiresAt, new Date()),
+      ));
   }
 
   async acceptInvitation(

--- a/packages/web/src/pages/athletes.tsx
+++ b/packages/web/src/pages/athletes.tsx
@@ -631,8 +631,8 @@ export default function Athletes() {
 
   const handleBulkExportDashr = async () => {
     const selected = athletes
-      .filter(a => selectedAthletes.has(a.id))
-      .map(a => ({ firstName: a.firstName ?? '', lastName: a.lastName ?? '' }));
+      .filter((a: any) => selectedAthletes.has(a.id))
+      .map((a: any) => ({ firstName: a.firstName ?? '', lastName: a.lastName ?? '' }));
     const today = new Date().toISOString().split('T')[0];
     const filename = sanitizeDashrFilename(`athletes-${today}`);
     try {


### PR DESCRIPTION
## Summary

- OAuth sign-in could silently create a duplicate account when the signer already had a pending (unaccepted) invitation. A production case: `christianhull43@gmail.com` ended up with two users — the original pending-athlete shell (`795cb07e`) with his team/measurements and no email on the row, plus a new OAuth-only account (`6c71ea45`) that every subsequent Google login landed on.
- Root cause: `authenticateWithOAuth` only matches existing users via `users.emails[]`. A pending athlete shell typically has that array empty (email lives on the invitation row), so OAuth couldn't find them and auto-provisioned a new user.
- Fix: after `getUsersByEmail` returns empty, check for an active invitation addressed to the OAuth email. If one exists, return a user-facing error asking them to accept the invitation first instead of creating a new user.

## Changes

- `packages/api/storage.ts` — new `getPendingInvitationsByEmail(email)` on `IStorage` that returns invitations where `isUsed=false`, `cancelledAt IS NULL`, and `expiresAt > now()` with a case-insensitive email match.
- `packages/api/services/oauth-service.ts` — new step between "email match in users" and "create new OAuth user" that fails the auth with a clear prompt if an active invitation is pending.
- `packages/api/__tests__/oauth-service-pending-invitation.test.ts` — integration tests for the block, plus negative cases (cancelled invitation, expired invitation) and case-insensitive matching.

## Production data fix (already applied)

The two Christian Hull records have been consolidated using the existing `scripts/merge-duplicate-users.ts`: 64 measurements, 1 team membership, 1 org membership were moved onto the OAuth-active record, the secondary was soft-deleted, and `legal_accepted_at` was backfilled from the audit log. Christian's next Google login will land on the consolidated account.

## Test plan

- [x] `packages/api/__tests__/oauth-service-pending-invitation.test.ts` — 4/4 passing
- [x] `packages/api/__tests__/oauth-service-getUsersByEmail.test.ts` — 4/4 passing (no regression)
- [x] `packages/api/__tests__/storage-getUsersByEmail.test.ts` — 6/6 passing
- [ ] Manual smoke test on staging: create invitation, attempt Google OAuth with that email before accepting — expect login page with the "pending invitation" error; accept the invitation; retry OAuth — expect account-linking email as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)