### PR TITLE
release: Dashr XLSX export + OAuth pending-invitation fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2485,6 +2485,47 @@
         }
       }
     },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
@@ -7386,6 +7427,81 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -7502,7 +7618,6 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
@@ -7758,7 +7873,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-arraybuffer": {
@@ -7844,6 +7958,28 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7855,6 +7991,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/bmp-js": {
       "version": "0.1.0",
@@ -8033,6 +8186,39 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -8044,6 +8230,23 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -8227,6 +8430,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -8571,6 +8786,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8679,6 +8909,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/create-jest": {
@@ -8869,6 +9130,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -9428,6 +9695,51 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -9532,6 +9844,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -9859,6 +10180,38 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10065,6 +10418,19 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -10424,6 +10790,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -10452,6 +10824,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/function-bind": {
@@ -10734,7 +11122,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/hammerjs": {
@@ -11091,6 +11478,32 @@
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -13371,6 +13784,54 @@
         "jspdf": "^2 || ^3 || ^4"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -13402,6 +13863,54 @@
         "node": ">=6"
       }
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/leac": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
@@ -13419,6 +13928,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -13719,6 +14237,12 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "license": "ISC"
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -13744,6 +14268,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -13756,10 +14310,29 @@
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
@@ -13780,6 +14353,12 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -13791,6 +14370,18 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -14726,6 +15317,18 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ml-array-max": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-1.2.4.tgz",
@@ -15102,7 +15705,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -16036,6 +16638,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -16668,6 +17276,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -16981,6 +17619,19 @@
       "optional": true,
       "engines": {
         "node": ">= 0.8.15"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/rndm": {
@@ -17335,6 +17986,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -18202,6 +18859,22 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -18469,6 +19142,15 @@
       "integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -18517,6 +19199,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tree-changes": {
@@ -18989,6 +19680,60 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -19105,6 +19850,15 @@
       "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -20057,7 +20811,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -20182,6 +20935,41 @@
       "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/zlibjs": {
       "version": "0.3.1",
@@ -20348,6 +21136,7 @@
         "dexie-react-hooks": "^4.2.0",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
+        "exceljs": "^4.4.0",
         "framer-motion": "^11.13.1",
         "html2canvas": "^1.4.1",
         "input-otp": "^1.4.2",

--- a/packages/api/__tests__/oauth-service-pending-invitation.test.ts
+++ b/packages/api/__tests__/oauth-service-pending-invitation.test.ts
@@ -1,0 +1,194 @@
+/**
+ * OAuth Service - Pending Invitation Guard
+ *
+ * Regression for the "Christian Hull" incident: when a user OAuths in before
+ * their pending invitation is accepted, a duplicate orphan account gets
+ * created because the original pending-athlete row often has no email.
+ *
+ * The fix: if a pending invitation exists for the OAuth email, block
+ * auto-provisioning a new OAuth user and ask the caller to accept the
+ * invitation first.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import crypto from "crypto";
+import { db } from "../db";
+import { users, invitations, organizations, accountLinkingTokens } from "@shared/schema";
+import { eq, inArray } from "drizzle-orm";
+import { OAuthService } from "../services/oauth-service";
+
+vi.mock("../services/email-service", () => ({
+  EmailService: vi.fn().mockImplementation(() => ({
+    sendAccountLinkingEmail: vi.fn().mockResolvedValue(true),
+  })),
+}));
+
+describe("OAuth Service - Pending Invitation Guard", () => {
+  let oauthService: OAuthService;
+  const timestamp = Date.now().toString();
+  const createdUserIds: string[] = [];
+  const createdInvitationIds: string[] = [];
+  const createdOrgIds: string[] = [];
+
+  beforeEach(() => {
+    oauthService = new OAuthService();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    if (createdInvitationIds.length > 0) {
+      await db.delete(invitations).where(inArray(invitations.id, createdInvitationIds));
+      createdInvitationIds.length = 0;
+    }
+    for (const userId of createdUserIds) {
+      await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.userId, userId));
+      await db.delete(users).where(eq(users.id, userId));
+    }
+    createdUserIds.length = 0;
+    if (createdOrgIds.length > 0) {
+      await db.delete(organizations).where(inArray(organizations.id, createdOrgIds));
+      createdOrgIds.length = 0;
+    }
+  });
+
+  async function createTestOrg(name: string): Promise<string> {
+    const [org] = await db
+      .insert(organizations)
+      .values({ name, orgType: "club" })
+      .returning();
+    createdOrgIds.push(org.id);
+    return org.id;
+  }
+
+  async function createPendingInvitation(email: string, organizationId: string): Promise<void> {
+    const [invite] = await db
+      .insert(invitations)
+      .values({
+        email,
+        firstName: "Pending",
+        lastName: "Athlete",
+        organizationId,
+        role: "athlete",
+        token: crypto.randomBytes(32).toString("hex"),
+        status: "pending",
+        isUsed: false,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      })
+      .returning();
+    createdInvitationIds.push(invite.id);
+  }
+
+  it("blocks new OAuth user creation when a pending invitation exists for the email", async () => {
+    const email = `pending-invite-${timestamp}@example.com`;
+    const orgId = await createTestOrg(`Pending Invite Org ${timestamp}`);
+    await createPendingInvitation(email, orgId);
+
+    const googleProfile = {
+      id: `google_id_${timestamp}`,
+      emails: [{ value: email, verified: true }],
+      name: { givenName: "Pending", familyName: "Athlete" },
+    };
+
+    const result = await oauthService.handleGoogleAuth(googleProfile);
+
+    expect(result.success).toBe(false);
+    expect(result.userId).toBeUndefined();
+    expect(result.error).toMatch(/invitation/i);
+
+    // Critical: verify NO duplicate user was created for this email.
+    const usersWithEmail = await db
+      .select()
+      .from(users)
+      .where(eq(users.oauthEmail, email));
+    expect(usersWithEmail).toHaveLength(0);
+
+    const usersWithProviderId = await db
+      .select()
+      .from(users)
+      .where(eq(users.googleId, googleProfile.id));
+    expect(usersWithProviderId).toHaveLength(0);
+  });
+
+  it("ignores cancelled invitations and proceeds with normal OAuth flow", async () => {
+    const email = `cancelled-invite-${timestamp}@example.com`;
+    const orgId = await createTestOrg(`Cancelled Invite Org ${timestamp}`);
+
+    // Create a cancelled invitation — it should not block OAuth
+    const [invite] = await db
+      .insert(invitations)
+      .values({
+        email,
+        organizationId: orgId,
+        role: "athlete",
+        token: crypto.randomBytes(32).toString("hex"),
+        status: "cancelled",
+        isUsed: false,
+        cancelledAt: new Date(),
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      })
+      .returning();
+    createdInvitationIds.push(invite.id);
+
+    const googleProfile = {
+      id: `google_cancelled_${timestamp}`,
+      emails: [{ value: email, verified: true }],
+      name: { givenName: "Cancelled", familyName: "User" },
+    };
+
+    const result = await oauthService.handleGoogleAuth(googleProfile);
+
+    // New OAuth user should be created — the cancelled invite doesn't block
+    expect(result.success).toBe(true);
+    expect(result.userId).toBeTruthy();
+    if (result.userId) createdUserIds.push(result.userId);
+  });
+
+  it("ignores expired invitations and proceeds with normal OAuth flow", async () => {
+    const email = `expired-invite-${timestamp}@example.com`;
+    const orgId = await createTestOrg(`Expired Invite Org ${timestamp}`);
+
+    const [invite] = await db
+      .insert(invitations)
+      .values({
+        email,
+        organizationId: orgId,
+        role: "athlete",
+        token: crypto.randomBytes(32).toString("hex"),
+        status: "pending",
+        isUsed: false,
+        expiresAt: new Date(Date.now() - 60 * 1000), // expired 1 minute ago
+      })
+      .returning();
+    createdInvitationIds.push(invite.id);
+
+    const googleProfile = {
+      id: `google_expired_${timestamp}`,
+      emails: [{ value: email, verified: true }],
+      name: { givenName: "Expired", familyName: "User" },
+    };
+
+    const result = await oauthService.handleGoogleAuth(googleProfile);
+
+    expect(result.success).toBe(true);
+    expect(result.userId).toBeTruthy();
+    if (result.userId) createdUserIds.push(result.userId);
+  });
+
+  it("matches pending invitations case-insensitively", async () => {
+    const canonicalEmail = `Case-Invite-${timestamp}@Example.com`;
+    const orgId = await createTestOrg(`Case Invite Org ${timestamp}`);
+    await createPendingInvitation(canonicalEmail, orgId);
+
+    // Google returns lowercased email — common real-world case
+    const googleProfile = {
+      id: `google_case_${timestamp}`,
+      emails: [{ value: canonicalEmail.toLowerCase(), verified: true }],
+      name: { givenName: "Case", familyName: "Test" },
+    };
+
+    const result = await oauthService.handleGoogleAuth(googleProfile);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/invitation/i);
+  });
+});

--- a/packages/api/services/oauth-service.ts
+++ b/packages/api/services/oauth-service.ts
@@ -162,7 +162,23 @@ export class OAuthService extends BaseService {
         };
       }
 
-      // 3. New user - create account with OAuth
+      // 3. Block new-user creation if a pending invitation exists for this email.
+      // Otherwise OAuth creates an orphan account while the invitation quietly
+      // waits — producing two users with the same email.
+      const pendingInvitations = await this.storage.getPendingInvitationsByEmail(profile.email);
+      if (pendingInvitations.length > 0) {
+        console.warn('[OAuth] Blocked new OAuth user: pending invitation exists for email', {
+          email: profile.email,
+          invitationCount: pendingInvitations.length,
+          provider: profile.provider,
+        });
+        return {
+          success: false,
+          error: 'A pending invitation exists for this email. Please accept the invitation from your email first, then sign in.',
+        };
+      }
+
+      // 4. New user - create account with OAuth
       const newUser = await this.createOAuthUser(profile);
       return { success: true, userId: newUser.id };
 

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -126,6 +126,7 @@ export interface IStorage {
   getInvitation(token: string): Promise<Invitation | undefined>;
   getInvitationById(id: string): Promise<Invitation | undefined>;
   getInvitationByToken(token: string): Promise<Invitation | undefined>;
+  getPendingInvitationsByEmail(email: string): Promise<Invitation[]>;
   updateInvitation(id: string, invitation: Partial<Omit<Invitation, 'id' | 'createdAt'>>): Promise<Invitation>;
   acceptInvitation(token: string, userInfo: { email: string; username: string; password: string; firstName: string; lastName: string }): Promise<{ user: User }>;
 
@@ -1655,6 +1656,18 @@ export class DatabaseStorage implements IStorage {
     const [invitation] = await db.select().from(invitations)
       .where(eq(invitations.token, token));
     return invitation || undefined;
+  }
+
+  async getPendingInvitationsByEmail(email: string): Promise<Invitation[]> {
+    // Case-insensitive match: OAuth providers often lowercase emails while
+    // admins may enter invitations with mixed case.
+    return await db.select().from(invitations)
+      .where(and(
+        sql`LOWER(${invitations.email}) = LOWER(${email})`,
+        eq(invitations.isUsed, false),
+        isNull(invitations.cancelledAt),
+        gte(invitations.expiresAt, new Date()),
+      ));
   }
 
   async acceptInvitation(

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -53,6 +53,7 @@
     "dexie-react-hooks": "^4.2.0",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",
+    "exceljs": "^4.4.0",
     "framer-motion": "^11.13.1",
     "html2canvas": "^1.4.1",
     "input-otp": "^1.4.2",

--- a/packages/web/src/pages/athletes.tsx
+++ b/packages/web/src/pages/athletes.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Plus, Search, Eye, Edit, Trash2, FileUp, UsersRound, Mail, Clock, AlertCircle, Copy, RotateCcw, UserMinus, Power, X, ArrowUpDown, ArrowUp, ArrowDown, GitMerge } from "lucide-react";
+import { Plus, Search, Eye, Edit, Trash2, FileUp, UsersRound, Mail, Clock, AlertCircle, Copy, RotateCcw, UserMinus, Power, X, ArrowUpDown, ArrowUp, ArrowDown, GitMerge, Download } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
@@ -22,6 +22,7 @@ import { AthletesCardView } from "@/components/athletes-card-view";
 import { useContextualLabels } from "@/hooks/useContextualLabels";
 import { useSports, usePositionsForSports } from "@/lib/sports-api";
 import { ProfileMergeWizard } from "@/components/athletes";
+import { downloadDashrXlsx, sanitizeDashrFilename } from "@/utils/dashr-export";
 
 export default function Athletes() {
   const responsiveMode = useResponsiveMode();
@@ -625,6 +626,27 @@ export default function Athletes() {
 
     if (confirmed) {
       bulkInviteMutation.mutate(selectedAthletesArray);
+    }
+  };
+
+  const handleBulkExportDashr = async () => {
+    const selected = athletes
+      .filter(a => selectedAthletes.has(a.id))
+      .map(a => ({ firstName: a.firstName ?? '', lastName: a.lastName ?? '' }));
+    const today = new Date().toISOString().split('T')[0];
+    const filename = sanitizeDashrFilename(`athletes-${today}`);
+    try {
+      await downloadDashrXlsx(filename, selected);
+      toast({
+        title: 'Exported to Dashr',
+        description: `${selected.length} athlete${selected.length !== 1 ? 's' : ''} → ${filename}`,
+      });
+    } catch (err) {
+      toast({
+        title: 'Export failed',
+        description: err instanceof Error ? err.message : 'Could not build Dashr workbook',
+        variant: 'destructive',
+      });
     }
   };
 
@@ -1512,6 +1534,16 @@ export default function Athletes() {
             >
               <Mail className="h-4 w-4 mr-2" />
               Bulk Invite
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleBulkExportDashr}
+              className="text-white hover:bg-emerald-600 bg-emerald-700"
+              data-testid="bulk-export-dashr-button"
+            >
+              <Download className="h-4 w-4 mr-2" />
+              Export to Dashr
             </Button>
             <Button
               variant="ghost"

--- a/packages/web/src/pages/athletes.tsx
+++ b/packages/web/src/pages/athletes.tsx
@@ -631,8 +631,8 @@ export default function Athletes() {
 
   const handleBulkExportDashr = async () => {
     const selected = athletes
-      .filter(a => selectedAthletes.has(a.id))
-      .map(a => ({ firstName: a.firstName ?? '', lastName: a.lastName ?? '' }));
+      .filter((a: any) => selectedAthletes.has(a.id))
+      .map((a: any) => ({ firstName: a.firstName ?? '', lastName: a.lastName ?? '' }));
     const today = new Date().toISOString().split('T')[0];
     const filename = sanitizeDashrFilename(`athletes-${today}`);
     try {

--- a/packages/web/src/pages/teams.tsx
+++ b/packages/web/src/pages/teams.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { Plus, Edit, Trash2, Users, MoreHorizontal, Archive, RotateCcw, Settings } from "lucide-react";
+import { Plus, Edit, Trash2, Users, MoreHorizontal, Archive, RotateCcw, Settings, Download } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import TeamModal from "@/components/team-modal";
@@ -19,6 +19,7 @@ import type { Team, ArchiveTeam } from "@shared/schema";
 import { Skeleton } from "@/components/ui/skeleton";
 import { KPICardSkeleton } from "@/components/ui/loading-states";
 import { useContextualLabels } from "@/hooks/useContextualLabels";
+import { downloadDashrXlsx, sanitizeDashrFilename } from "@/utils/dashr-export";
 
 export default function Teams() {
   const labels = useContextualLabels(); // Get contextual labels
@@ -136,6 +137,33 @@ export default function Teams() {
   const handleDeleteTeam = async (teamId: string, teamName: string) => {
     if (window.confirm(`Are you sure you want to delete "${teamName}"? This action cannot be undone.`)) {
       deleteTeamMutation.mutate(teamId);
+    }
+  };
+
+  const handleExportTeamToDashr = async (team: Team) => {
+    try {
+      const params = new URLSearchParams({ teamId: team.id });
+      if (effectiveOrganizationId) {
+        params.append('organizationId', effectiveOrganizationId);
+      }
+      const response = await apiRequest('GET', `/api/athletes?${params}`);
+      const data: Array<{ firstName?: string; lastName?: string }> = await response.json();
+      const roster = data.map(a => ({ firstName: a.firstName ?? '', lastName: a.lastName ?? '' }));
+
+      const stem = team.season ? `${team.name}-${team.season}` : team.name;
+      const filename = sanitizeDashrFilename(stem);
+      await downloadDashrXlsx(filename, roster);
+
+      toast({
+        title: 'Exported to Dashr',
+        description: `${roster.length} athlete${roster.length !== 1 ? 's' : ''} → ${filename}`,
+      });
+    } catch (err) {
+      toast({
+        title: 'Export failed',
+        description: err instanceof Error ? err.message : 'Could not export team roster',
+        variant: 'destructive',
+      });
     }
   };
 
@@ -278,6 +306,13 @@ export default function Teams() {
                         Archive {labels.team}
                       </DropdownMenuItem>
                     )}
+                    <DropdownMenuItem
+                      onClick={() => handleExportTeamToDashr(team)}
+                      data-testid={`menu-export-dashr-${team.id}`}
+                    >
+                      <Download className="h-4 w-4 mr-2" />
+                      Export to Dashr
+                    </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
                       onClick={() => handleDeleteTeam(team.id, team.name)}

--- a/packages/web/src/utils/__tests__/dashr-export.test.ts
+++ b/packages/web/src/utils/__tests__/dashr-export.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import ExcelJS from 'exceljs';
+import {
+  DASHR_COLUMNS,
+  buildDashrXlsxBuffer,
+  sanitizeDashrFilename,
+} from '../dashr-export';
+
+async function parseWorkbook(buffer: Uint8Array | ArrayBuffer) {
+  const wb = new ExcelJS.Workbook();
+  await wb.xlsx.load(buffer as ArrayBuffer);
+  const ws = wb.worksheets[0];
+  const rows: string[][] = [];
+  ws.eachRow({ includeEmpty: false }, row => {
+    const cells: string[] = [];
+    for (let i = 1; i <= DASHR_COLUMNS.length; i++) {
+      const v = row.getCell(i).value;
+      cells.push(v == null ? '' : String(v));
+    }
+    rows.push(cells);
+  });
+  return { worksheet: ws, rows };
+}
+
+describe('DASHR_COLUMNS', () => {
+  it('has exactly 22 columns in Dashr template order', () => {
+    expect(DASHR_COLUMNS).toHaveLength(22);
+    expect(DASHR_COLUMNS[0]).toBe('First Name (Required)');
+    expect(DASHR_COLUMNS[1]).toBe('Middle Name');
+    expect(DASHR_COLUMNS[2]).toBe('Last Name (Required)');
+    expect(DASHR_COLUMNS[21]).toBe('Custom Field 4');
+  });
+});
+
+describe('buildDashrXlsxBuffer', () => {
+  it('emits a single worksheet named "Athletes"', async () => {
+    const buf = await buildDashrXlsxBuffer([]);
+    const { worksheet } = await parseWorkbook(buf);
+    expect(worksheet.name).toBe('Athletes');
+  });
+
+  it('produces header row only for empty athlete list', async () => {
+    const buf = await buildDashrXlsxBuffer([]);
+    const { rows } = await parseWorkbook(buf);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual([...DASHR_COLUMNS]);
+  });
+
+  it('populates First Name (col 1) and Last Name (col 3) only; other 20 cols blank', async () => {
+    const buf = await buildDashrXlsxBuffer([
+      { firstName: 'Jonathan', lastName: 'Sherman' },
+    ]);
+    const { rows } = await parseWorkbook(buf);
+    expect(rows).toHaveLength(2);
+    expect(rows[1][0]).toBe('Jonathan');
+    expect(rows[1][1]).toBe('');
+    expect(rows[1][2]).toBe('Sherman');
+    for (let i = 3; i < 22; i++) {
+      expect(rows[1][i]).toBe('');
+    }
+  });
+
+  it('emits one data row per athlete in input order', async () => {
+    const buf = await buildDashrXlsxBuffer([
+      { firstName: 'Jonathan', lastName: 'Sherman' },
+      { firstName: 'Test', lastName: 'Athlete' },
+      { firstName: 'Jane', lastName: 'Doe' },
+    ]);
+    const { rows } = await parseWorkbook(buf);
+    expect(rows).toHaveLength(4);
+    expect(rows[1][0]).toBe('Jonathan');
+    expect(rows[2][0]).toBe('Test');
+    expect(rows[3][0]).toBe('Jane');
+  });
+
+  it('passes names with leading =/+/-/@ through unchanged (XLSX stores them as shared strings, not formulas)', async () => {
+    const buf = await buildDashrXlsxBuffer([
+      { firstName: '=1+1', lastName: '@cmd' },
+    ]);
+    const { rows } = await parseWorkbook(buf);
+    expect(rows[1][0]).toBe('=1+1');
+    expect(rows[1][2]).toBe('@cmd');
+  });
+
+  it('emits blank cells for empty first/last name strings', async () => {
+    const buf = await buildDashrXlsxBuffer([
+      { firstName: '', lastName: '' },
+    ]);
+    const { rows } = await parseWorkbook(buf);
+    expect(rows).toHaveLength(2);
+    expect(rows[1][0]).toBe('');
+    expect(rows[1][2]).toBe('');
+  });
+
+  it('preserves names containing commas without CSV quoting artifacts', async () => {
+    const buf = await buildDashrXlsxBuffer([
+      { firstName: 'Smith, Jr.', lastName: 'Doe' },
+    ]);
+    const { rows } = await parseWorkbook(buf);
+    expect(rows[1][0]).toBe('Smith, Jr.');
+    expect(rows[1][2]).toBe('Doe');
+  });
+
+  it('bolds the header row', async () => {
+    const buf = await buildDashrXlsxBuffer([]);
+    const { worksheet } = await parseWorkbook(buf);
+    expect(worksheet.getRow(1).font?.bold).toBe(true);
+  });
+});
+
+describe('sanitizeDashrFilename', () => {
+  it('lowercases and replaces unsafe characters with hyphens, emits .xlsx', () => {
+    expect(sanitizeDashrFilename('Varsity Soccer 2025')).toBe('dashr-varsity-soccer-2025.xlsx');
+  });
+
+  it('strips leading and trailing separators', () => {
+    expect(sanitizeDashrFilename('  !!team!!  ')).toBe('dashr-team.xlsx');
+  });
+
+  it('falls back to a default stem when input is empty or all-unsafe', () => {
+    expect(sanitizeDashrFilename('')).toBe('dashr-athletes.xlsx');
+    expect(sanitizeDashrFilename('///')).toBe('dashr-athletes.xlsx');
+  });
+
+  it('preserves hyphens, underscores, and digits', () => {
+    expect(sanitizeDashrFilename('U14_boys-A')).toBe('dashr-u14_boys-a.xlsx');
+  });
+});

--- a/packages/web/src/utils/dashr-export.ts
+++ b/packages/web/src/utils/dashr-export.ts
@@ -1,0 +1,85 @@
+export const DASHR_COLUMNS = [
+  'First Name (Required)',
+  'Middle Name',
+  'Last Name (Required)',
+  'Shoe Size',
+  'Height',
+  'Weight',
+  'Wingspan',
+  'Reach',
+  'Hand Size',
+  'Email',
+  'Date Measured',
+  'Sport',
+  'Position',
+  'Graduation Year',
+  'Birthday',
+  'Sex',
+  'Badge ID',
+  'Third Party ID',
+  'Custom Field 1',
+  'Custom Field 2',
+  'Custom Field 3',
+  'Custom Field 4',
+] as const;
+
+export interface DashrExportAthlete {
+  firstName: string;
+  lastName: string;
+}
+
+function buildRow(athlete: DashrExportAthlete): string[] {
+  const cells = new Array<string>(DASHR_COLUMNS.length).fill('');
+  cells[0] = athlete.firstName;
+  cells[2] = athlete.lastName;
+  return cells;
+}
+
+export async function buildDashrXlsxBuffer(
+  athletes: DashrExportAthlete[],
+): Promise<Uint8Array> {
+  const ExcelJS = (await import('exceljs')).default;
+  const workbook = new ExcelJS.Workbook();
+  const worksheet = workbook.addWorksheet('Athletes');
+
+  worksheet.addRow([...DASHR_COLUMNS]);
+  worksheet.getRow(1).font = { bold: true };
+
+  for (const athlete of athletes) {
+    worksheet.addRow(buildRow(athlete));
+  }
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return new Uint8Array(buffer as ArrayBuffer);
+}
+
+export function sanitizeDashrFilename(name: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const stem = cleaned || 'athletes';
+  return `dashr-${stem}.xlsx`;
+}
+
+export async function downloadDashrXlsx(
+  filename: string,
+  athletes: DashrExportAthlete[],
+): Promise<void> {
+  const buffer = await buildDashrXlsxBuffer(athletes);
+  const blob = new Blob([buffer], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+  const url = URL.createObjectURL(blob);
+  try {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/tests/e2e/dashr-export.spec.ts
+++ b/tests/e2e/dashr-export.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import { loginAsDefaultUser } from './helpers/auth';
+import { goToAthletes, goToTeams } from './helpers/navigation';
+
+const STAGING_URL = process.env.STAGING_URL || 'http://localhost:5000';
+
+test.describe('Dashr Export — Athletes page', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsDefaultUser(page);
+    await goToAthletes(page);
+  });
+
+  test('bulk-export button is hidden when no athletes are selected', async ({ page }) => {
+    // The floating bulk-action bar (and its Export button) must not be visible
+    // until at least one athlete is selected.
+    await expect(page.locator('[data-testid="bulk-export-dashr-button"]')).not.toBeVisible();
+  });
+
+  test('selecting an athlete reveals the Export to Dashr button', async ({ page }) => {
+    const firstCheckbox = page.locator('[data-testid^="checkbox-athlete-"]').first();
+
+    // Skip gracefully when the page has no athletes (empty org)
+    const count = await firstCheckbox.count();
+    if (count === 0) {
+      test.skip();
+      return;
+    }
+
+    await firstCheckbox.click();
+    await expect(page.locator('[data-testid="bulk-export-dashr-button"]')).toBeVisible();
+  });
+
+  test('clicking Export to Dashr downloads an .xlsx file', async ({ page }) => {
+    const firstCheckbox = page.locator('[data-testid^="checkbox-athlete-"]').first();
+
+    const count = await firstCheckbox.count();
+    if (count === 0) {
+      test.skip();
+      return;
+    }
+
+    await firstCheckbox.click();
+    await expect(page.locator('[data-testid="bulk-export-dashr-button"]')).toBeVisible();
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.locator('[data-testid="bulk-export-dashr-button"]').click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/^dashr-.*\.xlsx$/);
+  });
+});
+
+test.describe('Dashr Export — Teams page', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsDefaultUser(page);
+    await goToTeams(page);
+  });
+
+  test('team action menu contains Export to Dashr item', async ({ page }) => {
+    const firstMenuTrigger = page.locator('[data-testid^="button-team-menu-"]').first();
+
+    const count = await firstMenuTrigger.count();
+    if (count === 0) {
+      test.skip();
+      return;
+    }
+
+    await firstMenuTrigger.click();
+    const exportItem = page.locator('[data-testid^="menu-export-dashr-"]').first();
+    await expect(exportItem).toBeVisible();
+    await expect(exportItem).toContainText('Export to Dashr');
+  });
+
+  test('clicking Export to Dashr from team menu downloads an .xlsx file', async ({ page }) => {
+    const firstMenuTrigger = page.locator('[data-testid^="button-team-menu-"]').first();
+
+    const count = await firstMenuTrigger.count();
+    if (count === 0) {
+      test.skip();
+      return;
+    }
+
+    await firstMenuTrigger.click();
+    const exportItem = page.locator('[data-testid^="menu-export-dashr-"]').first();
+    await expect(exportItem).toBeVisible();
+
+    const downloadPromise = page.waitForEvent('download');
+    await exportItem.click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/^dashr-.*\.xlsx$/);
+  });
+});


### PR DESCRIPTION
## Summary

Release PR merging `develop` into `main`. Contains two squash-merged PRs:

- **#373 — feat(export): Dashr XLSX export for athletes and teams**
  New "Export to Dashr" action on the Athletes bulk bar and per-team Teams dropdown. Produces a 22-column `.xlsx` matching Dashr's roster template (First/Last name populated, other columns empty per product decision). `exceljs` is dynamically imported so it only loads when a coach clicks Export.

- **#374 — fix(oauth): block new user creation when pending invitation exists**
  Closes a bug where a Google sign-in for an email that had a pending (unaccepted) invitation would silently create a duplicate OAuth-only user instead of matching the pending-athlete shell. Now returns a user-facing error prompting the athlete to accept the invitation first. Includes `getPendingInvitationsByEmail` on `IStorage` and integration tests covering the block, cancelled/expired invitations, and case-insensitive email matching. Production duplicate already consolidated via `scripts/merge-duplicate-users.ts`.

## Scope of changes

`git diff main develop --stat`: 10 files, +1394 / -8. Main surface area:

- `packages/web/src/pages/{athletes,teams}.tsx` — new export buttons
- `packages/web/src/utils/dashr-export.ts` (+ tests) — XLSX builder
- `packages/web/package.json` — adds `exceljs`
- `packages/api/services/oauth-service.ts` — pending-invitation guard
- `packages/api/storage.ts` — `getPendingInvitationsByEmail`
- `packages/api/__tests__/oauth-service-pending-invitation.test.ts`
- `tests/e2e/dashr-export.spec.ts`

## Test plan

- [x] Unit + integration tests green on `develop` (Dashr export 13/13, OAuth pending-invitation 4/4, OAuth getUsersByEmail 4/4, storage 6/6)
- [x] `npm run check` passes
- [ ] Post-merge: verify Railway production deploy healthchecks pass
- [ ] Post-merge smoke: Google OAuth sign-in for an email with a pending invitation returns the "accept invitation first" error
- [ ] Post-merge smoke: `/athletes` bulk-select → **Export to Dashr** downloads a valid `.xlsx`; upload to Dashr succeeds

## Risk

Low. The export feature is additive (new buttons, no changes to existing export paths) and the OAuth change tightens auth against a bug the production data-fix already corrected — no new users can reach the duplicate-creation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)