### PR TITLE
release: v0.19.1 — Sprint F-V site setting persistence fix

### DIFF
--- a/packages/api/routes/__tests__/site-settings-routes.test.ts
+++ b/packages/api/routes/__tests__/site-settings-routes.test.ts
@@ -393,6 +393,60 @@ describe("Site Settings API Routes", () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toContain("Validation error");
     });
+
+    it("should persist sprintFvEnabled=true across updates (regression)", async () => {
+      mockSessionUser = {
+        id: testSiteAdminId,
+        email: `siteadmin-settings-${Date.now()}@test.com`,
+        role: "site_admin",
+        isSiteAdmin: true,
+      };
+
+      const enableResponse = await request(app)
+        .patch("/api/site-settings")
+        .send({ sprintFvEnabled: true });
+
+      expect(enableResponse.status).toBe(200);
+      expect(enableResponse.body.sprintFvEnabled).toBe(true);
+
+      const readback = await request(app).get("/api/site-settings");
+      expect(readback.status).toBe(200);
+      expect(readback.body.sprintFvEnabled).toBe(true);
+
+      const publicReadback = await request(app).get("/api/site-settings/public");
+      expect(publicReadback.status).toBe(200);
+      expect(publicReadback.body.sprintFvEnabled).toBe(true);
+    });
+
+    it("should persist sprintFvEnabled=false across updates (regression)", async () => {
+      mockSessionUser = {
+        id: testSiteAdminId,
+        email: `siteadmin-settings-${Date.now()}@test.com`,
+        role: "site_admin",
+        isSiteAdmin: true,
+      };
+
+      await request(app)
+        .patch("/api/site-settings")
+        .send({ sprintFvEnabled: true });
+
+      // Intermediate readback: proves the enable PATCH actually persisted.
+      // Without this, the test passes pre-fix because the DB default is false
+      // and enable→disable silent-drops in both directions end at false.
+      const intermediate = await request(app).get("/api/site-settings");
+      expect(intermediate.body.sprintFvEnabled).toBe(true);
+
+      const disableResponse = await request(app)
+        .patch("/api/site-settings")
+        .send({ sprintFvEnabled: false });
+
+      expect(disableResponse.status).toBe(200);
+      expect(disableResponse.body.sprintFvEnabled).toBe(false);
+
+      const readback = await request(app).get("/api/site-settings");
+      expect(readback.status).toBe(200);
+      expect(readback.body.sprintFvEnabled).toBe(false);
+    });
   });
 
   describe("GET /api/ai-models", () => {

--- a/packages/api/routes/site-settings-routes.ts
+++ b/packages/api/routes/site-settings-routes.ts
@@ -81,6 +81,7 @@ router.get("/", requireSiteAdmin, async (req, res) => {
       return res.json({
         aiModel: "gpt-5-nano",
         wellnessModuleEnabled: true,
+        sprintFvEnabled: false,
         updatedAt: new Date().toISOString(),
         updatedBy: null,
       });

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -365,7 +365,12 @@ export interface IStorage {
 
   // Site Settings (Global Settings)
   getSiteSettings(): Promise<SiteSettings | undefined>;
-  updateSiteSettings(settings: { aiModel: string; updatedBy: string | null }): Promise<SiteSettings>;
+  updateSiteSettings(settings: {
+    aiModel?: string;
+    wellnessModuleEnabled?: boolean;
+    sprintFvEnabled?: boolean;
+    updatedBy: string | null;
+  }): Promise<SiteSettings>;
 
   // Reports
   getReport(id: string): Promise<Report | undefined>;
@@ -5494,7 +5499,12 @@ export class DatabaseStorage implements IStorage {
     return settings || undefined;
   }
 
-  async updateSiteSettings(settings: { aiModel?: string; wellnessModuleEnabled?: boolean; updatedBy: string | null }): Promise<SiteSettings> {
+  async updateSiteSettings(settings: {
+    aiModel?: string;
+    wellnessModuleEnabled?: boolean;
+    sprintFvEnabled?: boolean;
+    updatedBy: string | null;
+  }): Promise<SiteSettings> {
     // Singleton pattern - check if settings exist
     const existing = await this.getSiteSettings();
 
@@ -5513,6 +5523,10 @@ export class DatabaseStorage implements IStorage {
         updateData.wellnessModuleEnabled = settings.wellnessModuleEnabled;
       }
 
+      if (settings.sprintFvEnabled !== undefined) {
+        updateData.sprintFvEnabled = settings.sprintFvEnabled;
+      }
+
       const [updated] = await db
         .update(siteSettings)
         .set(updateData)
@@ -5526,6 +5540,7 @@ export class DatabaseStorage implements IStorage {
         .values({
           aiModel: settings.aiModel || 'gpt-5-nano',
           wellnessModuleEnabled: settings.wellnessModuleEnabled ?? true,
+          sprintFvEnabled: settings.sprintFvEnabled ?? false,
           updatedBy: settings.updatedBy,
         })
         .returning();


### PR DESCRIPTION
## Release: v0.19.1

Single-fix patch release on top of v0.19.0. The Sprint F-V enable/disable toggle in Site Settings (`/admin`) now persists correctly when toggled off, unblocking per-org enablement (which is gated on the site-level flag).

### Scope

- **1 commit**, 3 files, +72/-2 LOC
- **Type:** PATCH (pure bug fix, no features, no breaking changes)

### Changelog

#### Bug Fixes
- **Site settings: persist `sprintFvEnabled` flag on update** (#376) — `storage.updateSiteSettings` was silently dropping the `sprintFvEnabled` field because the `IStorage` interface and implementation did not list it. Toggling Sprint F-V off at `/admin` bumped `updated_at` but left `sprint_fv_enabled=false` in the DB. Fixed in `packages/api/storage.ts` (both UPDATE and INSERT branches, plus interface tightening that also picked up `wellnessModuleEnabled`) and `packages/api/routes/site-settings-routes.ts` (default-settings fallback shape). Added two regression integration tests in `packages/api/routes/__tests__/site-settings-routes.test.ts` covering PATCH → GET round-trips for both the admin and public endpoints.

### Release Readiness

- [x] PR #376 CI: Unit, Integration, TypeScript, Build, Security Audit, Migration Idempotency, Workflow Lint — all pass
- [x] Claude review — pass
- [x] Regression tests added and green
- [x] No schema/migration changes
- [x] No new dependencies
- [x] No breaking changes

### Files Changed

```
packages/api/routes/__tests__/site-settings-routes.test.ts  | +54
packages/api/routes/site-settings-routes.ts                 |  +1
packages/api/storage.ts                                     | +17/-2
```

### Post-Merge Steps (not done by this PR)

1. Tag `v0.19.1` on `main` after squash merge
2. Create GitHub release with the changelog above
3. Verify Railway production deploy succeeds

---
**Full diff:** `v0.19.0...develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)