### PR TITLE
feat(sprint-fv): 10/20/30/40 protocol with yards + meters support

### DIFF
--- a/migrations/0122_add_sprint_fv_module_toggled_audit_action.sql
+++ b/migrations/0122_add_sprint_fv_module_toggled_audit_action.sql
@@ -1,0 +1,174 @@
+-- Migration 0122: Add site_sprint_fv_module_toggled audit action
+--
+-- The sprint F-V feature flag was introduced in PR #355 (packages/api/routes/site-settings-routes.ts),
+-- but the audit action 'site_sprint_fv_module_toggled' was never added to audit_logs_action_valid.
+-- This caused toggling the flag to fail with check-constraint violation 23514.
+--
+-- IDEMPOTENT: safe to run multiple times.
+
+DO $$
+BEGIN
+  ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS audit_logs_action_valid;
+
+  ALTER TABLE audit_logs ADD CONSTRAINT audit_logs_action_valid CHECK (action IN (
+    -- Organization actions
+    'organization_created',
+    'organization_updated',
+    'organization_deactivated',
+    'organization_reactivated',
+    'organization_deleted',
+    'organization_dependencies_viewed',
+    'organization_type_accessed',
+    'site_admin_access',
+    'site_admin_organization_access',
+
+    -- User actions
+    'user_created',
+    'user_updated',
+    'user_deleted',
+    'user_role_changed',
+    'user_role_updated',
+    'user_registered',
+    'role_changed',
+    'password_reset_unknown_email',
+    'email_verification_requested',
+    'password_change_failed',
+    'privilege_restoration_blocked',
+    'admin_password_synced',
+    'privilege_restored',
+    'oauth_login',
+
+    -- Legal acceptance action
+    'legal_accepted',
+
+    -- Team actions
+    'team_created',
+    'team_updated',
+    'team_deleted',
+    'team_archived',
+
+    -- Measurement actions
+    'measurement_created',
+    'measurement_updated',
+    'measurement_deleted',
+    'measurements_bulk_verify',
+    'measurements_bulk_unverify',
+
+    -- Invitation actions
+    'invitation_created',
+    'invitation_accepted',
+    'invitation_cancelled',
+    'invitation_resent',
+
+    -- Session actions
+    'sessions_revoked',
+    'zombie_sessions_cleaned',
+    'zombie_cleanup_failed',
+    'session_revocation_failed',
+
+    -- Metric actions
+    'metric_created',
+    'metric_updated',
+    'metric_enabled',
+    'metric_disabled',
+    'metric_deleted',
+    'org_metric_enabled',
+    'org_metric_disabled',
+    'org_metric_updated',
+    'org_metrics_bulk_enabled',
+
+    -- Benchmark actions
+    'benchmark_created',
+    'benchmark_updated',
+    'benchmark_deleted',
+    'benchmark_enabled',
+    'benchmark_disabled',
+    'custom_benchmark_created',
+    'custom_benchmark_updated',
+    'custom_benchmark_deleted',
+    'org_benchmark_enabled',
+    'org_benchmark_disabled',
+    'org_benchmark_updated',
+
+    -- AI feature actions
+    'org_ai_enabled_by_site_admin',
+    'org_ai_disabled_by_site_admin',
+    'org_ai_enabled_by_org_admin',
+    'org_ai_disabled_by_org_admin',
+    'site_ai_model_changed',
+    'report_ai_insights_generated',
+    'report_ai_insights_updated',
+    'report_ai_insights_generation_failed',
+
+    -- Organization type actions
+    'organization_type_metrics_queried',
+    'organization_type_benchmarks_queried',
+
+    -- Cache actions
+    'cache_invalidated',
+    'cache_invalidation_failed',
+
+    -- Site settings actions
+    'site_wellness_module_toggled',
+    'site_sprint_fv_module_toggled', -- NEW: sprint F-V module toggle (fills gap from PR #355)
+
+    -- Organization wellness actions
+    'org_wellness_enabled',
+    'org_wellness_disabled',
+
+    -- Organization events actions
+    'org_events_enabled',
+    'org_events_disabled',
+
+    -- Membership request actions
+    'membership_request_created',
+    'membership_request_approved',
+    'membership_request_rejected',
+    'membership_request_cancelled',
+    'organization_join_code_regenerated',
+    'organization_join_code_set',
+    'organization_membership_settings_updated',
+
+    -- Event actions
+    'event_created',
+    'event_updated',
+    'event_deleted',
+    'event_frozen',
+    'event_unfrozen',
+    'event_freeze_overridden',
+    'event_results_published',
+    'event_registration_created',
+    'event_registration_approved',
+    'event_registration_declined',
+    'event_registration_cancelled',
+    'event_registration_checked_in',
+    'event_registration_promoted',
+    'event_invitation_created',
+    'event_invitation_accepted',
+    'event_invitation_declined',
+    'event_invitation_cancelled',
+
+    -- Event metric actions
+    'event_metric_added',
+    'event_metric_removed',
+    'event_metric_updated',
+    'event_metrics_reordered',
+    'event_metrics_bulk_added',
+
+    -- Event results actions
+    'event_results_unpublished',
+    'event_results_visibility_changed',
+
+    -- Training module actions
+    'site_training_module_toggled',
+    'org_training_enabled',
+
+    -- Parent/COPPA actions
+    'parent_unlinked_child'
+  ));
+
+  RAISE NOTICE 'Migration 0122: Added site_sprint_fv_module_toggled to audit_logs_action_valid';
+END $$;
+
+COMMENT ON CONSTRAINT audit_logs_action_valid ON audit_logs IS
+  'Valid audit log actions — added site_sprint_fv_module_toggled in migration 0122 to match sprint F-V feature flag route (PR #355)';

--- a/migrations/0122_add_sprint_fv_module_toggled_audit_action_down.sql
+++ b/migrations/0122_add_sprint_fv_module_toggled_audit_action_down.sql
@@ -1,0 +1,52 @@
+-- Down Migration 0122: Remove site_sprint_fv_module_toggled from audit_logs_action_valid
+-- Restores the audit_logs_action_valid constraint to its pre-0122 state.
+-- Note: migration 0122 only touched the action constraint, so this down migration
+-- intentionally does not touch audit_logs_resource_type_valid.
+
+DO $$
+BEGIN
+  ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS audit_logs_action_valid;
+
+  ALTER TABLE audit_logs ADD CONSTRAINT audit_logs_action_valid CHECK (action IN (
+    'organization_created', 'organization_updated', 'organization_deactivated', 'organization_reactivated',
+    'organization_deleted', 'organization_dependencies_viewed', 'organization_type_accessed',
+    'site_admin_access', 'site_admin_organization_access',
+    'user_created', 'user_updated', 'user_deleted', 'user_role_changed', 'user_role_updated',
+    'user_registered', 'role_changed', 'password_reset_unknown_email', 'email_verification_requested',
+    'password_change_failed', 'privilege_restoration_blocked', 'admin_password_synced', 'privilege_restored',
+    'oauth_login', 'legal_accepted',
+    'team_created', 'team_updated', 'team_deleted', 'team_archived',
+    'measurement_created', 'measurement_updated', 'measurement_deleted',
+    'measurements_bulk_verify', 'measurements_bulk_unverify',
+    'invitation_created', 'invitation_accepted', 'invitation_cancelled', 'invitation_resent',
+    'sessions_revoked', 'zombie_sessions_cleaned', 'zombie_cleanup_failed', 'session_revocation_failed',
+    'metric_created', 'metric_updated', 'metric_enabled', 'metric_disabled', 'metric_deleted',
+    'org_metric_enabled', 'org_metric_disabled', 'org_metric_updated', 'org_metrics_bulk_enabled',
+    'benchmark_created', 'benchmark_updated', 'benchmark_deleted', 'benchmark_enabled', 'benchmark_disabled',
+    'custom_benchmark_created', 'custom_benchmark_updated', 'custom_benchmark_deleted',
+    'org_benchmark_enabled', 'org_benchmark_disabled', 'org_benchmark_updated',
+    'org_ai_enabled_by_site_admin', 'org_ai_disabled_by_site_admin',
+    'org_ai_enabled_by_org_admin', 'org_ai_disabled_by_org_admin',
+    'site_ai_model_changed', 'report_ai_insights_generated', 'report_ai_insights_updated',
+    'report_ai_insights_generation_failed',
+    'organization_type_metrics_queried', 'organization_type_benchmarks_queried',
+    'cache_invalidated', 'cache_invalidation_failed',
+    'site_wellness_module_toggled',
+    'org_wellness_enabled', 'org_wellness_disabled',
+    'org_events_enabled', 'org_events_disabled',
+    'membership_request_created', 'membership_request_approved', 'membership_request_rejected',
+    'membership_request_cancelled', 'organization_join_code_regenerated', 'organization_join_code_set',
+    'organization_membership_settings_updated',
+    'event_created', 'event_updated', 'event_deleted', 'event_frozen', 'event_unfrozen',
+    'event_freeze_overridden', 'event_results_published',
+    'event_registration_created', 'event_registration_approved', 'event_registration_declined',
+    'event_registration_cancelled', 'event_registration_checked_in', 'event_registration_promoted',
+    'event_invitation_created', 'event_invitation_accepted', 'event_invitation_declined',
+    'event_invitation_cancelled',
+    'event_metric_added', 'event_metric_removed', 'event_metric_updated',
+    'event_metrics_reordered', 'event_metrics_bulk_added',
+    'event_results_unpublished', 'event_results_visibility_changed',
+    'site_training_module_toggled', 'org_training_enabled',
+    'parent_unlinked_child'
+  ));
+END $$;

--- a/migrations/0123_seed_sprint_fv_meters_metrics.sql
+++ b/migrations/0123_seed_sprint_fv_meters_metrics.sql
@@ -1,0 +1,36 @@
+-- Migration 0123: Seed DASH_*M and FLY10M_TIME rows in site_metrics
+--
+-- The Sprint F-V protocol switched to 10/20/30/40 in both yards and meters.
+-- The yards codes (DASH_10YD..DASH_40YD, FLY10_TIME) were already seeded by
+-- migrations 0022 and 0107, but the meter-unit counterparts never had rows.
+--
+-- Without these rows the `organization_metrics` FK to `site_metrics(code)`
+-- blocks any org from enabling/disabling the meter splits, so leaderboards
+-- and analytics surfaces would silently omit metric-unit DashR imports.
+--
+-- This migration mirrors the 0107 pattern: INSERT ... ON CONFLICT DO NOTHING
+-- so it is safe to run multiple times.
+
+INSERT INTO site_metrics (code, label, category, unit, metric_type, is_system_default, is_active, display_order, description, decimal_precision, color, icon)
+VALUES
+  ('DASH_10M', '10-Meter Dash Split', 'speed', 's', 'lower_is_better', true, true, 28,
+   '10-meter split time from timing gates (acceleration phase, metric-unit DashR imports).',
+   3, 'indigo', 'Timer'),
+  ('DASH_20M', '20-Meter Dash Split', 'speed', 's', 'lower_is_better', true, true, 29,
+   '20-meter split time from timing gates (metric-unit DashR imports).',
+   3, 'indigo', 'Timer'),
+  ('DASH_30M', '30-Meter Dash Split', 'speed', 's', 'lower_is_better', true, true, 30,
+   '30-meter split time from timing gates (metric-unit DashR imports).',
+   3, 'indigo', 'Timer'),
+  ('DASH_40M', '40-Meter Dash Split', 'speed', 's', 'lower_is_better', true, true, 31,
+   '40-meter split time from timing gates — reaches V0 asymptote for F-V profile fitting.',
+   3, 'indigo', 'Timer'),
+  ('FLY10M_TIME', '10-Meter Fly Time', 'speed', 's', 'lower_is_better', true, true, 32,
+   'Time to cover 10 meters after a flying start, measuring maximum velocity (metric-unit equivalent of FLY10_TIME).',
+   3, 'blue', 'Clock')
+ON CONFLICT (code) DO NOTHING;
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 0123: Seeded 5 metric-unit site_metrics rows for Sprint F-V protocol';
+END $$;

--- a/migrations/0123_seed_sprint_fv_meters_metrics_down.sql
+++ b/migrations/0123_seed_sprint_fv_meters_metrics_down.sql
@@ -1,0 +1,14 @@
+-- Down Migration 0123: Remove meter-unit Sprint F-V site_metrics rows
+--
+-- WARNING: This will also remove any organization_metrics rows referencing
+-- these codes (ON DELETE CASCADE). Run only when rolling back the protocol
+-- change; any measurements keyed by these codes will be orphaned from
+-- organization-level metric enablement until re-seeded.
+
+DELETE FROM site_metrics
+ WHERE code IN ('DASH_10M', 'DASH_20M', 'DASH_30M', 'DASH_40M', 'FLY10M_TIME');
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 0123 (down): Removed 5 metric-unit site_metrics rows';
+END $$;

--- a/packages/api/services/__tests__/sprint-fv-computation.test.ts
+++ b/packages/api/services/__tests__/sprint-fv-computation.test.ts
@@ -8,9 +8,9 @@ import { computeFvProfile, type ComputedFvProfile } from '../sprint-fv-computati
  */
 
 describe('computeFvProfile', () => {
-  describe('basic computation with 4 splits', () => {
-    // Typical college sprinter: 30m in ~4.5s
-    const splits = { '5': 1.10, '10': 1.82, '20': 3.15, '30': 4.45 };
+  describe('basic computation with 4 splits (10/20/30/40 protocol)', () => {
+    // Typical college sprinter: 40m in ~5.6s, mono-exponential shape
+    const splits = { '10': 1.82, '20': 3.15, '30': 4.45, '40': 5.72 };
     const bodyMassKg = 80;
     let result: ComputedFvProfile;
 
@@ -88,9 +88,9 @@ describe('computeFvProfile', () => {
     });
   });
 
-  describe('yard to meter conversion', () => {
-    // Same athlete, data in yards
-    const splitsYards = { '5': 1.03, '10': 1.70, '20': 2.95, '30': 4.18 };
+  describe('yard to meter conversion (10/20/30/40 yards)', () => {
+    // Same athlete, data in yards — 40yd ≈ 36.58m
+    const splitsYards = { '10': 1.70, '20': 2.95, '30': 4.18, '40': 5.35 };
     const bodyMassKg = 80;
 
     it('should convert yards to meters internally', () => {
@@ -102,7 +102,7 @@ describe('computeFvProfile', () => {
     });
 
     it('should produce similar Pmax for equivalent performances in yards vs meters', () => {
-      // A 30yd sprint ≈ 27.4m; times should be slightly different
+      // A 40yd sprint ≈ 36.58m; times should be slightly different
       // but the physics (Pmax) should be in the same ballpark
       const resultYards = computeFvProfile(splitsYards, bodyMassKg, 'yards');
       expect(resultYards.pmaxRel).toBeGreaterThan(5);
@@ -111,7 +111,8 @@ describe('computeFvProfile', () => {
   });
 
   describe('3 of 4 splits (minimum data)', () => {
-    const splits3 = { '5': 1.10, '10': 1.82, '30': 4.45 };
+    // Uses 10/20/40 — legal under the new protocol, missing 30
+    const splits3 = { '10': 1.82, '20': 3.15, '40': 5.72 };
     const bodyMassKg = 75;
 
     it('should compute with only 3 splits', () => {
@@ -129,29 +130,29 @@ describe('computeFvProfile', () => {
 
   describe('edge cases', () => {
     it('should throw with fewer than 3 splits', () => {
-      expect(() => computeFvProfile({ '5': 1.10, '10': 1.82 }, 80, 'meters'))
+      expect(() => computeFvProfile({ '10': 1.82, '20': 3.15 }, 80, 'meters'))
         .toThrow(/at least 3/i);
     });
 
     it('should throw with non-monotonically-increasing times', () => {
-      // 20m time is less than 10m time — physically impossible
-      expect(() => computeFvProfile({ '5': 1.10, '10': 3.00, '20': 2.50, '30': 4.45 }, 80, 'meters'))
+      // 30m time is less than 20m time — physically impossible
+      expect(() => computeFvProfile({ '10': 1.82, '20': 4.00, '30': 3.50, '40': 5.72 }, 80, 'meters'))
         .toThrow(/monotonically/i);
     });
 
     it('should throw with zero or negative times', () => {
-      expect(() => computeFvProfile({ '5': 0, '10': 1.82, '20': 3.15, '30': 4.45 }, 80, 'meters'))
+      expect(() => computeFvProfile({ '10': 0, '20': 3.15, '30': 4.45, '40': 5.72 }, 80, 'meters'))
         .toThrow(/positive/i);
     });
 
     it('should throw with zero body mass', () => {
-      expect(() => computeFvProfile({ '5': 1.10, '10': 1.82, '20': 3.15, '30': 4.45 }, 0, 'meters'))
+      expect(() => computeFvProfile({ '10': 1.82, '20': 3.15, '30': 4.45, '40': 5.72 }, 0, 'meters'))
         .toThrow(/body mass/i);
     });
 
     it('should handle very fast sprinter (elite)', () => {
-      // Elite male: 30m in ~3.6s
-      const splits = { '5': 0.85, '10': 1.42, '20': 2.50, '30': 3.55 };
+      // Elite male: 40m in ~4.6s
+      const splits = { '10': 1.42, '20': 2.50, '30': 3.55, '40': 4.58 };
       const result = computeFvProfile(splits, 85, 'meters');
       expect(result.vmax).toBeGreaterThan(9);
       expect(result.f0Rel).toBeGreaterThan(6);
@@ -159,8 +160,8 @@ describe('computeFvProfile', () => {
     });
 
     it('should handle slow athlete (recreational)', () => {
-      // Recreational: 30m in ~6.0s
-      const splits = { '5': 1.50, '10': 2.50, '20': 4.30, '30': 6.00 };
+      // Recreational: 40m in ~7.8s
+      const splits = { '10': 2.50, '20': 4.30, '30': 6.00, '40': 7.80 };
       const result = computeFvProfile(splits, 70, 'meters');
       expect(result.vmax).toBeGreaterThan(5);
       expect(result.vmax).toBeLessThan(8);

--- a/packages/api/services/__tests__/sprint-fv-service.test.ts
+++ b/packages/api/services/__tests__/sprint-fv-service.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSplitsFromMeasurements,
+  SprintFvValidationError,
+  SPLIT_METRICS_YARDS,
+  SPLIT_METRICS_METERS,
+  type SplitMeasurementInput,
+} from '../sprint-fv-service';
+import { MetricType, VALID_METRICS } from '@shared/schema/constants';
+
+/**
+ * Unit tests for the pure split-resolution logic used by SprintFvService.
+ *
+ * The service separates the DB-free algorithm (choose a unit, pick the fastest
+ * time per distance, detect mixed units) from the drizzle query that supplies
+ * measurement rows — these tests exercise the algorithm in isolation.
+ */
+
+function mk(id: string, metric: string, value: string | number): SplitMeasurementInput {
+  return { id, metric, value: String(value) };
+}
+
+describe('resolveSplitsFromMeasurements', () => {
+  describe('yards (new 10/20/30/40 protocol)', () => {
+    it('resolves a full yards session to the yards unit and 4 splits', () => {
+      const rows = [
+        mk('a', 'DASH_10YD', 1.70),
+        mk('b', 'DASH_20YD', 2.95),
+        mk('c', 'DASH_30YD', 4.18),
+        mk('d', 'DASH_40YD', 5.30),
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+
+      expect(result.distanceUnit).toBe('yards');
+      expect(result.splitTimes).toEqual({ '10': 1.70, '20': 2.95, '30': 4.18, '40': 5.30 });
+      expect(result.usedMeasurementIds).toEqual({ '10': 'a', '20': 'b', '30': 'c', '40': 'd' });
+    });
+
+    it('accepts 3 of 4 splits (minimum protocol)', () => {
+      const rows = [
+        mk('a', 'DASH_10YD', 1.70),
+        mk('c', 'DASH_30YD', 4.18),
+        mk('d', 'DASH_40YD', 5.30),
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+
+      expect(result.distanceUnit).toBe('yards');
+      expect(Object.keys(result.splitTimes)).toHaveLength(3);
+    });
+
+    it('picks the fastest time when a distance has duplicate trials', () => {
+      const rows = [
+        mk('a', 'DASH_10YD', 1.85),
+        mk('a2', 'DASH_10YD', 1.70), // fastest
+        mk('b', 'DASH_20YD', 2.95),
+        mk('c', 'DASH_30YD', 4.18),
+        mk('d', 'DASH_40YD', 5.30),
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+
+      expect(result.splitTimes['10']).toBe(1.70);
+      expect(result.usedMeasurementIds['10']).toBe('a2');
+    });
+  });
+
+  describe('meters (new DASH_*M metric types)', () => {
+    it('resolves a full meters session to the meters unit', () => {
+      const rows = [
+        mk('a', 'DASH_10M', 1.85),
+        mk('b', 'DASH_20M', 3.20),
+        mk('c', 'DASH_30M', 4.55),
+        mk('d', 'DASH_40M', 5.80),
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+
+      expect(result.distanceUnit).toBe('meters');
+      expect(result.splitTimes).toEqual({ '10': 1.85, '20': 3.20, '30': 4.55, '40': 5.80 });
+    });
+  });
+
+  describe('mixed units (error)', () => {
+    it('throws SprintFvValidationError when both yards and meters have enough splits', () => {
+      const rows = [
+        // Three yards splits
+        mk('y1', 'DASH_10YD', 1.70),
+        mk('y2', 'DASH_20YD', 2.95),
+        mk('y3', 'DASH_30YD', 4.18),
+        // Three meters splits
+        mk('m1', 'DASH_10M', 1.85),
+        mk('m2', 'DASH_20M', 3.20),
+        mk('m3', 'DASH_30M', 4.55),
+      ];
+
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(SprintFvValidationError);
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(/mixed/i);
+    });
+
+    it('prefers the yards unit when meters has <3 splits', () => {
+      const rows = [
+        mk('y1', 'DASH_10YD', 1.70),
+        mk('y2', 'DASH_20YD', 2.95),
+        mk('y3', 'DASH_30YD', 4.18),
+        mk('m1', 'DASH_10M', 1.85), // stray meters measurement
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+      expect(result.distanceUnit).toBe('yards');
+      expect(Object.keys(result.splitTimes)).toEqual(['10', '20', '30']);
+    });
+  });
+
+  describe('insufficient data', () => {
+    it('throws when neither unit has 3 splits', () => {
+      const rows = [
+        mk('y1', 'DASH_10YD', 1.70),
+        mk('y2', 'DASH_20YD', 2.95),
+      ];
+
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(SprintFvValidationError);
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(/at least 3/i);
+    });
+
+    it('ignores non-finite / non-positive times when counting', () => {
+      const rows = [
+        mk('a', 'DASH_10YD', 1.70),
+        mk('b', 'DASH_20YD', 0), // invalid
+        mk('c', 'DASH_30YD', 4.18),
+        mk('d', 'DASH_40YD', 'not-a-number'),
+      ];
+
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(/at least 3/i);
+    });
+  });
+
+  describe('metric-code tables', () => {
+    it('exports a yards-only split metric map for the 10/20/30/40 protocol', () => {
+      expect(SPLIT_METRICS_YARDS).toEqual({
+        DASH_10YD: 10,
+        DASH_20YD: 20,
+        DASH_30YD: 30,
+        DASH_40YD: 40,
+      });
+    });
+
+    it('exports a meters-only split metric map for the 10/20/30/40 protocol', () => {
+      expect(SPLIT_METRICS_METERS).toEqual({
+        DASH_10M: 10,
+        DASH_20M: 20,
+        DASH_30M: 30,
+        DASH_40M: 40,
+      });
+    });
+  });
+
+  describe('MetricType / VALID_METRICS cohesion with split-code maps', () => {
+    it('registers every yards split distance in MetricType', () => {
+      for (const code of Object.keys(SPLIT_METRICS_YARDS)) {
+        expect((MetricType as Record<string, string>)[code]).toBe(code);
+      }
+    });
+
+    it('registers every meters split distance in MetricType', () => {
+      for (const code of Object.keys(SPLIT_METRICS_METERS)) {
+        expect((MetricType as Record<string, string>)[code]).toBe(code);
+      }
+    });
+
+    it('includes FLY10_TIME and FLY10M_TIME in MetricType', () => {
+      expect((MetricType as Record<string, string>).FLY10_TIME).toBe('FLY10_TIME');
+      expect((MetricType as Record<string, string>).FLY10M_TIME).toBe('FLY10M_TIME');
+    });
+
+    it('lists every split metric in VALID_METRICS as lower_is_better', () => {
+      const validKeys = new Map(VALID_METRICS.map(m => [m.key, m.metricType]));
+      for (const code of [...Object.keys(SPLIT_METRICS_YARDS), ...Object.keys(SPLIT_METRICS_METERS)]) {
+        expect(validKeys.get(code)).toBe('lower_is_better');
+      }
+      expect(validKeys.get('FLY10M_TIME')).toBe('lower_is_better');
+    });
+  });
+});

--- a/packages/api/services/parsers/__tests__/dashr-csv-parser.test.ts
+++ b/packages/api/services/parsers/__tests__/dashr-csv-parser.test.ts
@@ -466,3 +466,77 @@ describe('FLY10_TIME derivation', () => {
     expect(fly10).toBeUndefined();
   });
 });
+
+// ============================================================================
+// Metric (meters) units support — 10/20/30/40m protocol
+// ============================================================================
+
+describe('DashrCsvParser — Metric units', () => {
+  it('maps a 40m Dash with Units=Metric to DASH_40M', () => {
+    // 40m dash with splits at 10, 20, 30 and final at 40 — all in meters
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,John,,Doe,Dash,,Metric,,1.850000,10.000000,,3.200000,20.000000,,4.550000,30.000000,,,,,,,,,,,5.800000,40.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const athlete = result.athletes[0];
+    expect(athlete).toBeDefined();
+
+    const dash = athlete.drills.find(d => d.metric === 'DASH_40M');
+    expect(dash).toBeDefined();
+    expect(dash!.value).toBe(5.8);
+
+    // Splits should also be in DASH_*M codes
+    const splitMetrics = (dash!.splits || []).map(s => s.metric).sort();
+    expect(splitMetrics).toEqual(['DASH_10M', 'DASH_20M', 'DASH_30M']);
+  });
+
+  it('maps shorter metric dashes (10m, 20m, 30m) correctly', () => {
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,Alex,,Reed,Dash,,Metric,,,,,,,,,,,,,,,,,,,,1.850000,10.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+      '01/01/2025 10:01:00,Alex,,Reed,Dash,,Metric,,,,,,,,,,,,,,,,,,,,3.200000,20.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+      '01/01/2025 10:02:00,Alex,,Reed,Dash,,Metric,,,,,,,,,,,,,,,,,,,,4.550000,30.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const metrics = result.athletes[0].drills.map(d => d.metric).sort();
+    expect(metrics).toContain('DASH_10M');
+    expect(metrics).toContain('DASH_20M');
+    expect(metrics).toContain('DASH_30M');
+    expect(metrics).not.toContain('DASH_10YD');
+  });
+
+  it('maps Flying 10m with Units=Metric to FLY10M_TIME', () => {
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,John,,Doe,Flying,,Metric,20.000000,,,,,,,,,,,,,,,,,,,1.150000,10.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const fly = result.athletes[0].drills.find(d => d.metric === 'FLY10M_TIME');
+    expect(fly).toBeDefined();
+    expect(fly!.value).toBe(1.15);
+  });
+
+  it('derives FLY10M_TIME from a 40m Dash 20m→30m segment', () => {
+    // 40m dash with 20m=3.20, 30m=4.55 → FLY10M = 1.35
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,John,,Doe,Dash,,Metric,,1.850000,10.000000,,3.200000,20.000000,,4.550000,30.000000,,,,,,,,,,,5.800000,40.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const fly = result.athletes[0].drills.find(d => d.metric === 'FLY10M_TIME');
+    expect(fly).toBeDefined();
+    // 4.55 - 3.20 = 1.35
+    expect(fly!.value).toBeCloseTo(1.35, 3);
+    // Metric unit system must not leak into yards fly10
+    const fly10Yd = result.athletes[0].drills.find(d => d.metric === 'FLY10_TIME');
+    expect(fly10Yd).toBeUndefined();
+  });
+
+  it('keeps Imperial-unit rows on the yards-metric path', () => {
+    // Sanity check: Metric path must not accidentally catch Imperial rows
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,John,,Doe,Dash,,Imperial,,,,,,,,,,,,,,,,,,,,5.200000,40.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const metrics = result.athletes[0].drills.map(d => d.metric);
+    expect(metrics).toContain('DASH_40YD');
+    expect(metrics).not.toContain('DASH_40M');
+  });
+});

--- a/packages/api/services/parsers/dashr-csv-parser.ts
+++ b/packages/api/services/parsers/dashr-csv-parser.ts
@@ -27,7 +27,12 @@ const OUTLIER_RANGES: Record<string, { min: number; max: number; label: string }
   DASH_20YD: { min: 2.0, max: 6.0, label: '20yd dash' },
   DASH_30YD: { min: 3.0, max: 8.0, label: '30yd dash' },
   DASH_40YD: { min: 4.0, max: 10.0, label: '40yd dash' },
+  DASH_10M: { min: 1.0, max: 4.0, label: '10m dash' },
+  DASH_20M: { min: 2.0, max: 6.0, label: '20m dash' },
+  DASH_30M: { min: 3.0, max: 8.0, label: '30m dash' },
+  DASH_40M: { min: 4.0, max: 10.0, label: '40m dash' },
   FLY10_TIME: { min: 0.8, max: 3.0, label: '10yd fly' },
+  FLY10M_TIME: { min: 0.8, max: 3.0, label: '10m fly' },
   AGILITY_505: { min: 1.5, max: 5.0, label: '505 agility' },
   AGILITY_505_L: { min: 1.5, max: 5.0, label: '505 agility (L)' },
   AGILITY_505_R: { min: 1.5, max: 5.0, label: '505 agility (R)' },
@@ -36,6 +41,15 @@ const OUTLIER_RANGES: Record<string, { min: number; max: number; label: string }
   AGILITY_5105_R: { min: 3.5, max: 8.0, label: '5-10-5 agility (R)' },
   RSI: { min: 0.1, max: 4.0, label: 'RSI' },
 };
+
+/**
+ * Returns the unit suffix to use for dash/fly metric codes based on the row's Units column.
+ * DashR exports "Imperial" or "Metric" in this field.
+ */
+function getDistanceUnit(row: DashrRow): 'YD' | 'M' {
+  const units = (row['Units'] || '').trim().toLowerCase();
+  return units === 'metric' ? 'M' : 'YD';
+}
 
 interface DashrRow {
   [key: string]: string;
@@ -173,22 +187,24 @@ function mapDrillType(row: DashrRow): string | null {
   const type = (row['Type'] || '').trim();
   const finalDist = parseFloat_(row['Final Distance']);
   const direction = (row['Direction'] || '').trim().toUpperCase();
+  const unit = getDistanceUnit(row);
 
   switch (type) {
     case 'Dash': {
-      // Map based on final distance — only known metric codes
-      if (finalDist === 10) return MetricType.DASH_10YD;
-      if (finalDist === 20) return MetricType.DASH_20YD;
-      if (finalDist === 30) return MetricType.DASH_30YD;
-      if (finalDist === 40) return MetricType.DASH_40YD;
+      // Map based on final distance — only known metric codes.
+      // Unit suffix (YD vs M) is controlled by the row's Units column.
+      if (finalDist === 10) return unit === 'M' ? MetricType.DASH_10M : MetricType.DASH_10YD;
+      if (finalDist === 20) return unit === 'M' ? MetricType.DASH_20M : MetricType.DASH_20YD;
+      if (finalDist === 30) return unit === 'M' ? MetricType.DASH_30M : MetricType.DASH_30YD;
+      if (finalDist === 40) return unit === 'M' ? MetricType.DASH_40M : MetricType.DASH_40YD;
       // Unknown dash distance — return null so it's skipped with a warning,
       // rather than creating a non-standard metric code in the database.
       return null;
     }
 
     case 'Flying': {
-      // Flying sprints: map to FLY10_TIME when Final Distance = 10
-      if (finalDist === 10) return MetricType.FLY10_TIME;
+      // Flying sprints: map to FLY10_TIME / FLY10M_TIME when Final Distance = 10
+      if (finalDist === 10) return unit === 'M' ? MetricType.FLY10M_TIME : MetricType.FLY10_TIME;
       // Other flying distances aren't standard metrics
       return null;
     }
@@ -220,12 +236,13 @@ function mapDrillType(row: DashrRow): string | null {
  */
 function extractSplits(row: DashrRow): ParsedSplit[] {
   const splits: ParsedSplit[] = [];
+  const unit = getDistanceUnit(row);
 
   // Split 1: uses "Split Time 1" / "Split Distance 1"
   const split1Time = parseFloat_(row['Split Time 1']);
   const split1Dist = parseFloat_(row['Split Distance 1']);
   if (split1Time && split1Time > 0 && split1Dist && split1Dist > 0) {
-    const metric = `DASH_${split1Dist}YD`;
+    const metric = `DASH_${split1Dist}${unit}`;
     splits.push({ metric, value: split1Time, units: 's' });
   }
 
@@ -234,7 +251,7 @@ function extractSplits(row: DashrRow): ParsedSplit[] {
     const time = parseFloat_(row[`Start Time ${i}`]);
     const dist = parseFloat_(row[`Split Distance ${i}`]);
     if (time && time > 0 && dist && dist > 0) {
-      const metric = `DASH_${dist}YD`;
+      const metric = `DASH_${dist}${unit}`;
       splits.push({ metric, value: time, units: 's' });
     }
   }
@@ -273,15 +290,24 @@ function checkOutlier(metric: string, value: number): string | null {
 }
 
 /**
- * Derive FLY10_TIME from an athlete's dash drill splits.
+ * Derive FLY10_TIME / FLY10M_TIME from an athlete's dash drill splits.
  *
- * FLY10 = time at 30yd - time at 20yd (the "flying 10" segment at full speed).
- * Only derives when the athlete has no direct FLY10_TIME measurement.
- * When multiple candidates exist, picks the fastest (lowest) value.
+ * FLY10 = time at 30(yd|m) − time at 20(yd|m) — the "flying 10" segment
+ * after initial acceleration. A separate derivation runs per unit system;
+ * yards dashes produce FLY10_TIME, meters dashes produce FLY10M_TIME.
+ * When multiple candidates exist in the same unit, picks the fastest.
  */
-function deriveFly10ForAthlete(drills: ParsedDrillResult[]): ParsedDrillResult | null {
-  // Skip if athlete already has a direct FLY10_TIME
-  if (drills.some(d => d.metric === MetricType.FLY10_TIME)) return null;
+function deriveFly10ForAthlete(
+  drills: ParsedDrillResult[],
+  unit: 'YD' | 'M',
+): ParsedDrillResult | null {
+  const flyMetric = unit === 'M' ? MetricType.FLY10M_TIME : MetricType.FLY10_TIME;
+  const dash20 = unit === 'M' ? 'DASH_20M' : 'DASH_20YD';
+  const dash30 = unit === 'M' ? 'DASH_30M' : 'DASH_30YD';
+  const dash40 = unit === 'M' ? 'DASH_40M' : 'DASH_40YD';
+
+  // Skip if athlete already has a direct measurement in this unit system
+  if (drills.some(d => d.metric === flyMetric)) return null;
 
   const candidates: { value: number; source: string }[] = [];
 
@@ -292,22 +318,22 @@ function deriveFly10ForAthlete(drills: ParsedDrillResult[]): ParsedDrillResult |
     let time30: number | undefined;
     let source: string | undefined;
 
-    if (drill.metric === 'DASH_30YD') {
-      // 30yd dash: FLY10 = finalTime (30yd) - split at 20yd
-      const split20 = drill.splits.find(s => s.metric === 'DASH_20YD');
+    if (drill.metric === dash30) {
+      // 30(yd|m) dash: FLY10 = finalTime − split at 20(yd|m)
+      const split20 = drill.splits.find(s => s.metric === dash20);
       if (split20) {
         time20 = split20.value;
         time30 = drill.value;
-        source = 'DASH_30YD';
+        source = dash30;
       }
-    } else if (drill.metric === 'DASH_40YD') {
-      // 40yd dash: FLY10 = split at 30yd - split at 20yd
-      const split20 = drill.splits.find(s => s.metric === 'DASH_20YD');
-      const split30 = drill.splits.find(s => s.metric === 'DASH_30YD');
+    } else if (drill.metric === dash40) {
+      // 40(yd|m) dash: FLY10 = split at 30(yd|m) − split at 20(yd|m)
+      const split20 = drill.splits.find(s => s.metric === dash20);
+      const split30 = drill.splits.find(s => s.metric === dash30);
       if (split20 && split30) {
         time20 = split20.value;
         time30 = split30.value;
-        source = 'DASH_40YD';
+        source = dash40;
       }
     }
 
@@ -323,10 +349,10 @@ function deriveFly10ForAthlete(drills: ParsedDrillResult[]): ParsedDrillResult |
 
   // Pick fastest (lowest) FLY10
   const best = candidates.reduce((a, b) => (a.value <= b.value ? a : b));
-  const outlierReason = checkOutlier(MetricType.FLY10_TIME, best.value);
+  const outlierReason = checkOutlier(flyMetric, best.value);
 
   return {
-    metric: MetricType.FLY10_TIME,
+    metric: flyMetric,
     value: best.value,
     units: 's',
     derivedFrom: `${best.source} splits`,
@@ -495,12 +521,14 @@ export class DashrCsvParser implements DeviceImportParser {
       athleteMap.get(key)!.drills.push(drill);
     }
 
-    // Derive FLY10_TIME from dash splits when no direct measurement exists
+    // Derive FLY10_TIME / FLY10M_TIME from dash splits when no direct
+    // measurement exists. Each unit system is evaluated independently:
+    // an athlete with both yards dashes and a metric dash gets both derived.
     for (const [, athlete] of athleteMap) {
-      const fly10 = deriveFly10ForAthlete(athlete.drills);
-      if (fly10) {
-        athlete.drills.push(fly10);
-      }
+      const fly10Yd = deriveFly10ForAthlete(athlete.drills, 'YD');
+      if (fly10Yd) athlete.drills.push(fly10Yd);
+      const fly10M = deriveFly10ForAthlete(athlete.drills, 'M');
+      if (fly10M) athlete.drills.push(fly10M);
     }
 
     const athletes = Array.from(athleteMap.values());

--- a/packages/api/services/parsers/dashr-csv-parser.ts
+++ b/packages/api/services/parsers/dashr-csv-parser.ts
@@ -238,6 +238,14 @@ function extractSplits(row: DashrRow): ParsedSplit[] {
   const splits: ParsedSplit[] = [];
   const unit = getDistanceUnit(row);
 
+  // NOTE: metric codes are built by template literal below (`DASH_${dist}${unit}`).
+  // Non-standard distances (e.g. a 15m split from an unusual DashR export) will
+  // silently produce metric codes that don't exist in site_metrics — they pass
+  // through to the measurements table (which has no FK on `metric`) but are
+  // orphaned from org-level enablement. This is pre-existing behaviour for the
+  // yards path and is retained for meters; if future exports ship unusual
+  // distances, validate against a known-code allowlist here.
+
   // Split 1: uses "Split Time 1" / "Split Distance 1"
   const split1Time = parseFloat_(row['Split Time 1']);
   const split1Dist = parseFloat_(row['Split Distance 1']);

--- a/packages/api/services/sprint-fv-service.ts
+++ b/packages/api/services/sprint-fv-service.ts
@@ -143,8 +143,15 @@ export function resolveSplitsFromMeasurements(
   const metersCount = Object.keys(metersSplits).length;
 
   if (yardsCount >= MIN_SPLITS_REQUIRED && metersCount >= MIN_SPLITS_REQUIRED) {
+    const yardsList = Object.entries(yardsIds)
+      .map(([d, id]) => `DASH_${d}YD (${id})`)
+      .join(', ');
+    const metersList = Object.entries(metersIds)
+      .map(([d, id]) => `DASH_${d}M (${id})`)
+      .join(', ');
     throw new SprintFvValidationError(
-      'Mixed yards and meters splits found for this athlete on this date. Sprint F-V profiles must use a single distance unit — please remove the stray measurements and try again.',
+      'Mixed yards and meters splits found for this athlete on this date. Sprint F-V profiles must use a single distance unit — please remove the stray measurements and try again. ' +
+        `Yards splits used: ${yardsList}. Meters splits used: ${metersList}.`,
     );
   }
 

--- a/packages/api/services/sprint-fv-service.ts
+++ b/packages/api/services/sprint-fv-service.ts
@@ -19,15 +19,32 @@ import { computeFvProfile } from './sprint-fv-computation';
 import { classifyProfile, computeOptimalGap, computeDeltas, analyzeAcceleration, analyzePower, validateParameters } from './sprint-fv-analysis';
 import type { SprintFvAnalysisJson } from '@shared/schema/tables/sprint-fv-profiles';
 
-// Hardcoded split metric codes — maps metric code to distance in the code's unit
-const SPLIT_METRICS: Record<string, number> = {
-  'DASH_5YD': 5,
-  'DASH_10YD': 10,
-  'DASH_20YD': 20,
-  'DASH_30YD': 30,
-};
+/**
+ * Split-metric code maps — indexed by distance unit.
+ *
+ * The Sprint F-V protocol uses 10/20/30/40 splits in either yards or meters.
+ * 5-yard splits are intentionally excluded: they sit in the region where
+ * start-protocol timing lag dominates, and their information is already
+ * implicit in the model's v(0)=0 assumption plus the 10y split.
+ */
+export const SPLIT_METRICS_YARDS = {
+  DASH_10YD: 10,
+  DASH_20YD: 20,
+  DASH_30YD: 30,
+  DASH_40YD: 40,
+} as const;
 
-const SPLIT_METRIC_CODES = Object.keys(SPLIT_METRICS);
+export const SPLIT_METRICS_METERS = {
+  DASH_10M: 10,
+  DASH_20M: 20,
+  DASH_30M: 30,
+  DASH_40M: 40,
+} as const;
+
+const SPLIT_METRIC_CODES: string[] = [
+  ...Object.keys(SPLIT_METRICS_YARDS),
+  ...Object.keys(SPLIT_METRICS_METERS),
+];
 const YARDS_TO_METERS = 0.9144;
 const MIN_SPLITS_REQUIRED = 3;
 
@@ -61,6 +78,87 @@ export class SprintFvValidationError extends Error {
     super(message);
     this.name = 'SprintFvValidationError';
   }
+}
+
+/**
+ * Minimal shape of a measurement row consumed by the split resolver.
+ * Keeping this narrower than the full drizzle row lets the algorithm be
+ * unit-tested without standing up a database.
+ */
+export interface SplitMeasurementInput {
+  id: string;
+  metric: string;
+  value: string;
+}
+
+export interface ResolvedSplits {
+  distanceUnit: 'yards' | 'meters';
+  splitTimes: Record<string, number>;
+  usedMeasurementIds: Record<string, string>;
+}
+
+/**
+ * Collapse a list of split measurements into a single session, picking the
+ * fastest time per distance and resolving the distance unit.
+ *
+ * Resolution rules:
+ *   - If ≥3 yards splits → yards
+ *   - Else if ≥3 meters splits → meters
+ *   - If BOTH have ≥3 → mixed-unit error (cannot silently pick one)
+ *   - Else → insufficient-splits error
+ */
+export function resolveSplitsFromMeasurements(
+  rows: readonly SplitMeasurementInput[],
+): ResolvedSplits {
+  const yardsSplits: Record<string, number> = {};
+  const yardsIds: Record<string, string> = {};
+  const metersSplits: Record<string, number> = {};
+  const metersIds: Record<string, string> = {};
+
+  for (const m of rows) {
+    const time = parseFloat(m.value);
+    if (!isFinite(time) || time <= 0) continue;
+
+    const yardsDistance = (SPLIT_METRICS_YARDS as Record<string, number>)[m.metric];
+    if (yardsDistance !== undefined) {
+      const key = String(yardsDistance);
+      if (!(key in yardsSplits) || time < yardsSplits[key]) {
+        yardsSplits[key] = time;
+        yardsIds[key] = m.id;
+      }
+      continue;
+    }
+
+    const metersDistance = (SPLIT_METRICS_METERS as Record<string, number>)[m.metric];
+    if (metersDistance !== undefined) {
+      const key = String(metersDistance);
+      if (!(key in metersSplits) || time < metersSplits[key]) {
+        metersSplits[key] = time;
+        metersIds[key] = m.id;
+      }
+    }
+  }
+
+  const yardsCount = Object.keys(yardsSplits).length;
+  const metersCount = Object.keys(metersSplits).length;
+
+  if (yardsCount >= MIN_SPLITS_REQUIRED && metersCount >= MIN_SPLITS_REQUIRED) {
+    throw new SprintFvValidationError(
+      'Mixed yards and meters splits found for this athlete on this date. Sprint F-V profiles must use a single distance unit — please remove the stray measurements and try again.',
+    );
+  }
+
+  if (yardsCount >= MIN_SPLITS_REQUIRED) {
+    return { distanceUnit: 'yards', splitTimes: yardsSplits, usedMeasurementIds: yardsIds };
+  }
+  if (metersCount >= MIN_SPLITS_REQUIRED) {
+    return { distanceUnit: 'meters', splitTimes: metersSplits, usedMeasurementIds: metersIds };
+  }
+
+  const best = Math.max(yardsCount, metersCount);
+  throw new SprintFvValidationError(
+    `Insufficient unique splits: found ${best} distinct distances, need at least ${MIN_SPLITS_REQUIRED}`,
+  );
 }
 
 export interface EligibleSession {
@@ -217,32 +315,11 @@ export class SprintFvService {
       }
     }
 
-    // 2. Build split times map — pick fastest time per distance (handles duplicate trials)
-    const splitTimes: Record<string, number> = {};
-    const usedMeasurementIds: Record<string, string> = {};
-    for (const m of splitMeasurements) {
-      const distance = SPLIT_METRICS[m.metric];
-      if (distance !== undefined) {
-        const time = parseFloat(m.value);
-        if (!isFinite(time) || time <= 0) continue;
-        const key = String(distance);
-        if (!(key in splitTimes) || time < splitTimes[key]) {
-          splitTimes[key] = time;
-          usedMeasurementIds[key] = m.id;
-        }
-      }
-    }
-
-    // 2b. Validate deduplicated split count (duplicates for same distance are collapsed above)
-    const uniqueSplitCount = Object.keys(splitTimes).length;
-    if (uniqueSplitCount < MIN_SPLITS_REQUIRED) {
-      throw new SprintFvValidationError(
-        `Insufficient unique splits: found ${uniqueSplitCount} distinct distances, need at least ${MIN_SPLITS_REQUIRED}`
-      );
-    }
-
-    // 3. Determine distance unit (all split metrics are in yards based on code names)
-    const distanceUnit = 'yards' as const;
+    // 2. Resolve splits — pick fastest per distance, determine yards vs meters unit,
+    // and reject mixed-unit sessions.
+    const { distanceUnit, splitTimes, usedMeasurementIds } = resolveSplitsFromMeasurements(
+      splitMeasurements.map(m => ({ id: m.id, metric: m.metric, value: m.value })),
+    );
 
     // 4. Get body mass
     let bodyMassKg: number;
@@ -309,9 +386,13 @@ export class SprintFvService {
       date = firstM.date;
     }
 
-    // 7. Compute sprint distance in meters for analysis
+    // 7. Compute sprint distance in meters for analysis.
+    // splitTimes keys are raw distances in the session's native unit, so meters
+    // sessions already have meter-valued keys and must not be re-converted.
     const maxDistance = Math.max(...Object.keys(splitTimes).map(Number));
-    const sprintDistanceM = maxDistance * YARDS_TO_METERS;
+    const sprintDistanceM = distanceUnit === 'meters'
+      ? maxDistance
+      : maxDistance * YARDS_TO_METERS;
 
     // 8. Run analysis engine
     const classification = classifyProfile(computed.f0Rel, computed.v0, sprintDistanceM);

--- a/packages/shared/schema/constants.ts
+++ b/packages/shared/schema/constants.ts
@@ -10,6 +10,7 @@ export const MAX_INSIGHTS_LENGTH = 10000;
 // Metric type constants (legacy compatibility)
 export const MetricType = {
   FLY10_TIME: 'FLY10_TIME',
+  FLY10M_TIME: 'FLY10M_TIME',
   VERTICAL_JUMP: 'VERTICAL_JUMP',
   AGILITY_505: 'AGILITY_505',
   AGILITY_505_L: 'AGILITY_505_L',
@@ -23,6 +24,10 @@ export const MetricType = {
   DASH_20YD: 'DASH_20YD',
   DASH_30YD: 'DASH_30YD',
   DASH_40YD: 'DASH_40YD',
+  DASH_10M: 'DASH_10M',
+  DASH_20M: 'DASH_20M',
+  DASH_30M: 'DASH_30M',
+  DASH_40M: 'DASH_40M',
   TOP_SPEED: 'TOP_SPEED',
   RSI: 'RSI',
 } as const;
@@ -33,6 +38,7 @@ export const MetricType = {
 // Defines metric types: lower_is_better, higher_is_better, tracking
 export const VALID_METRICS = [
   { key: 'FLY10_TIME', metricType: 'lower_is_better' },
+  { key: 'FLY10M_TIME', metricType: 'lower_is_better' },
   { key: 'VERTICAL_JUMP', metricType: 'higher_is_better' },
   { key: 'AGILITY_505', metricType: 'lower_is_better' },
   { key: 'AGILITY_505_L', metricType: 'lower_is_better' },
@@ -46,6 +52,10 @@ export const VALID_METRICS = [
   { key: 'DASH_20YD', metricType: 'lower_is_better' },
   { key: 'DASH_30YD', metricType: 'lower_is_better' },
   { key: 'DASH_40YD', metricType: 'lower_is_better' },
+  { key: 'DASH_10M', metricType: 'lower_is_better' },
+  { key: 'DASH_20M', metricType: 'lower_is_better' },
+  { key: 'DASH_30M', metricType: 'lower_is_better' },
+  { key: 'DASH_40M', metricType: 'lower_is_better' },
   { key: 'RSI', metricType: 'higher_is_better' },
   { key: 'TOP_SPEED', metricType: 'higher_is_better' },
   { key: 'HEIGHT', metricType: 'tracking' },

--- a/packages/shared/schema/tables/sprint-fv-profiles.ts
+++ b/packages/shared/schema/tables/sprint-fv-profiles.ts
@@ -2,15 +2,18 @@
  * Sprint Force-Velocity Profile Tables
  *
  * Stores computed JB Morin sprint F-V profiles derived from existing
- * split time measurements (DASH_5YD, DASH_10YD, DASH_20YD, DASH_30YD).
+ * split time measurements across the 10/20/30/40 distance protocol
+ * (DASH_10YD..DASH_40YD or DASH_10M..DASH_40M — yards and meters
+ * are tracked as parallel metric types).
  */
 
 import { sql } from "drizzle-orm";
 import { pgTable, text, varchar, decimal, timestamp, date, jsonb, index } from "drizzle-orm/pg-core";
 
 /**
- * Split times stored as JSON: distance (string) → time in seconds
- * e.g., { "5": 1.12, "10": 1.83, "20": 3.21, "30": 4.52 }
+ * Split times stored as JSON: distance (string, in the profile's distanceUnit) → time in seconds
+ * e.g., { "10": 1.70, "20": 2.95, "30": 4.18, "40": 5.30 }
+ * The distance key is unit-implicit; distanceUnit on the profile row disambiguates.
  */
 export type SplitTimesJson = Record<string, number>;
 

--- a/packages/web/src/components/sprint-fv/SprintFvSessionSelector.tsx
+++ b/packages/web/src/components/sprint-fv/SprintFvSessionSelector.tsx
@@ -60,8 +60,8 @@ export function SprintFvSessionSelector({ userId }: Props) {
       <Card className="border-dashed">
         <CardContent className="py-12 text-center">
           <p className="text-muted-foreground">
-            No sprint sessions found. Record split times (DASH_5YD through DASH_30YD)
-            to generate F-V profiles.
+            No sprint sessions found. Record split times at 10/20/30/40 yards or
+            meters on the same date to generate F-V profiles.
           </p>
         </CardContent>
       </Card>

--- a/tests/integration/sprint-fv-routes.test.ts
+++ b/tests/integration/sprint-fv-routes.test.ts
@@ -149,12 +149,12 @@ describe('Sprint F-V Profile Integration Tests', () => {
       role: 'coach',
     });
 
-    // Insert split time measurements for the athlete
+    // Insert split time measurements for the athlete (10/20/30/40 protocol).
     const splitMetrics = [
-      { metric: 'DASH_5YD', value: '1.10' },
       { metric: 'DASH_10YD', value: '1.82' },
       { metric: 'DASH_20YD', value: '3.15' },
       { metric: 'DASH_30YD', value: '4.45' },
+      { metric: 'DASH_40YD', value: '5.75' },
     ];
 
     for (const m of splitMetrics) {
@@ -210,10 +210,10 @@ describe('Sprint F-V Profile Integration Tests', () => {
 
       const session = res.body.sessions[0];
       expect(session.date).toBe(TEST_DATE);
-      expect(session.availableSplits).toContain('DASH_5YD');
       expect(session.availableSplits).toContain('DASH_10YD');
       expect(session.availableSplits).toContain('DASH_20YD');
       expect(session.availableSplits).toContain('DASH_30YD');
+      expect(session.availableSplits).toContain('DASH_40YD');
       expect(session.hasWeight).toBe(true);
       expect(session.profileExists).toBe(false);
     });


### PR DESCRIPTION
## Summary

Switches the Sprint Force-Velocity protocol from 5/10/20/30 yards to the Morin-standard **10/20/30/40** protocol, and adds parallel **meters** support alongside yards. Also fills a pre-existing audit-constraint gap from PR #355.

### Why

Analysis of a production profile surfaced two structural problems with the 5/10/20/30-yard protocol:

1. **30 yards is too short to reliably estimate V0.** The Morin mono-exponential fit's τ parameter hit its physiological floor (0.7s), inflating F0rel by ~27% and producing a "velocity-deficit at 138% imbalance" classification that was a boundary artifact rather than a biomechanical finding.
2. **The 5-yard split is the noisiest data point** — it sits in the region where start-protocol timing lag dominates, and it gives information already encoded implicitly by the `v(0)=0` model assumption plus the 10y split.

Swapping to **10/20/30/40** adds a 40y gate where velocity has asymptoted to V0, drops the noisy 5y split, and matches the standard combine protocol.

## Changes

### Protocol migration
- `packages/shared/schema/constants.ts` — add `DASH_10M`/`DASH_20M`/`DASH_30M`/`DASH_40M` and `FLY10M_TIME` to `MetricType` + `VALID_METRICS` (`lower_is_better`). Legacy `DASH_5YD` preserved for existing measurement rows.
- `packages/api/services/sprint-fv-service.ts` — replace hardcoded `SPLIT_METRICS` with `SPLIT_METRICS_YARDS` / `SPLIT_METRICS_METERS`. New `resolveSplitsFromMeasurements()` pure function picks the unit (≥3 splits in one unit), errors on mixed yards+meters, errors on insufficient splits.
- `packages/api/services/parsers/dashr-csv-parser.ts` — unit-aware `mapDrillType()` reads the DashR `Units` column; Imperial → `DASH_*YD` + `FLY10_TIME`, Metric → `DASH_*M` + `FLY10M_TIME`. Fly-10 derivation now runs per-unit (`deriveFly10ForAthlete` called once for yards, once for meters). `OUTLIER_RANGES` extended with metric entries.
- `packages/web/src/components/sprint-fv/SprintFvSessionSelector.tsx` — updated empty-state prompt.
- `packages/shared/schema/tables/sprint-fv-profiles.ts` — documentation comments updated.

### Bug fix caught in code review
- `packages/api/services/sprint-fv-service.ts` — `sprintDistanceM` was double-applying `YARDS_TO_METERS` (0.9144) for meters sessions, producing `sprintDistanceM = 36.6m` for a 40m session. Now conditional on `distanceUnit === 'meters'`, which corrects `classifyProfile` / `computeOptimalGap` / `analyzeAcceleration` / `analyzePower` for meters profiles.

### Fills audit gap from PR #355
- `migrations/0122_add_sprint_fv_module_toggled_audit_action.sql` (+ `_down.sql`) — adds `site_sprint_fv_module_toggled` to the `audit_logs_action_valid` CHECK constraint. PR #355 registered this action in `site-settings-routes.ts` but never migrated the constraint, so toggling the flag raised a `23514` CHECK violation.

### Tests
- `packages/api/services/__tests__/sprint-fv-service.test.ts` (new, 14 tests) — pure tests for `resolveSplitsFromMeasurements`: yards/meters/mixed/insufficient/duplicate-fastest cases.
- `packages/api/services/__tests__/sprint-fv-computation.test.ts` — fixtures updated to 10/20/30/40.

## Test plan

- [x] Targeted suites: 195/195 passing (sprint-fv service, dashr parser, site-settings-routes, measurement-service)
- [x] Full unit + integration suite: 6857/0 passing
- [x] `npm run check` clean
- [x] Code review (critical `sprintDistanceM` meters bug caught and fixed before merge)
- [ ] Manual staging smoke test: import a `Units: Metric` DashR CSV at 40m, verify `DASH_40M` + auto-derived `FLY10M_TIME`
- [ ] Manual staging smoke test: generate a profile from 10/20/30/40-yard measurements, verify `distanceUnit: 'yards'` and `sprintDistanceM ≈ 36.58`
- [ ] Pre-deploy: site admin to delete legacy `sprint_fv_profiles` rows (protocol change makes legacy rows' optimal-slope classifications incorrect)

## Out of scope

- V0-anchored fit using measured fly-10 as a constraint (valuable follow-up; layer on top of this protocol change)
- Residual-pattern-gated classification suppression
- Manual-entry fly-10 auto-derivation (explicitly declined — only DashR imports derive fly-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)