### PR TITLE
release: v0.20.0 — LLM export + Sprint F-V 10/20/30/40 + meters support

### DIFF
--- a/.github/workflows/e2e-test-reminder.yml
+++ b/.github/workflows/e2e-test-reminder.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Post reminder comment
         if: steps.check-e2e.outputs.needs_reminder == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             try {

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -321,7 +321,7 @@ jobs:
           ADMIN_PASSWORD: TestPassword123!
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts
           path: dist/

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Find preview comment
         id: find-comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Find existing preview comment
         id: find-comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
@@ -403,7 +403,7 @@ jobs:
 
       - name: Find preview comment
         id: find-comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Check for migration files in PR diff
         id: migration-check
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -332,7 +332,7 @@ jobs:
 
       - name: Post deployment comment
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const status = '${{ job.status }}';

--- a/.github/workflows/security-audit-scheduled.yml
+++ b/.github/workflows/security-audit-scheduled.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure() && steps.security-audit.outcome == 'failure'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/migrations/0122_add_sprint_fv_module_toggled_audit_action.sql
+++ b/migrations/0122_add_sprint_fv_module_toggled_audit_action.sql
@@ -1,0 +1,174 @@
+-- Migration 0122: Add site_sprint_fv_module_toggled audit action
+--
+-- The sprint F-V feature flag was introduced in PR #355 (packages/api/routes/site-settings-routes.ts),
+-- but the audit action 'site_sprint_fv_module_toggled' was never added to audit_logs_action_valid.
+-- This caused toggling the flag to fail with check-constraint violation 23514.
+--
+-- IDEMPOTENT: safe to run multiple times.
+
+DO $$
+BEGIN
+  ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS audit_logs_action_valid;
+
+  ALTER TABLE audit_logs ADD CONSTRAINT audit_logs_action_valid CHECK (action IN (
+    -- Organization actions
+    'organization_created',
+    'organization_updated',
+    'organization_deactivated',
+    'organization_reactivated',
+    'organization_deleted',
+    'organization_dependencies_viewed',
+    'organization_type_accessed',
+    'site_admin_access',
+    'site_admin_organization_access',
+
+    -- User actions
+    'user_created',
+    'user_updated',
+    'user_deleted',
+    'user_role_changed',
+    'user_role_updated',
+    'user_registered',
+    'role_changed',
+    'password_reset_unknown_email',
+    'email_verification_requested',
+    'password_change_failed',
+    'privilege_restoration_blocked',
+    'admin_password_synced',
+    'privilege_restored',
+    'oauth_login',
+
+    -- Legal acceptance action
+    'legal_accepted',
+
+    -- Team actions
+    'team_created',
+    'team_updated',
+    'team_deleted',
+    'team_archived',
+
+    -- Measurement actions
+    'measurement_created',
+    'measurement_updated',
+    'measurement_deleted',
+    'measurements_bulk_verify',
+    'measurements_bulk_unverify',
+
+    -- Invitation actions
+    'invitation_created',
+    'invitation_accepted',
+    'invitation_cancelled',
+    'invitation_resent',
+
+    -- Session actions
+    'sessions_revoked',
+    'zombie_sessions_cleaned',
+    'zombie_cleanup_failed',
+    'session_revocation_failed',
+
+    -- Metric actions
+    'metric_created',
+    'metric_updated',
+    'metric_enabled',
+    'metric_disabled',
+    'metric_deleted',
+    'org_metric_enabled',
+    'org_metric_disabled',
+    'org_metric_updated',
+    'org_metrics_bulk_enabled',
+
+    -- Benchmark actions
+    'benchmark_created',
+    'benchmark_updated',
+    'benchmark_deleted',
+    'benchmark_enabled',
+    'benchmark_disabled',
+    'custom_benchmark_created',
+    'custom_benchmark_updated',
+    'custom_benchmark_deleted',
+    'org_benchmark_enabled',
+    'org_benchmark_disabled',
+    'org_benchmark_updated',
+
+    -- AI feature actions
+    'org_ai_enabled_by_site_admin',
+    'org_ai_disabled_by_site_admin',
+    'org_ai_enabled_by_org_admin',
+    'org_ai_disabled_by_org_admin',
+    'site_ai_model_changed',
+    'report_ai_insights_generated',
+    'report_ai_insights_updated',
+    'report_ai_insights_generation_failed',
+
+    -- Organization type actions
+    'organization_type_metrics_queried',
+    'organization_type_benchmarks_queried',
+
+    -- Cache actions
+    'cache_invalidated',
+    'cache_invalidation_failed',
+
+    -- Site settings actions
+    'site_wellness_module_toggled',
+    'site_sprint_fv_module_toggled', -- NEW: sprint F-V module toggle (fills gap from PR #355)
+
+    -- Organization wellness actions
+    'org_wellness_enabled',
+    'org_wellness_disabled',
+
+    -- Organization events actions
+    'org_events_enabled',
+    'org_events_disabled',
+
+    -- Membership request actions
+    'membership_request_created',
+    'membership_request_approved',
+    'membership_request_rejected',
+    'membership_request_cancelled',
+    'organization_join_code_regenerated',
+    'organization_join_code_set',
+    'organization_membership_settings_updated',
+
+    -- Event actions
+    'event_created',
+    'event_updated',
+    'event_deleted',
+    'event_frozen',
+    'event_unfrozen',
+    'event_freeze_overridden',
+    'event_results_published',
+    'event_registration_created',
+    'event_registration_approved',
+    'event_registration_declined',
+    'event_registration_cancelled',
+    'event_registration_checked_in',
+    'event_registration_promoted',
+    'event_invitation_created',
+    'event_invitation_accepted',
+    'event_invitation_declined',
+    'event_invitation_cancelled',
+
+    -- Event metric actions
+    'event_metric_added',
+    'event_metric_removed',
+    'event_metric_updated',
+    'event_metrics_reordered',
+    'event_metrics_bulk_added',
+
+    -- Event results actions
+    'event_results_unpublished',
+    'event_results_visibility_changed',
+
+    -- Training module actions
+    'site_training_module_toggled',
+    'org_training_enabled',
+
+    -- Parent/COPPA actions
+    'parent_unlinked_child'
+  ));
+
+  RAISE NOTICE 'Migration 0122: Added site_sprint_fv_module_toggled to audit_logs_action_valid';
+END $$;
+
+COMMENT ON CONSTRAINT audit_logs_action_valid ON audit_logs IS
+  'Valid audit log actions — added site_sprint_fv_module_toggled in migration 0122 to match sprint F-V feature flag route (PR #355)';

--- a/migrations/0122_add_sprint_fv_module_toggled_audit_action_down.sql
+++ b/migrations/0122_add_sprint_fv_module_toggled_audit_action_down.sql
@@ -1,0 +1,52 @@
+-- Down Migration 0122: Remove site_sprint_fv_module_toggled from audit_logs_action_valid
+-- Restores the audit_logs_action_valid constraint to its pre-0122 state.
+-- Note: migration 0122 only touched the action constraint, so this down migration
+-- intentionally does not touch audit_logs_resource_type_valid.
+
+DO $$
+BEGIN
+  ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS audit_logs_action_valid;
+
+  ALTER TABLE audit_logs ADD CONSTRAINT audit_logs_action_valid CHECK (action IN (
+    'organization_created', 'organization_updated', 'organization_deactivated', 'organization_reactivated',
+    'organization_deleted', 'organization_dependencies_viewed', 'organization_type_accessed',
+    'site_admin_access', 'site_admin_organization_access',
+    'user_created', 'user_updated', 'user_deleted', 'user_role_changed', 'user_role_updated',
+    'user_registered', 'role_changed', 'password_reset_unknown_email', 'email_verification_requested',
+    'password_change_failed', 'privilege_restoration_blocked', 'admin_password_synced', 'privilege_restored',
+    'oauth_login', 'legal_accepted',
+    'team_created', 'team_updated', 'team_deleted', 'team_archived',
+    'measurement_created', 'measurement_updated', 'measurement_deleted',
+    'measurements_bulk_verify', 'measurements_bulk_unverify',
+    'invitation_created', 'invitation_accepted', 'invitation_cancelled', 'invitation_resent',
+    'sessions_revoked', 'zombie_sessions_cleaned', 'zombie_cleanup_failed', 'session_revocation_failed',
+    'metric_created', 'metric_updated', 'metric_enabled', 'metric_disabled', 'metric_deleted',
+    'org_metric_enabled', 'org_metric_disabled', 'org_metric_updated', 'org_metrics_bulk_enabled',
+    'benchmark_created', 'benchmark_updated', 'benchmark_deleted', 'benchmark_enabled', 'benchmark_disabled',
+    'custom_benchmark_created', 'custom_benchmark_updated', 'custom_benchmark_deleted',
+    'org_benchmark_enabled', 'org_benchmark_disabled', 'org_benchmark_updated',
+    'org_ai_enabled_by_site_admin', 'org_ai_disabled_by_site_admin',
+    'org_ai_enabled_by_org_admin', 'org_ai_disabled_by_org_admin',
+    'site_ai_model_changed', 'report_ai_insights_generated', 'report_ai_insights_updated',
+    'report_ai_insights_generation_failed',
+    'organization_type_metrics_queried', 'organization_type_benchmarks_queried',
+    'cache_invalidated', 'cache_invalidation_failed',
+    'site_wellness_module_toggled',
+    'org_wellness_enabled', 'org_wellness_disabled',
+    'org_events_enabled', 'org_events_disabled',
+    'membership_request_created', 'membership_request_approved', 'membership_request_rejected',
+    'membership_request_cancelled', 'organization_join_code_regenerated', 'organization_join_code_set',
+    'organization_membership_settings_updated',
+    'event_created', 'event_updated', 'event_deleted', 'event_frozen', 'event_unfrozen',
+    'event_freeze_overridden', 'event_results_published',
+    'event_registration_created', 'event_registration_approved', 'event_registration_declined',
+    'event_registration_cancelled', 'event_registration_checked_in', 'event_registration_promoted',
+    'event_invitation_created', 'event_invitation_accepted', 'event_invitation_declined',
+    'event_invitation_cancelled',
+    'event_metric_added', 'event_metric_removed', 'event_metric_updated',
+    'event_metrics_reordered', 'event_metrics_bulk_added',
+    'event_results_unpublished', 'event_results_visibility_changed',
+    'site_training_module_toggled', 'org_training_enabled',
+    'parent_unlinked_child'
+  ));
+END $$;

--- a/migrations/0123_seed_sprint_fv_meters_metrics.sql
+++ b/migrations/0123_seed_sprint_fv_meters_metrics.sql
@@ -1,0 +1,36 @@
+-- Migration 0123: Seed DASH_*M and FLY10M_TIME rows in site_metrics
+--
+-- The Sprint F-V protocol switched to 10/20/30/40 in both yards and meters.
+-- The yards codes (DASH_10YD..DASH_40YD, FLY10_TIME) were already seeded by
+-- migrations 0022 and 0107, but the meter-unit counterparts never had rows.
+--
+-- Without these rows the `organization_metrics` FK to `site_metrics(code)`
+-- blocks any org from enabling/disabling the meter splits, so leaderboards
+-- and analytics surfaces would silently omit metric-unit DashR imports.
+--
+-- This migration mirrors the 0107 pattern: INSERT ... ON CONFLICT DO NOTHING
+-- so it is safe to run multiple times.
+
+INSERT INTO site_metrics (code, label, category, unit, metric_type, is_system_default, is_active, display_order, description, decimal_precision, color, icon)
+VALUES
+  ('DASH_10M', '10-Meter Dash Split', 'speed', 's', 'lower_is_better', true, true, 28,
+   '10-meter split time from timing gates (acceleration phase, metric-unit DashR imports).',
+   3, 'indigo', 'Timer'),
+  ('DASH_20M', '20-Meter Dash Split', 'speed', 's', 'lower_is_better', true, true, 29,
+   '20-meter split time from timing gates (metric-unit DashR imports).',
+   3, 'indigo', 'Timer'),
+  ('DASH_30M', '30-Meter Dash Split', 'speed', 's', 'lower_is_better', true, true, 30,
+   '30-meter split time from timing gates (metric-unit DashR imports).',
+   3, 'indigo', 'Timer'),
+  ('DASH_40M', '40-Meter Dash Split', 'speed', 's', 'lower_is_better', true, true, 31,
+   '40-meter split time from timing gates — reaches V0 asymptote for F-V profile fitting.',
+   3, 'indigo', 'Timer'),
+  ('FLY10M_TIME', '10-Meter Fly Time', 'speed', 's', 'lower_is_better', true, true, 32,
+   'Time to cover 10 meters after a flying start, measuring maximum velocity (metric-unit equivalent of FLY10_TIME).',
+   3, 'blue', 'Clock')
+ON CONFLICT (code) DO NOTHING;
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 0123: Seeded 5 metric-unit site_metrics rows for Sprint F-V protocol';
+END $$;

--- a/migrations/0123_seed_sprint_fv_meters_metrics_down.sql
+++ b/migrations/0123_seed_sprint_fv_meters_metrics_down.sql
@@ -1,0 +1,14 @@
+-- Down Migration 0123: Remove meter-unit Sprint F-V site_metrics rows
+--
+-- WARNING: This will also remove any organization_metrics rows referencing
+-- these codes (ON DELETE CASCADE). Run only when rolling back the protocol
+-- change; any measurements keyed by these codes will be orphaned from
+-- organization-level metric enablement until re-seeded.
+
+DELETE FROM site_metrics
+ WHERE code IN ('DASH_10M', 'DASH_20M', 'DASH_30M', 'DASH_40M', 'FLY10M_TIME');
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 0123 (down): Removed 5 metric-unit site_metrics rows';
+END $$;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@anthropic-ai/claude-code": "^2.1.92",
-        "@anthropic-ai/sdk": "^0.69.0",
+        "@anthropic-ai/sdk": "^0.90.0",
         "@google/generative-ai": "^0.24.1",
         "@react-pdf/renderer": "^4.3.1",
         "@types/canvas-confetti": "^1.9.0",
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.69.0.tgz",
-      "integrity": "sha512-L92d2q47BSq+7slUqHBL1d2DwloulZotYGCTDt9AYRtPmYF+iK6rnwq9JaZwPPJgk+LenbcbQ/nj6gfaDFsl9w==",
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "happy-dom": "^20.0.0",
         "jest": "^29.7.0",
         "postcss": "^8.4.47",
-        "supertest": "^6.3.4",
+        "supertest": "^7.2.2",
         "tailwindcss": "^3.4.17",
         "terser": "^5.44.0",
         "tsx": "^4.19.1",
@@ -2033,7 +2033,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2050,7 +2049,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2067,7 +2065,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2084,7 +2081,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2101,7 +2097,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2118,7 +2113,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2135,7 +2129,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2152,7 +2145,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2169,7 +2161,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2186,7 +2177,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,7 +2193,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,7 +2209,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2237,7 +2225,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2254,7 +2241,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2271,7 +2257,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2288,7 +2273,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2305,7 +2289,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,7 +2305,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,7 +2321,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,7 +2337,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2373,7 +2353,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2390,7 +2369,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2407,7 +2385,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2424,7 +2401,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2441,7 +2417,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2458,7 +2433,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10699,9 +10673,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10716,16 +10690,18 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
-      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -18670,54 +18646,49 @@
       }
     },
     "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
-      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "component-emitter": "^1.3.0",
+        "component-emitter": "^1.3.1",
         "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
+        "debug": "^4.3.7",
         "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
+        "qs": "^6.14.1"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
-      }
-    },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supertest": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
-      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
-      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "cookie-signature": "^1.2.2",
         "methods": "^1.1.2",
-        "superagent": "^8.1.2"
+        "superagent": "^10.3.0"
       },
       "engines": {
-        "node": ">=6.4.0"
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17015,9 +17015,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.66.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.0.tgz",
-      "integrity": "sha512-xXBqsWGKrY46ZqaHDo+ZUYiMUgi8suYu5kdrS20EG8KiL7VRQitEbNjm+UcrDYrNi1YLyfpmAeGjCZYXLT9YBw==",
+      "version": "7.72.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
+      "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -21119,7 +21119,7 @@
         "react-chartjs-2": "^5.3.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
-        "react-hook-form": "^7.55.0",
+        "react-hook-form": "^7.72.1",
         "react-icons": "^5.4.0",
         "react-joyride": "^2.9.3",
         "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "happy-dom": "^20.0.0",
     "jest": "^29.7.0",
     "postcss": "^8.4.47",
-    "supertest": "^6.3.4",
+    "supertest": "^7.2.2",
     "tailwindcss": "^3.4.17",
     "terser": "^5.44.0",
     "tsx": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-code": "^2.1.92",
-    "@anthropic-ai/sdk": "^0.69.0",
+    "@anthropic-ai/sdk": "^0.90.0",
     "@google/generative-ai": "^0.24.1",
     "@react-pdf/renderer": "^4.3.1",
     "@types/canvas-confetti": "^1.9.0",

--- a/packages/api/routes/__tests__/site-settings-routes.test.ts
+++ b/packages/api/routes/__tests__/site-settings-routes.test.ts
@@ -393,6 +393,60 @@ describe("Site Settings API Routes", () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toContain("Validation error");
     });
+
+    it("should persist sprintFvEnabled=true across updates (regression)", async () => {
+      mockSessionUser = {
+        id: testSiteAdminId,
+        email: `siteadmin-settings-${Date.now()}@test.com`,
+        role: "site_admin",
+        isSiteAdmin: true,
+      };
+
+      const enableResponse = await request(app)
+        .patch("/api/site-settings")
+        .send({ sprintFvEnabled: true });
+
+      expect(enableResponse.status).toBe(200);
+      expect(enableResponse.body.sprintFvEnabled).toBe(true);
+
+      const readback = await request(app).get("/api/site-settings");
+      expect(readback.status).toBe(200);
+      expect(readback.body.sprintFvEnabled).toBe(true);
+
+      const publicReadback = await request(app).get("/api/site-settings/public");
+      expect(publicReadback.status).toBe(200);
+      expect(publicReadback.body.sprintFvEnabled).toBe(true);
+    });
+
+    it("should persist sprintFvEnabled=false across updates (regression)", async () => {
+      mockSessionUser = {
+        id: testSiteAdminId,
+        email: `siteadmin-settings-${Date.now()}@test.com`,
+        role: "site_admin",
+        isSiteAdmin: true,
+      };
+
+      await request(app)
+        .patch("/api/site-settings")
+        .send({ sprintFvEnabled: true });
+
+      // Intermediate readback: proves the enable PATCH actually persisted.
+      // Without this, the test passes pre-fix because the DB default is false
+      // and enable→disable silent-drops in both directions end at false.
+      const intermediate = await request(app).get("/api/site-settings");
+      expect(intermediate.body.sprintFvEnabled).toBe(true);
+
+      const disableResponse = await request(app)
+        .patch("/api/site-settings")
+        .send({ sprintFvEnabled: false });
+
+      expect(disableResponse.status).toBe(200);
+      expect(disableResponse.body.sprintFvEnabled).toBe(false);
+
+      const readback = await request(app).get("/api/site-settings");
+      expect(readback.status).toBe(200);
+      expect(readback.body.sprintFvEnabled).toBe(false);
+    });
   });
 
   describe("GET /api/ai-models", () => {

--- a/packages/api/routes/index.ts
+++ b/packages/api/routes/index.ts
@@ -53,6 +53,7 @@ import { registerParentRoutes } from "./parent-routes";
 import { registerParentLinkRequestRoutes } from "./parent-link-request-routes";
 import { registerDeviceImportRoutes } from "./device-import-routes";
 import { registerSprintFvRoutes } from "./sprint-fv-routes";
+import { registerLlmExportRoutes } from "./llm-export-routes";
 
 /**
  * Register all application routes
@@ -209,6 +210,9 @@ export function registerAllRoutes(app: Express) {
 
   // Sprint Force-Velocity profile routes (Morin F-V profiling)
   registerSprintFvRoutes(app);
+
+  // LLM export route (athlete → Markdown/JSON for paste-into-LLM program design)
+  registerLlmExportRoutes(app);
 
   console.log("✅ All routes registered successfully");
 }

--- a/packages/api/routes/llm-export-routes.ts
+++ b/packages/api/routes/llm-export-routes.ts
@@ -1,0 +1,234 @@
+/**
+ * LLM export routes
+ *
+ * GET /api/athletes/:id/llm-export?format=markdown|json
+ *
+ * Assembles an athlete-centric export suitable for pasting into an LLM to
+ * design a training program. This is a *coaching tool*, not a self-service
+ * export — permission model is an allowlist (see `ALLOWED_LLM_EXPORT_ROLES`):
+ *   - site_admin: any athlete
+ *   - coach / org_admin: athletes in their org (via org membership OR team membership)
+ *   - athlete role: denied, even for self-access
+ *     (coaches are the audience for LLM-generated training programs)
+ *   - all other roles (guest, parent, …): denied
+ *
+ * The athlete-self-denial is covered by integration test
+ * "returns 403 for an athlete attempting to export their own profile".
+ */
+
+import type { Express } from 'express';
+import rateLimit from 'express-rate-limit';
+import { storage } from '../storage';
+import { requireAuth } from '../middleware';
+import { isSiteAdmin } from '../utils/auth-helpers';
+import { getCachedUserOrganizations } from '../helpers/cached-org-access';
+import { logAuthorizationFailure } from '../helpers/audit-logging';
+import {
+  AthleteNotFoundError,
+  buildAthleteLlmExport,
+} from '../services/llm-export-service';
+
+const llmExportLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 30,
+  message: { message: 'Too many export requests, please try again later.' },
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+});
+
+// PostgreSQL raises "invalid input syntax for type uuid" when a UUID-typed
+// column is queried with a non-UUID string. Several DB lookups in this route
+// query `users.id` (UUID), so a malformed route param escapes as a generic
+// 500. Validate the shape up-front and return 404 — 400 would leak the fact
+// that the route specifically inspects UUID format, narrowing the oracle.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// LLM export is a coaching tool: only coaches, org admins, and site admins
+// may generate one. Allocated once at module load rather than per-request;
+// the Set is immutable after construction and safe to share.
+const ALLOWED_LLM_EXPORT_ROLES = new Set(['coach', 'org_admin']);
+
+export function registerLlmExportRoutes(app: Express) {
+  app.get(
+    '/api/athletes/:id/llm-export',
+    llmExportLimiter,
+    requireAuth,
+    async (req, res) => {
+      try {
+        const athleteId = req.params.id;
+        const currentUser = req.session.user;
+        if (!currentUser?.id) {
+          return res.status(401).json({ message: 'User not authenticated' });
+        }
+
+        if (!UUID_RE.test(athleteId)) {
+          return res.status(404).json({ message: 'Athlete not found' });
+        }
+
+        // Express parses repeated query params (?format=a&format=b) as string[].
+        // Pick the first entry so the subsequent === comparison is always a
+        // string compare, not a silent array-to-string coercion.
+        const rawFormatParam = req.query.format;
+        const rawFormat = Array.isArray(rawFormatParam)
+          ? rawFormatParam[0]
+          : (rawFormatParam ?? 'markdown');
+        if (rawFormat !== 'markdown' && rawFormat !== 'json') {
+          return res.status(400).json({
+            message: "Invalid format — must be 'markdown' or 'json'",
+          });
+        }
+
+        const userIsSiteAdmin = isSiteAdmin(currentUser);
+        let targetOrganizationId: string | null = null;
+
+        // The allowlist is an *allowlist*, not a denylist — any role not
+        // explicitly named (athlete, parent, guest, …) is denied, so new
+        // roles added to the system default to no-access until a policy
+        // decision is made.
+        //
+        // Role check runs *before* the athlete-existence lookup so a denied
+        // caller cannot distinguish "athlete exists but you can't read it"
+        // (403) from "athlete does not exist" (404). The 404-vs-403 split is
+        // an existence oracle for unauthorised callers; flatten it to 403.
+        if (!userIsSiteAdmin && !ALLOWED_LLM_EXPORT_ROLES.has(currentUser.role)) {
+          return res.status(403).json({
+            message: 'LLM export is only available to coaches and organization admins',
+          });
+        }
+
+        const athlete = await storage.getAthlete(athleteId);
+        if (!athlete) {
+          return res.status(404).json({ message: 'Athlete not found' });
+        }
+
+        if (!userIsSiteAdmin) {
+          const userOrgs = await getCachedUserOrganizations(
+            req,
+            currentUser.id,
+          );
+          if (userOrgs.length === 0) {
+            // Audit the revoked-coach probe pattern: a session that survived
+            // org-membership removal is a signal worth capturing. Without
+            // this log, the only other 403 branch (`sharedOrgId === null`,
+            // below) is the only audited path — revoked coaches would probe
+            // silently.
+            logAuthorizationFailure(currentUser.id, 'read', 'athlete', {
+              userOrgIds: [],
+              ipAddress: req.ip,
+              userAgent: req.get('user-agent'),
+              route: req.path,
+              method: req.method,
+            });
+            return res
+              .status(403)
+              .json({ message: 'Access denied - no organization access' });
+          }
+
+          // Two independent lookups — fetch in parallel to halve the
+          // authorization round-trip cost.
+          const [athleteOrgs, athleteTeams] = await Promise.all([
+            getCachedUserOrganizations(req, athleteId),
+            storage.getUserTeams(athleteId),
+          ]);
+
+          if (athleteOrgs.length === 0 && athleteTeams.length === 0) {
+            // Audit for parity with the other two 403 branches (revoked coach
+            // at line 116, cross-org at line 154). A coach probing
+            // unaffiliated athletes is as much a detection signal as probing
+            // cross-org athletes — without logging here, the "unaffiliated
+            // athlete sweep" pattern would be invisible.
+            // Omit `attemptedOrgId` — there is no athlete-side org to attempt
+            // against. That absence is itself the branch-distinguishing
+            // signal when a defender reads the audit log (the cross-org
+            // branch always populates attemptedOrgId).
+            logAuthorizationFailure(currentUser.id, 'read', 'athlete', {
+              userOrgIds: userOrgs.map((o) => o.organizationId),
+              ipAddress: req.ip,
+              userAgent: req.get('user-agent'),
+              route: req.path,
+              method: req.method,
+            });
+            // Generic body to avoid signalling whether the athlete exists or
+            // what state their org/team assignments are in.
+            return res.status(403).json({ message: 'Access denied' });
+          }
+
+          const userOrgIds = userOrgs.map((o) => o.organizationId);
+          const athleteOrgIds = athleteOrgs.map((o) => o.organizationId);
+          const athleteTeamOrgIds = athleteTeams.map(
+            (t) => t.team.organizationId,
+          );
+          const allAthleteOrgIds = Array.from(
+            new Set([...athleteOrgIds, ...athleteTeamOrgIds]),
+          );
+
+          const sharedOrgId = allAthleteOrgIds.find((id) =>
+            userOrgIds.includes(id),
+          );
+          if (!sharedOrgId) {
+            logAuthorizationFailure(currentUser.id, 'read', 'athlete', {
+              attemptedOrgId: allAthleteOrgIds[0],
+              userOrgIds,
+              ipAddress: req.ip,
+              userAgent: req.get('user-agent'),
+              route: req.path,
+              method: req.method,
+            });
+            // Generic body to match the sibling branch at line 138 — a caller
+            // must not be able to distinguish "athlete is unaffiliated" from
+            // "athlete belongs to a different org" by comparing 403 bodies.
+            // Differentiated messages let a probing coach oracle an athlete's
+            // org-affiliation state; the audit log captures the granular
+            // reason server-side where it belongs.
+            return res.status(403).json({ message: 'Access denied' });
+          }
+          targetOrganizationId = sharedOrgId;
+        } else {
+          // Site admin: use athlete's first org if present, else null.
+          const athleteOrgs = await getCachedUserOrganizations(req, athleteId);
+          targetOrganizationId = athleteOrgs[0]?.organizationId ?? null;
+        }
+
+        const format = rawFormat as 'markdown' | 'json';
+        const { content, filename, contentType } = await buildAthleteLlmExport(
+          athleteId,
+          format,
+          { organizationId: targetOrganizationId },
+        );
+
+        res.setHeader('Content-Type', contentType);
+        // NOTE: `filename=` is the RFC 6266 unquoted-ASCII form. This is
+        // only correct because `filenameFor` strips diacritics and collapses
+        // non-alphanumerics, so the slug is guaranteed [a-z0-9-]. If Unicode
+        // filenames are ever introduced, switch to `filename*=UTF-8''<encoded>`
+        // per RFC 5987 to avoid malformed headers on strict HTTP stacks.
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="${filename}"`,
+        );
+        // TODO(audit): emit a `data_export` security event for successful
+        // exports so exfiltration patterns are detectable — the payload
+        // includes medical notes and is intended for external-LLM paste.
+        // Deferred: the `createSecurityEventSchema` enum in
+        // `@shared/enhanced-auth-schema` does not currently include a
+        // `data_export` variant, so this needs a schema+migration change
+        // tracked in its own PR. Success-path audit here would be too
+        // loosely typed to sit on `authorization_failed` or
+        // `suspicious_activity`.
+        res.status(200).send(content);
+      } catch (err) {
+        // If the athlete was deleted between the route-level existence check
+        // and the service's own query, the service throws AthleteNotFoundError.
+        // Surface as a 404 rather than the generic 500.
+        if (err instanceof AthleteNotFoundError) {
+          return res.status(404).json({ message: 'Athlete not found' });
+        }
+        console.error('LLM export failed:', err);
+        res.status(500).json({
+          message: 'Failed to generate LLM export',
+        });
+      }
+    },
+  );
+}

--- a/packages/api/routes/site-settings-routes.ts
+++ b/packages/api/routes/site-settings-routes.ts
@@ -81,6 +81,7 @@ router.get("/", requireSiteAdmin, async (req, res) => {
       return res.json({
         aiModel: "gpt-5-nano",
         wellnessModuleEnabled: true,
+        sprintFvEnabled: false,
         updatedAt: new Date().toISOString(),
         updatedBy: null,
       });

--- a/packages/api/services/__tests__/llm-export-service.test.ts
+++ b/packages/api/services/__tests__/llm-export-service.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderMarkdown,
+  renderJson,
+  filenameFor,
+  AthleteNotFoundError,
+  type AthleteExportData,
+} from '../llm-export-service';
+
+function sampleData(overrides: Partial<AthleteExportData> = {}): AthleteExportData {
+  return {
+    generatedAt: new Date('2026-04-19T12:00:00Z'),
+    athlete: {
+      id: 'athlete-1',
+      fullName: 'Jane Doe',
+      age: 17,
+      gender: 'Female',
+      graduationYear: 2027,
+      heightIn: 66,
+      weightLb: 135,
+      sports: ['Soccer'],
+      positions: ['Midfielder'],
+      teams: [{ name: 'Varsity Soccer', level: 'HS', season: '2026-Spring' }],
+    },
+    organization: { id: 'org-1', name: 'Example High School' },
+    currentSnapshot: [
+      {
+        metricCode: 'FLY10_TIME',
+        metricLabel: '10-yd Fly Time',
+        value: 1.08,
+        units: 's',
+        date: '2026-03-14',
+      },
+      {
+        metricCode: 'VERTICAL_JUMP',
+        metricLabel: 'Vertical Jump',
+        value: 24.5,
+        units: 'in',
+        date: '2026-03-14',
+      },
+    ],
+    measurementHistory: {
+      FLY10_TIME: [
+        { date: '2026-03-14', value: 1.08, units: 's' },
+        { date: '2026-01-10', value: 1.12, units: 's' },
+      ],
+      VERTICAL_JUMP: [{ date: '2026-03-14', value: 24.5, units: 'in' }],
+    },
+    sprintFv: {
+      date: '2026-03-14',
+      f0Rel: 7.2,
+      v0: 9.1,
+      pmaxRel: 16.4,
+      fvSlope: -0.79,
+      rfPeak: 0.42,
+      drf: -0.071,
+      fitR2: 0.97,
+      classification: 'Force-deficit',
+      gap: { orientation: 'force', magnitudePct: 18 },
+      deltas: { f0Pct: -18, v0Pct: 5 },
+      trainingRecommendations: [
+        'Prioritize heavy strength work (squat, deadlift variations) to raise F0',
+        'Reduce volume of high-velocity sprint work until F0 deficit closes',
+      ],
+      notes: 'Follow-up retest in 6 weeks.',
+    },
+    activeGoals: [
+      {
+        metricCode: 'FLY10_TIME',
+        metricLabel: '10-yd Fly Time',
+        goalType: 'minimize',
+        baselineValue: 1.15,
+        currentValue: 1.08,
+        targetValue: 1.02,
+        targetDate: '2026-08-01',
+        units: 's',
+        notes: null,
+      },
+    ],
+    recentWellness: [
+      {
+        date: '2026-04-12',
+        submittedAt: '2026-04-12T07:30:00Z',
+        responses: { sleep: 7, soreness: 3, mood: 4, readiness: 8 },
+      },
+    ],
+    notes: {
+      medicalNotes: 'Mild left hamstring strain Jan 2026, cleared.',
+      coachNotes: 'Strong work ethic. Needs stronger posterior chain.',
+    },
+    metricGlossary: {
+      FLY10_TIME: {
+        label: '10-yd Fly Time',
+        units: 's',
+        explanation: 'Measures top-end speed with a flying start.',
+      },
+      VERTICAL_JUMP: {
+        label: 'Vertical Jump',
+        units: 'in',
+        explanation: 'Measures lower-body explosive power.',
+      },
+    },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function emptyData(): AthleteExportData {
+  return {
+    generatedAt: new Date('2026-04-19T12:00:00Z'),
+    athlete: {
+      id: 'athlete-2',
+      fullName: 'Alex Rivera',
+      age: null,
+      gender: null,
+      graduationYear: null,
+      heightIn: null,
+      weightLb: null,
+      sports: [],
+      positions: [],
+      teams: [],
+    },
+    organization: null,
+    currentSnapshot: [],
+    measurementHistory: {},
+    sprintFv: null,
+    activeGoals: [],
+    recentWellness: [],
+    notes: { medicalNotes: null, coachNotes: null },
+    metricGlossary: {},
+    warnings: [],
+  };
+}
+
+describe('renderMarkdown', () => {
+  it('renders an H1 with the athlete name', () => {
+    const md = renderMarkdown(sampleData());
+    expect(md).toMatch(/^# Athlete Performance Export — Jane Doe/m);
+  });
+
+  it('includes every required H2 section, in order', () => {
+    const md = renderMarkdown(sampleData());
+    const sections = [
+      '## Athlete Profile',
+      '## Current Performance Snapshot',
+      '## 12-Month Measurement History',
+      '## Sprint Force-Velocity Profile',
+      '## Active Goals',
+      '## Recent Wellness',
+      '## Medical & Coach Notes',
+      '## Metric Glossary',
+    ];
+    let lastIdx = -1;
+    for (const s of sections) {
+      const idx = md.indexOf(s);
+      expect(idx, `section "${s}" missing`).toBeGreaterThan(-1);
+      expect(idx, `section "${s}" out of order`).toBeGreaterThan(lastIdx);
+      lastIdx = idx;
+    }
+  });
+
+  it('labels units on every numeric value in the Current Performance Snapshot table', () => {
+    const md = renderMarkdown(sampleData());
+    const start = md.indexOf('## Current Performance Snapshot');
+    const end = md.indexOf('## 12-Month Measurement History');
+    const section = md.slice(start, end);
+    expect(section).toContain('| 1.08 | s |');
+    expect(section).toContain('| 24.5 | in |');
+  });
+
+  it('surfaces F-V classification as a bold callout line, not inside a table', () => {
+    const md = renderMarkdown(sampleData());
+    expect(md).toMatch(/\*\*Classification:\*\* Force-deficit/);
+    const fvStart = md.indexOf('## Sprint Force-Velocity Profile');
+    const fvEnd = md.indexOf('## Active Goals');
+    const fvSection = md.slice(fvStart, fvEnd);
+    expect(fvSection).not.toMatch(/\|.*Classification.*\|/);
+  });
+
+  it('renders training recommendations as a bulleted list, not a table cell', () => {
+    const md = renderMarkdown(sampleData());
+    expect(md).toMatch(/- Prioritize heavy strength work/);
+    expect(md).toMatch(/- Reduce volume of high-velocity sprint work/);
+  });
+
+  it('formats F-V gap/deltas as key=value pairs, not raw JSON', () => {
+    const md = renderMarkdown(sampleData());
+    const fvStart = md.indexOf('## Sprint Force-Velocity Profile');
+    const fvEnd = md.indexOf('## Active Goals');
+    const fvSection = md.slice(fvStart, fvEnd);
+    // Must NOT contain raw JSON object braces — those are a sign of
+    // JSON.stringify(obj) leaking through into Markdown.
+    expect(fvSection).not.toMatch(/\{"orientation"/);
+    expect(fvSection).not.toMatch(/\{"f0Pct"/);
+    // Must contain readable key=value form.
+    expect(fvSection).toMatch(/orientation=force/);
+    expect(fvSection).toMatch(/magnitudePct=18/);
+    expect(fvSection).toMatch(/f0Pct=-18/);
+    expect(fvSection).toMatch(/v0Pct=5/);
+  });
+
+  it('ends with the prompt-starter callout', () => {
+    const md = renderMarkdown(sampleData());
+    expect(md).toMatch(/\*\*Prompt suggestion:\*\*/);
+    expect(md.trimEnd()).toMatch(/week-by-week table with sets, reps, and intent for each session\.$/);
+  });
+
+  it('emits "_No data yet._" placeholders when sections are empty (stable structure)', () => {
+    const md = renderMarkdown(emptyData());
+    // Every section heading still present
+    expect(md).toContain('## Current Performance Snapshot');
+    expect(md).toContain('## Sprint Force-Velocity Profile');
+    expect(md).toContain('## Active Goals');
+    expect(md).toContain('## Recent Wellness');
+    expect(md).toContain('## Medical & Coach Notes');
+    // Empty sections use the italic placeholder
+    const placeholderCount = (md.match(/_No data yet\._/g) || []).length;
+    expect(placeholderCount).toBeGreaterThanOrEqual(5);
+  });
+
+  it('escapes pipe characters in the athlete name to avoid breaking tables', () => {
+    const data = sampleData({
+      athlete: { ...sampleData().athlete, fullName: 'A|B Smith' },
+    });
+    const md = renderMarkdown(data);
+    expect(md).toContain('A\\|B Smith');
+  });
+
+  it('uses ASCII characters only in tables (no emoji / decorative unicode)', () => {
+    const md = renderMarkdown(sampleData());
+    // Allow em-dash and smart quotes in prose; disallow emoji range
+    expect(md).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u);
+  });
+
+  it('includes the metric glossary for every metric seen in snapshot or history', () => {
+    const md = renderMarkdown(sampleData());
+    const glossaryStart = md.indexOf('## Metric Glossary');
+    const glossary = md.slice(glossaryStart);
+    expect(glossary).toContain('FLY10_TIME');
+    expect(glossary).toContain('VERTICAL_JUMP');
+  });
+
+  it('appends a warnings footer when warnings are present', () => {
+    const md = renderMarkdown(sampleData({ warnings: ['Sprint F-V query failed'] }));
+    expect(md).toMatch(/\*\*Warnings:\*\*/);
+    expect(md).toContain('Sprint F-V query failed');
+  });
+
+  it('omits the warnings footer when warnings are empty', () => {
+    const md = renderMarkdown(sampleData());
+    expect(md).not.toMatch(/\*\*Warnings:\*\*/);
+  });
+
+  it('formats nested wellness response values as key=value, not raw JSON', () => {
+    const data = sampleData({
+      recentWellness: [
+        {
+          date: '2026-04-12',
+          submittedAt: '2026-04-12T07:30:00Z',
+          // A template with nested structure (e.g. a Likert response with metadata)
+          responses: {
+            sleep: 7,
+            nutrition: { meals: 3, hydration: 'good' },
+          },
+        },
+      ],
+    });
+    const md = renderMarkdown(data);
+    const start = md.indexOf('## Recent Wellness');
+    const end = md.indexOf('## Medical & Coach Notes');
+    const section = md.slice(start, end);
+    // Must not leak raw JSON braces
+    expect(section).not.toMatch(/\{"meals"/);
+    // Should expose nested fields in readable key=value form
+    expect(section).toContain('meals=3');
+    expect(section).toContain('hydration=good');
+  });
+
+  it('escapes markdown emphasis characters in the athlete name in the H1', () => {
+    const data = sampleData({
+      athlete: { ...sampleData().athlete, fullName: 'Jane *Star* Doe_Smith' },
+    });
+    const md = renderMarkdown(data);
+    // H1 is the first line; unescaped `*` or `_` inside the heading would
+    // render as emphasis. Consistent with the header org-name handling.
+    const h1 = md.split('\n')[0];
+    expect(h1).toContain('Jane \\*Star\\* Doe\\_Smith');
+  });
+
+  it('escapes markdown-breaking characters in the organization name in the header', () => {
+    const data = sampleData({
+      organization: { id: 'org-1', name: 'Acme_Athletics * HS' },
+    });
+    const md = renderMarkdown(data);
+    // Header is wrapped in single asterisks to produce an italic run. A bare `*`
+    // or `_` inside the name would prematurely close the italic — escaping with
+    // a backslash preserves the wrapper while rendering the literal character.
+    const headerLine = md.split('\n')[1];
+    expect(headerLine).toContain('Acme\\_Athletics \\* HS');
+  });
+
+  it('renders a display-name fallback when the athlete fullName is empty', () => {
+    // If users.fullName, firstName, and lastName are all null (a malformed or
+    // partially-created record), the assembler produces an empty fullName.
+    // Without a renderer-side fallback, the H1 would render as
+    // "# Athlete Performance Export — " with nothing after the em-dash, which
+    // looks broken in both human and LLM consumption.
+    const data = sampleData({
+      athlete: { ...sampleData().athlete, fullName: '' },
+    });
+    const md = renderMarkdown(data);
+    const h1 = md.split('\n')[0];
+    expect(h1).toBe('# Athlete Performance Export — Unknown Athlete');
+  });
+});
+
+describe('AthleteNotFoundError', () => {
+  it('is a distinct error type the route can use to return 404', () => {
+    const err = new AthleteNotFoundError('athlete-missing');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AthleteNotFoundError);
+    expect(err.message).toMatch(/athlete-missing/);
+  });
+});
+
+describe('renderJson', () => {
+  it('matches the expected shape', () => {
+    const json = renderJson(sampleData());
+    expect(json).toMatchObject({
+      generatedAt: expect.any(String),
+      athlete: expect.objectContaining({
+        id: 'athlete-1',
+        fullName: 'Jane Doe',
+      }),
+      sprintFv: expect.objectContaining({ classification: 'Force-deficit' }),
+      activeGoals: expect.arrayContaining([
+        expect.objectContaining({ metricCode: 'FLY10_TIME' }),
+      ]),
+      metricGlossary: expect.objectContaining({
+        FLY10_TIME: expect.objectContaining({ label: '10-yd Fly Time' }),
+      }),
+    });
+  });
+
+  it('serializes generatedAt as an ISO string', () => {
+    const json = renderJson(sampleData());
+    expect(() => new Date(json.generatedAt).toISOString()).not.toThrow();
+    expect(json.generatedAt).toBe('2026-04-19T12:00:00.000Z');
+  });
+
+  it('passes sprintFv.analysisJson-derived fields through without mutation', () => {
+    const data = sampleData();
+    const json = renderJson(data);
+    expect(json.sprintFv?.classification).toBe(data.sprintFv!.classification);
+    expect(json.sprintFv?.gap).toEqual(data.sprintFv!.gap);
+    expect(json.sprintFv?.deltas).toEqual(data.sprintFv!.deltas);
+    expect(json.sprintFv?.trainingRecommendations).toEqual(
+      data.sprintFv!.trainingRecommendations,
+    );
+  });
+
+  it('returns sprintFv as null when the athlete has no profile', () => {
+    const json = renderJson(emptyData());
+    expect(json.sprintFv).toBeNull();
+  });
+});
+
+describe('filenameFor', () => {
+  it('uses the athlete slug and export date', () => {
+    const fn = filenameFor('Jane Doe', 'markdown', new Date('2026-04-19T00:00:00Z'));
+    expect(fn).toBe('jane-doe-2026-04-19.md');
+  });
+
+  it('strips diacritics', () => {
+    const fn = filenameFor('José Núñez', 'markdown', new Date('2026-04-19T00:00:00Z'));
+    expect(fn).toBe('jose-nunez-2026-04-19.md');
+  });
+
+  it('collapses whitespace and lowercases', () => {
+    const fn = filenameFor('  Multi   Word   Name  ', 'markdown', new Date('2026-04-19T00:00:00Z'));
+    expect(fn).toBe('multi-word-name-2026-04-19.md');
+  });
+
+  it('uses .json extension for json format', () => {
+    const fn = filenameFor('Jane Doe', 'json', new Date('2026-04-19T00:00:00Z'));
+    expect(fn).toBe('jane-doe-2026-04-19.json');
+  });
+
+  it('strips non-alphanumeric characters (pipes, slashes)', () => {
+    const fn = filenameFor('A|B/Name', 'markdown', new Date('2026-04-19T00:00:00Z'));
+    expect(fn).toBe('ab-name-2026-04-19.md');
+  });
+
+  it("falls back to 'athlete' when the slug would be empty", () => {
+    // All-symbol/whitespace names would otherwise produce "-2026-04-19.md"
+    // which is a malformed filename leading with a dash.
+    const fn = filenameFor('!!!', 'markdown', new Date('2026-04-19T00:00:00Z'));
+    expect(fn).toBe('athlete-2026-04-19.md');
+  });
+});

--- a/packages/api/services/__tests__/sprint-fv-computation.test.ts
+++ b/packages/api/services/__tests__/sprint-fv-computation.test.ts
@@ -8,9 +8,9 @@ import { computeFvProfile, type ComputedFvProfile } from '../sprint-fv-computati
  */
 
 describe('computeFvProfile', () => {
-  describe('basic computation with 4 splits', () => {
-    // Typical college sprinter: 30m in ~4.5s
-    const splits = { '5': 1.10, '10': 1.82, '20': 3.15, '30': 4.45 };
+  describe('basic computation with 4 splits (10/20/30/40 protocol)', () => {
+    // Typical college sprinter: 40m in ~5.6s, mono-exponential shape
+    const splits = { '10': 1.82, '20': 3.15, '30': 4.45, '40': 5.72 };
     const bodyMassKg = 80;
     let result: ComputedFvProfile;
 
@@ -88,9 +88,9 @@ describe('computeFvProfile', () => {
     });
   });
 
-  describe('yard to meter conversion', () => {
-    // Same athlete, data in yards
-    const splitsYards = { '5': 1.03, '10': 1.70, '20': 2.95, '30': 4.18 };
+  describe('yard to meter conversion (10/20/30/40 yards)', () => {
+    // Same athlete, data in yards — 40yd ≈ 36.58m
+    const splitsYards = { '10': 1.70, '20': 2.95, '30': 4.18, '40': 5.35 };
     const bodyMassKg = 80;
 
     it('should convert yards to meters internally', () => {
@@ -102,7 +102,7 @@ describe('computeFvProfile', () => {
     });
 
     it('should produce similar Pmax for equivalent performances in yards vs meters', () => {
-      // A 30yd sprint ≈ 27.4m; times should be slightly different
+      // A 40yd sprint ≈ 36.58m; times should be slightly different
       // but the physics (Pmax) should be in the same ballpark
       const resultYards = computeFvProfile(splitsYards, bodyMassKg, 'yards');
       expect(resultYards.pmaxRel).toBeGreaterThan(5);
@@ -111,7 +111,8 @@ describe('computeFvProfile', () => {
   });
 
   describe('3 of 4 splits (minimum data)', () => {
-    const splits3 = { '5': 1.10, '10': 1.82, '30': 4.45 };
+    // Uses 10/20/40 — legal under the new protocol, missing 30
+    const splits3 = { '10': 1.82, '20': 3.15, '40': 5.72 };
     const bodyMassKg = 75;
 
     it('should compute with only 3 splits', () => {
@@ -129,29 +130,29 @@ describe('computeFvProfile', () => {
 
   describe('edge cases', () => {
     it('should throw with fewer than 3 splits', () => {
-      expect(() => computeFvProfile({ '5': 1.10, '10': 1.82 }, 80, 'meters'))
+      expect(() => computeFvProfile({ '10': 1.82, '20': 3.15 }, 80, 'meters'))
         .toThrow(/at least 3/i);
     });
 
     it('should throw with non-monotonically-increasing times', () => {
-      // 20m time is less than 10m time — physically impossible
-      expect(() => computeFvProfile({ '5': 1.10, '10': 3.00, '20': 2.50, '30': 4.45 }, 80, 'meters'))
+      // 30m time is less than 20m time — physically impossible
+      expect(() => computeFvProfile({ '10': 1.82, '20': 4.00, '30': 3.50, '40': 5.72 }, 80, 'meters'))
         .toThrow(/monotonically/i);
     });
 
     it('should throw with zero or negative times', () => {
-      expect(() => computeFvProfile({ '5': 0, '10': 1.82, '20': 3.15, '30': 4.45 }, 80, 'meters'))
+      expect(() => computeFvProfile({ '10': 0, '20': 3.15, '30': 4.45, '40': 5.72 }, 80, 'meters'))
         .toThrow(/positive/i);
     });
 
     it('should throw with zero body mass', () => {
-      expect(() => computeFvProfile({ '5': 1.10, '10': 1.82, '20': 3.15, '30': 4.45 }, 0, 'meters'))
+      expect(() => computeFvProfile({ '10': 1.82, '20': 3.15, '30': 4.45, '40': 5.72 }, 0, 'meters'))
         .toThrow(/body mass/i);
     });
 
     it('should handle very fast sprinter (elite)', () => {
-      // Elite male: 30m in ~3.6s
-      const splits = { '5': 0.85, '10': 1.42, '20': 2.50, '30': 3.55 };
+      // Elite male: 40m in ~4.6s
+      const splits = { '10': 1.42, '20': 2.50, '30': 3.55, '40': 4.58 };
       const result = computeFvProfile(splits, 85, 'meters');
       expect(result.vmax).toBeGreaterThan(9);
       expect(result.f0Rel).toBeGreaterThan(6);
@@ -159,8 +160,8 @@ describe('computeFvProfile', () => {
     });
 
     it('should handle slow athlete (recreational)', () => {
-      // Recreational: 30m in ~6.0s
-      const splits = { '5': 1.50, '10': 2.50, '20': 4.30, '30': 6.00 };
+      // Recreational: 40m in ~7.8s
+      const splits = { '10': 2.50, '20': 4.30, '30': 6.00, '40': 7.80 };
       const result = computeFvProfile(splits, 70, 'meters');
       expect(result.vmax).toBeGreaterThan(5);
       expect(result.vmax).toBeLessThan(8);

--- a/packages/api/services/__tests__/sprint-fv-service.test.ts
+++ b/packages/api/services/__tests__/sprint-fv-service.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSplitsFromMeasurements,
+  SprintFvValidationError,
+  SPLIT_METRICS_YARDS,
+  SPLIT_METRICS_METERS,
+  type SplitMeasurementInput,
+} from '../sprint-fv-service';
+import { MetricType, VALID_METRICS } from '@shared/schema/constants';
+
+/**
+ * Unit tests for the pure split-resolution logic used by SprintFvService.
+ *
+ * The service separates the DB-free algorithm (choose a unit, pick the fastest
+ * time per distance, detect mixed units) from the drizzle query that supplies
+ * measurement rows — these tests exercise the algorithm in isolation.
+ */
+
+function mk(id: string, metric: string, value: string | number): SplitMeasurementInput {
+  return { id, metric, value: String(value) };
+}
+
+describe('resolveSplitsFromMeasurements', () => {
+  describe('yards (new 10/20/30/40 protocol)', () => {
+    it('resolves a full yards session to the yards unit and 4 splits', () => {
+      const rows = [
+        mk('a', 'DASH_10YD', 1.70),
+        mk('b', 'DASH_20YD', 2.95),
+        mk('c', 'DASH_30YD', 4.18),
+        mk('d', 'DASH_40YD', 5.30),
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+
+      expect(result.distanceUnit).toBe('yards');
+      expect(result.splitTimes).toEqual({ '10': 1.70, '20': 2.95, '30': 4.18, '40': 5.30 });
+      expect(result.usedMeasurementIds).toEqual({ '10': 'a', '20': 'b', '30': 'c', '40': 'd' });
+    });
+
+    it('accepts 3 of 4 splits (minimum protocol)', () => {
+      const rows = [
+        mk('a', 'DASH_10YD', 1.70),
+        mk('c', 'DASH_30YD', 4.18),
+        mk('d', 'DASH_40YD', 5.30),
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+
+      expect(result.distanceUnit).toBe('yards');
+      expect(Object.keys(result.splitTimes)).toHaveLength(3);
+    });
+
+    it('picks the fastest time when a distance has duplicate trials', () => {
+      const rows = [
+        mk('a', 'DASH_10YD', 1.85),
+        mk('a2', 'DASH_10YD', 1.70), // fastest
+        mk('b', 'DASH_20YD', 2.95),
+        mk('c', 'DASH_30YD', 4.18),
+        mk('d', 'DASH_40YD', 5.30),
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+
+      expect(result.splitTimes['10']).toBe(1.70);
+      expect(result.usedMeasurementIds['10']).toBe('a2');
+    });
+  });
+
+  describe('meters (new DASH_*M metric types)', () => {
+    it('resolves a full meters session to the meters unit', () => {
+      const rows = [
+        mk('a', 'DASH_10M', 1.85),
+        mk('b', 'DASH_20M', 3.20),
+        mk('c', 'DASH_30M', 4.55),
+        mk('d', 'DASH_40M', 5.80),
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+
+      expect(result.distanceUnit).toBe('meters');
+      expect(result.splitTimes).toEqual({ '10': 1.85, '20': 3.20, '30': 4.55, '40': 5.80 });
+    });
+  });
+
+  describe('mixed units (error)', () => {
+    it('throws SprintFvValidationError when both yards and meters have enough splits', () => {
+      const rows = [
+        // Three yards splits
+        mk('y1', 'DASH_10YD', 1.70),
+        mk('y2', 'DASH_20YD', 2.95),
+        mk('y3', 'DASH_30YD', 4.18),
+        // Three meters splits
+        mk('m1', 'DASH_10M', 1.85),
+        mk('m2', 'DASH_20M', 3.20),
+        mk('m3', 'DASH_30M', 4.55),
+      ];
+
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(SprintFvValidationError);
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(/mixed/i);
+    });
+
+    it('prefers the yards unit when meters has <3 splits', () => {
+      const rows = [
+        mk('y1', 'DASH_10YD', 1.70),
+        mk('y2', 'DASH_20YD', 2.95),
+        mk('y3', 'DASH_30YD', 4.18),
+        mk('m1', 'DASH_10M', 1.85), // stray meters measurement
+      ];
+
+      const result = resolveSplitsFromMeasurements(rows);
+      expect(result.distanceUnit).toBe('yards');
+      expect(Object.keys(result.splitTimes)).toEqual(['10', '20', '30']);
+    });
+  });
+
+  describe('insufficient data', () => {
+    it('throws when neither unit has 3 splits', () => {
+      const rows = [
+        mk('y1', 'DASH_10YD', 1.70),
+        mk('y2', 'DASH_20YD', 2.95),
+      ];
+
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(SprintFvValidationError);
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(/at least 3/i);
+    });
+
+    it('ignores non-finite / non-positive times when counting', () => {
+      const rows = [
+        mk('a', 'DASH_10YD', 1.70),
+        mk('b', 'DASH_20YD', 0), // invalid
+        mk('c', 'DASH_30YD', 4.18),
+        mk('d', 'DASH_40YD', 'not-a-number'),
+      ];
+
+      expect(() => resolveSplitsFromMeasurements(rows)).toThrow(/at least 3/i);
+    });
+  });
+
+  describe('metric-code tables', () => {
+    it('exports a yards-only split metric map for the 10/20/30/40 protocol', () => {
+      expect(SPLIT_METRICS_YARDS).toEqual({
+        DASH_10YD: 10,
+        DASH_20YD: 20,
+        DASH_30YD: 30,
+        DASH_40YD: 40,
+      });
+    });
+
+    it('exports a meters-only split metric map for the 10/20/30/40 protocol', () => {
+      expect(SPLIT_METRICS_METERS).toEqual({
+        DASH_10M: 10,
+        DASH_20M: 20,
+        DASH_30M: 30,
+        DASH_40M: 40,
+      });
+    });
+  });
+
+  describe('MetricType / VALID_METRICS cohesion with split-code maps', () => {
+    it('registers every yards split distance in MetricType', () => {
+      for (const code of Object.keys(SPLIT_METRICS_YARDS)) {
+        expect((MetricType as Record<string, string>)[code]).toBe(code);
+      }
+    });
+
+    it('registers every meters split distance in MetricType', () => {
+      for (const code of Object.keys(SPLIT_METRICS_METERS)) {
+        expect((MetricType as Record<string, string>)[code]).toBe(code);
+      }
+    });
+
+    it('includes FLY10_TIME and FLY10M_TIME in MetricType', () => {
+      expect((MetricType as Record<string, string>).FLY10_TIME).toBe('FLY10_TIME');
+      expect((MetricType as Record<string, string>).FLY10M_TIME).toBe('FLY10M_TIME');
+    });
+
+    it('lists every split metric in VALID_METRICS as lower_is_better', () => {
+      const validKeys = new Map(VALID_METRICS.map(m => [m.key, m.metricType]));
+      for (const code of [...Object.keys(SPLIT_METRICS_YARDS), ...Object.keys(SPLIT_METRICS_METERS)]) {
+        expect(validKeys.get(code)).toBe('lower_is_better');
+      }
+      expect(validKeys.get('FLY10M_TIME')).toBe('lower_is_better');
+    });
+  });
+});

--- a/packages/api/services/llm-export-service.ts
+++ b/packages/api/services/llm-export-service.ts
@@ -1,0 +1,771 @@
+/**
+ * LLM Export Service
+ *
+ * Assembles an athlete-centric export designed for paste-into-LLM program design.
+ * V1 scope: demographics, current values, 12-month history, Sprint F-V profile,
+ * active goals, recent wellness, medical/coach notes, metric glossary.
+ * V2 will extract percentile/benchmark logic from report-service.ts and include it here.
+ */
+
+import { db } from '../db';
+import {
+  users,
+  userTeams,
+  teams,
+  measurements,
+  athleteProfiles,
+  organizations,
+  siteMetrics,
+} from '@shared/schema';
+import { goals } from '@shared/schema/tables/gamification';
+import { wellnessResponses } from '@shared/schema/tables/wellness';
+import { sprintFvProfiles } from '@shared/schema/tables/sprint-fv-profiles';
+import { and, desc, eq, gte, inArray } from 'drizzle-orm';
+import {
+  buildMetricExplanationsMap,
+  type MetricExplanation,
+} from '@shared/metric-explanations';
+
+// ---------- Types ----------
+
+export type ExportFormat = 'markdown' | 'json';
+
+export interface AthleteExportData {
+  generatedAt: Date;
+  athlete: {
+    id: string;
+    fullName: string;
+    age: number | null;
+    gender: string | null;
+    graduationYear: number | null;
+    heightIn: number | null;
+    weightLb: number | null;
+    sports: string[];
+    positions: string[];
+    teams: Array<{ name: string; level: string | null; season: string | null }>;
+  };
+  organization: { id: string; name: string } | null;
+  currentSnapshot: Array<{
+    metricCode: string;
+    metricLabel: string;
+    value: number;
+    units: string;
+    date: string;
+  }>;
+  measurementHistory: Record<
+    string,
+    Array<{ date: string; value: number; units: string }>
+  >;
+  sprintFv: {
+    date: string;
+    f0Rel: number | null;
+    v0: number | null;
+    pmaxRel: number | null;
+    fvSlope: number | null;
+    rfPeak: number | null;
+    drf: number | null;
+    fitR2: number | null;
+    classification: string | null;
+    // `gap` and `deltas` are JSONB passthrough from analysisJson. Their
+    // full shape lives in SprintFvAnalysisJson (packages/shared/schema/
+    // tables/sprint-fv-profiles.ts). Typed as unknown here because the
+    // renderer is structure-agnostic: formatAnalysisValue walks the value
+    // as scalar, array, or key=value object regardless of nested shape.
+    gap: unknown;
+    deltas: unknown;
+    trainingRecommendations: string[];
+    notes: string | null;
+  } | null;
+  activeGoals: Array<{
+    metricCode: string;
+    metricLabel: string;
+    goalType: string;
+    baselineValue: number;
+    currentValue: number;
+    targetValue: number;
+    targetDate: string;
+    units: string;
+    notes: string | null;
+  }>;
+  recentWellness: Array<{
+    date: string;
+    submittedAt: string;
+    responses: Record<string, unknown>;
+  }>;
+  notes: { medicalNotes: string | null; coachNotes: string | null };
+  metricGlossary: Record<string, { label: string; units: string; explanation: string }>;
+  warnings: string[];
+}
+
+export interface AthleteLlmExport extends Omit<AthleteExportData, 'generatedAt'> {
+  generatedAt: string;
+}
+
+// ---------- Pure utilities ----------
+
+const EMPTY = '_No data yet._';
+
+/**
+ * Thrown by gatherAthleteExportData when the athlete row disappears between
+ * the route-level existence check and the service's own parallel query.
+ * Routes catch this and translate to 404, not 500.
+ */
+export class AthleteNotFoundError extends Error {
+  constructor(athleteId: string) {
+    super(`Athlete not found: ${athleteId}`);
+    this.name = 'AthleteNotFoundError';
+  }
+}
+
+function escapeCell(v: string): string {
+  return v.replace(/\|/g, '\\|');
+}
+
+/**
+ * Escape markdown inline formatting characters. Use when interpolating a
+ * string into prose/headers wrapped in `*...*` or `_..._` — an unescaped
+ * asterisk or underscore inside the wrapper would close the run of emphasis
+ * early and break the output.
+ */
+function escapeMdInline(v: string): string {
+  return v.replace(/([*_`])/g, '\\$1');
+}
+
+function fmtNum(n: number): string {
+  return Number.isFinite(n) ? String(n) : '—';
+}
+
+function fmtDate(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+// Flattens an F-V analysis value (scalar or small flat object from analysisJson)
+// into a short human-readable form. Avoids surfacing raw JSON braces in the
+// Markdown that a coach reads — LLMs still parse this cleanly.
+function formatAnalysisValue(v: unknown): string {
+  if (v === null || v === undefined) return '—';
+  if (typeof v === 'number') return fmtNum(v);
+  if (typeof v === 'string' || typeof v === 'boolean') return String(v);
+  if (Array.isArray(v)) return v.map(formatAnalysisValue).join(', ');
+  if (typeof v === 'object') {
+    return Object.entries(v as Record<string, unknown>)
+      .map(([k, val]) => `${k}=${formatAnalysisValue(val)}`)
+      .join(', ');
+  }
+  return String(v);
+}
+
+export function filenameFor(fullName: string, format: ExportFormat, date: Date): string {
+  const withoutDiacritics = fullName
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+  // Pipes are stripped *without* replacement so `a|b` becomes `ab`, not `a-b`.
+  // This is different from the generic non-alphanumeric collapse below, which
+  // replaces runs of bad chars with a single dash. Rationale: pipes typically
+  // appear mid-name in bad data (copy-paste artifacts) rather than as word
+  // separators, so concatenation produces a cleaner slug than dash-splitting.
+  // Covered by the "strips non-alphanumeric characters (pipes, slashes)" unit
+  // test — don't remove without updating that contract.
+  const withoutPipes = withoutDiacritics.replace(/\|/g, '');
+  const slugged =
+    withoutPipes
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'athlete';
+  const ext = format === 'markdown' ? 'md' : 'json';
+  return `${slugged}-${fmtDate(date)}.${ext}`;
+}
+
+// ---------- Markdown renderer ----------
+
+const PROMPT_SUGGESTION =
+  '**Prompt suggestion:** Using the data above, design a 6-week off-season training block for this athlete. Prioritize their F-V deficit classification and active goals. Flag any metric where recent values are trending in the wrong direction as a development priority. Return the plan as a week-by-week table with sets, reps, and intent for each session.';
+
+function renderProfileSection(d: AthleteExportData): string {
+  const a = d.athlete;
+  const lines: string[] = ['## Athlete Profile'];
+  const ageStr = a.age != null ? `Age ${a.age}` : 'Age —';
+  const genderStr = a.gender ?? '—';
+  const gradStr = a.graduationYear != null ? `Class of ${a.graduationYear}` : 'Class —';
+  lines.push(`- ${ageStr} · ${genderStr} · ${gradStr}`);
+  const heightStr = a.heightIn != null ? `${a.heightIn} in` : '—';
+  const weightStr = a.weightLb != null ? `${a.weightLb} lb` : '—';
+  lines.push(`- Height: ${heightStr} · Weight: ${weightStr}`);
+  lines.push(`- Sports: ${a.sports.length ? a.sports.join(', ') : '—'}`);
+  lines.push(`- Positions: ${a.positions.length ? a.positions.join(', ') : '—'}`);
+  if (a.teams.length) {
+    const teamStrs = a.teams.map((t) => {
+      const parts = [t.name];
+      if (t.level) parts.push(t.level);
+      if (t.season) parts.push(t.season);
+      return parts.join(' · ');
+    });
+    lines.push(`- Teams: ${teamStrs.join('; ')}`);
+  } else {
+    lines.push('- Teams: —');
+  }
+  return lines.join('\n');
+}
+
+function renderSnapshotSection(d: AthleteExportData): string {
+  const lines: string[] = ['## Current Performance Snapshot'];
+  if (!d.currentSnapshot.length) {
+    lines.push('', EMPTY);
+    return lines.join('\n');
+  }
+  lines.push('', '| Metric | Value | Unit | Date |', '|---|---|---|---|');
+  for (const row of d.currentSnapshot) {
+    lines.push(
+      `| ${escapeCell(row.metricLabel)} | ${fmtNum(row.value)} | ${escapeCell(row.units)} | ${row.date} |`,
+    );
+  }
+  return lines.join('\n');
+}
+
+function renderHistorySection(d: AthleteExportData): string {
+  const lines: string[] = ['## 12-Month Measurement History'];
+  const codes = Object.keys(d.measurementHistory);
+  if (!codes.length) {
+    lines.push('', EMPTY);
+    return lines.join('\n');
+  }
+  for (const code of codes) {
+    const rows = d.measurementHistory[code];
+    if (!rows || !rows.length) continue;
+    const label = d.metricGlossary[code]?.label ?? code;
+    const units = d.metricGlossary[code]?.units ?? rows[0]?.units ?? '';
+    lines.push('', `### ${escapeCell(label)}${units ? ` (${units})` : ''}`);
+    lines.push('| Date | Value |', '|---|---|');
+    for (const r of rows) {
+      lines.push(`| ${r.date} | ${fmtNum(r.value)}${units ? ` ${escapeCell(units)}` : ''} |`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function renderFvSection(d: AthleteExportData): string {
+  const lines: string[] = ['## Sprint Force-Velocity Profile'];
+  const fv = d.sprintFv;
+  if (!fv) {
+    lines.push('', EMPTY);
+    return lines.join('\n');
+  }
+  lines.push('', `*Most recent session: ${fv.date}*`, '');
+  lines.push(`- F0 (relative): ${fv.f0Rel != null ? `${fv.f0Rel} N/kg` : '—'}`);
+  lines.push(`- V0: ${fv.v0 != null ? `${fv.v0} m/s` : '—'}`);
+  lines.push(`- Pmax (relative): ${fv.pmaxRel != null ? `${fv.pmaxRel} W/kg` : '—'}`);
+  lines.push(`- FV slope: ${fv.fvSlope != null ? fv.fvSlope : '—'}`);
+  lines.push(`- RFpeak: ${fv.rfPeak != null ? fv.rfPeak : '—'}`);
+  lines.push(`- DRF: ${fv.drf != null ? fv.drf : '—'}`);
+  if (fv.fitR2 != null) lines.push(`- Model fit (R²): ${fv.fitR2}`);
+  lines.push('', `**Classification:** ${fv.classification ?? '—'}`);
+  if (fv.gap !== null && fv.gap !== undefined) {
+    lines.push(`**F-V imbalance gap:** ${formatAnalysisValue(fv.gap)}`);
+  }
+  if (fv.deltas !== null && fv.deltas !== undefined) {
+    lines.push(`**Deltas vs optimal:** ${formatAnalysisValue(fv.deltas)}`);
+  }
+  if (fv.trainingRecommendations.length) {
+    lines.push('', '**Training recommendations:**');
+    for (const rec of fv.trainingRecommendations) {
+      lines.push(`- ${rec}`);
+    }
+  }
+  if (fv.notes) {
+    lines.push('', `*Notes:* ${escapeMdInline(fv.notes)}`);
+  }
+  return lines.join('\n');
+}
+
+function renderGoalsSection(d: AthleteExportData): string {
+  const lines: string[] = ['## Active Goals'];
+  if (!d.activeGoals.length) {
+    lines.push('', EMPTY);
+    return lines.join('\n');
+  }
+  lines.push('');
+  for (const g of d.activeGoals) {
+    // Units and goalType come from user-configurable metric definitions —
+    // today's values are safe (`s`, `in`, `minimize`) but custom metrics
+    // may allow free-text unit strings. Escape inline so a stray `*` or
+    // `_` can't toggle emphasis across the rest of the section.
+    const units = escapeMdInline(g.units);
+    const goalType = escapeMdInline(g.goalType);
+    const parts = [
+      `${escapeCell(g.metricLabel)}:`,
+      `baseline ${fmtNum(g.baselineValue)} ${units}`,
+      `→ current ${fmtNum(g.currentValue)} ${units}`,
+      `→ target ${fmtNum(g.targetValue)} ${units}`,
+      `by ${g.targetDate}`,
+      `(${goalType})`,
+    ];
+    lines.push(`- ${parts.join(' ')}`);
+    if (g.notes) lines.push(`  - Notes: ${escapeMdInline(g.notes)}`);
+  }
+  return lines.join('\n');
+}
+
+function renderWellnessSection(d: AthleteExportData): string {
+  const lines: string[] = ['## Recent Wellness'];
+  if (!d.recentWellness.length) {
+    lines.push('', EMPTY);
+    return lines.join('\n');
+  }
+  lines.push('', '| Date | Responses |', '|---|---|');
+  for (const w of d.recentWellness) {
+    const summary = Object.entries(w.responses)
+      .map(([k, v]) => `${k}=${formatAnalysisValue(v)}`)
+      .join(', ');
+    lines.push(`| ${w.date} | ${escapeCell(summary)} |`);
+  }
+  return lines.join('\n');
+}
+
+function renderNotesSection(d: AthleteExportData): string {
+  const lines: string[] = ['## Medical & Coach Notes'];
+  const m = d.notes.medicalNotes;
+  const c = d.notes.coachNotes;
+  if (!m && !c) {
+    lines.push('', EMPTY);
+    return lines.join('\n');
+  }
+  lines.push('');
+  // Notes render as list items, not table cells, so a stray `|` would only be
+  // a visual artifact — but `*`, `_`, and backticks in free-text notes would
+  // smuggle unintended emphasis or code-fence toggles into the export. Apply
+  // the inline escape for consistency with the header/H1 fields.
+  lines.push(`- **Medical:** ${m ? escapeMdInline(m) : '_none on file_'}`);
+  lines.push(`- **Coach:** ${c ? escapeMdInline(c) : '_none on file_'}`);
+  return lines.join('\n');
+}
+
+function renderGlossarySection(d: AthleteExportData): string {
+  const lines: string[] = ['## Metric Glossary'];
+  const entries = Object.entries(d.metricGlossary);
+  if (!entries.length) {
+    lines.push('', EMPTY);
+    return lines.join('\n');
+  }
+  lines.push('');
+  for (const [code, g] of entries) {
+    lines.push(`- **${code}** (${g.label}${g.units ? `, ${g.units}` : ''}): ${g.explanation}`);
+  }
+  return lines.join('\n');
+}
+
+export function renderMarkdown(d: AthleteExportData): string {
+  // Display-name fallback: malformed or partially-created user records can
+  // have fullName / firstName / lastName all null, producing an empty
+  // `fullName` in the assembled data. Without this guard, the H1 would be
+  // `# Athlete Performance Export — ` (trailing em-dash), which looks broken
+  // to both coaches and LLMs. `filenameFor` has its own separate fallback.
+  const displayName = d.athlete.fullName.trim() || 'Unknown Athlete';
+  const header = [
+    // Chain escapes: pipe-escape for any later table reuse + inline emphasis
+    // escape so `*`/`_`/`` ` `` in the name don't trigger formatting in the H1.
+    `# Athlete Performance Export — ${escapeMdInline(escapeCell(displayName))}`,
+    `*Generated ${d.generatedAt.toISOString()}${d.organization ? ` · ${escapeMdInline(d.organization.name)}` : ''}*`,
+  ].join('\n');
+
+  const body = [
+    renderProfileSection(d),
+    renderSnapshotSection(d),
+    renderHistorySection(d),
+    renderFvSection(d),
+    renderGoalsSection(d),
+    renderWellnessSection(d),
+    renderNotesSection(d),
+    renderGlossarySection(d),
+  ].join('\n\n');
+
+  const warningsFooter = d.warnings.length
+    ? `\n\n---\n\n**Warnings:** Some data could not be loaded.\n${d.warnings.map((w) => `- ${w}`).join('\n')}`
+    : '';
+
+  const promptFooter = `\n\n---\n\n${PROMPT_SUGGESTION}`;
+
+  return `${header}\n\n${body}${warningsFooter}${promptFooter}`;
+}
+
+// ---------- JSON renderer ----------
+
+export function renderJson(d: AthleteExportData): AthleteLlmExport {
+  return {
+    ...d,
+    generatedAt: d.generatedAt.toISOString(),
+  };
+}
+
+// ---------- Data gatherer ----------
+
+async function loadMetricGlossary(
+  codes: string[],
+): Promise<Record<string, { label: string; units: string; explanation: string }>> {
+  if (!codes.length) return {};
+  const rows = await db
+    .select({
+      code: siteMetrics.code,
+      label: siteMetrics.label,
+      unit: siteMetrics.unit,
+      whatItMeasures: siteMetrics.whatItMeasures,
+      shortDescription: siteMetrics.shortDescription,
+    })
+    .from(siteMetrics)
+    .where(inArray(siteMetrics.code, codes));
+
+  const explanationMap: Record<string, MetricExplanation> =
+    buildMetricExplanationsMap(codes);
+
+  const siteCodes = new Set(rows.map((r) => r.code));
+  const out: Record<string, { label: string; units: string; explanation: string }> = {};
+  for (const r of rows) {
+    const expl = explanationMap[r.code];
+    out[r.code] = {
+      label: r.label ?? expl?.title ?? r.code,
+      units: r.unit ?? expl?.unitNote ?? '',
+      explanation:
+        r.whatItMeasures ??
+        r.shortDescription ??
+        expl?.whatItMeasures ??
+        'No explanation available.',
+    };
+  }
+  // Codes absent from site_metrics still deserve a glossary entry from static explanations.
+  for (const code of codes) {
+    if (siteCodes.has(code)) continue;
+    const expl = explanationMap[code];
+    if (!expl) continue;
+    out[code] = {
+      label: expl.title ?? code,
+      units: expl.unitNote ?? '',
+      explanation: expl.whatItMeasures ?? 'No explanation available.',
+    };
+  }
+  return out;
+}
+
+// Upper bound on measurements returned in a single export. Prevents a
+// memory/markdown-size spike for high-volume athletes (weekly testing across
+// many metrics could otherwise return 500+ rows).
+const MEASUREMENT_HISTORY_LIMIT = 1000;
+
+export async function gatherAthleteExportData(
+  athleteId: string,
+  organizationId: string | null,
+  opts: { monthsBack?: number } = {},
+): Promise<AthleteExportData> {
+  const monthsBack = opts.monthsBack ?? 12;
+  // Calendar-month arithmetic in UTC, without the month-end rollover bug.
+  // All Date arithmetic below uses UTC methods to match fmtDate's UTC output.
+  // On a non-UTC server the local-TZ variant would silently produce a cutoff
+  // one day off near midnight.
+  //
+  // Naïve `setUTCMonth(getUTCMonth() - 12)` on Mar 31 would land on Apr 1
+  // (Feb 31 → Mar 3 in a non-leap year). We set day to 1 before stepping
+  // back months, then clamp the original day to the target month's length.
+  const now = new Date();
+  const historyCutoff = new Date(now);
+  historyCutoff.setUTCDate(1);
+  historyCutoff.setUTCMonth(historyCutoff.getUTCMonth() - monthsBack);
+  const daysInTargetMonth = new Date(
+    Date.UTC(
+      historyCutoff.getUTCFullYear(),
+      historyCutoff.getUTCMonth() + 1,
+      0,
+    ),
+  ).getUTCDate();
+  historyCutoff.setUTCDate(Math.min(now.getUTCDate(), daysInTargetMonth));
+  const cutoffStr = fmtDate(historyCutoff);
+
+  const warnings: string[] = [];
+
+  const safe = async <T>(label: string, fn: () => Promise<T>, fallback: T): Promise<T> => {
+    try {
+      return await fn();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(`[llm-export] ${label} failed`, err);
+      warnings.push(`${label} unavailable`);
+      return fallback;
+    }
+  };
+
+  const [
+    athleteRow,
+    teamRows,
+    orgRow,
+    measurementRows,
+    fvRow,
+    goalRows,
+    wellnessRows,
+    profileRow,
+  ] = await Promise.all([
+    db.select().from(users).where(eq(users.id, athleteId)).limit(1).then((r) => r[0] ?? null),
+    safe(
+      'Team memberships',
+      () =>
+        db
+          .select({
+            name: teams.name,
+            level: teams.level,
+            season: userTeams.season,
+          })
+          .from(userTeams)
+          .innerJoin(teams, eq(teams.id, userTeams.teamId))
+          .where(and(eq(userTeams.userId, athleteId), eq(userTeams.isActive, true))),
+      [] as Array<{ name: string; level: string | null; season: string | null }>,
+    ),
+    organizationId
+      ? db
+          .select({ id: organizations.id, name: organizations.name })
+          .from(organizations)
+          .where(eq(organizations.id, organizationId))
+          .limit(1)
+          .then((r) => r[0] ?? null)
+      : Promise.resolve(null),
+    safe(
+      'Measurement history',
+      () => {
+        // When organizationId is null (site admin viewing an unaffiliated athlete),
+        // scope by athlete identity alone. For all other callers we keep multi-tenant
+        // isolation by requiring org match.
+        const conditions = [
+          eq(measurements.userId, athleteId),
+          gte(measurements.date, cutoffStr),
+        ];
+        if (organizationId) {
+          conditions.push(eq(measurements.organizationId, organizationId));
+        }
+        // Cap the 12-month window: an athlete testing ~weekly across 8 metrics
+        // would produce ~400 rows. 1000 gives plenty of headroom while keeping
+        // the export bounded in both memory and Markdown size.
+        return db
+          .select()
+          .from(measurements)
+          .where(and(...conditions))
+          .orderBy(desc(measurements.date))
+          .limit(MEASUREMENT_HISTORY_LIMIT);
+      },
+      [] as Array<typeof measurements.$inferSelect>,
+    ),
+    safe(
+      'Sprint F-V profile',
+      () => {
+        // Multi-org athletes can have F-V sessions recorded under multiple orgs.
+        // Scope to the caller's org when known so Coach A (Org 1) doesn't see
+        // sessions entered by Coach B (Org 2).
+        const conditions = [eq(sprintFvProfiles.userId, athleteId)];
+        if (organizationId) {
+          conditions.push(eq(sprintFvProfiles.organizationId, organizationId));
+        }
+        return db
+          .select()
+          .from(sprintFvProfiles)
+          .where(and(...conditions))
+          .orderBy(desc(sprintFvProfiles.date))
+          .limit(1)
+          .then((r) => r[0] ?? null);
+      },
+      null,
+    ),
+    safe(
+      'Active goals',
+      () =>
+        // goals has no organizationId column — goals belong to the athlete's
+        // account, not a particular org. Route-layer access control gates
+        // whether the caller can see this athlete at all.
+        db
+          .select()
+          .from(goals)
+          .where(and(eq(goals.userId, athleteId), eq(goals.status, 'active')))
+          .orderBy(desc(goals.targetDate)),
+      [] as Array<typeof goals.$inferSelect>,
+    ),
+    safe(
+      'Recent wellness responses',
+      () => {
+        // wellness_responses.organizationId is a historical stamp (notNull).
+        // Scope so only responses entered under the caller's org leak into
+        // the export for multi-org athletes.
+        const conditions = [eq(wellnessResponses.userId, athleteId)];
+        if (organizationId) {
+          conditions.push(eq(wellnessResponses.organizationId, organizationId));
+        }
+        return db
+          .select()
+          .from(wellnessResponses)
+          .where(and(...conditions))
+          .orderBy(desc(wellnessResponses.submittedAt))
+          .limit(10);
+      },
+      [] as Array<typeof wellnessResponses.$inferSelect>,
+    ),
+    safe(
+      'Athlete profile',
+      () =>
+        db
+          .select()
+          .from(athleteProfiles)
+          .where(eq(athleteProfiles.userId, athleteId))
+          .limit(1)
+          .then((r) => r[0] ?? null),
+      null,
+    ),
+  ]);
+
+  if (!athleteRow) {
+    throw new AthleteNotFoundError(athleteId);
+  }
+
+  // Group measurements into history + current snapshot (most recent per metric)
+  const history: Record<string, Array<{ date: string; value: number; units: string }>> = {};
+  for (const m of measurementRows) {
+    const arr = history[m.metric] ?? [];
+    arr.push({
+      date: m.date,
+      value: parseFloat(m.value),
+      units: m.units ?? '',
+    });
+    history[m.metric] = arr;
+  }
+
+  const metricCodes = Object.keys(history);
+  const glossary = await safe(
+    'Metric glossary',
+    () => loadMetricGlossary(metricCodes),
+    {} as Record<string, { label: string; units: string; explanation: string }>,
+  );
+
+  const snapshot = metricCodes
+    .map((code) => {
+      const rows = history[code];
+      if (!rows?.length) return null;
+      const g = glossary[code];
+      return {
+        metricCode: code,
+        metricLabel: g?.label ?? code,
+        value: rows[0].value,
+        units: g?.units ?? rows[0].units ?? '',
+        date: rows[0].date,
+      };
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
+
+  // Sprint F-V parsing (all decimals are strings coming out of drizzle).
+  //
+  // The `analysisJson.classification.classification` double-access is
+  // intentional and matches the schema in
+  // packages/shared/schema/tables/sprint-fv-profiles.ts:
+  //   analysisJson: {
+  //     classification: {                          <-- the category group
+  //       classification: 'force-deficit' | ...    <-- the verdict
+  //       trainingRecommendations: [...],
+  //       imbalancePercent, dominantQuality, explanation,
+  //     },
+  //     optimalGap, accelerationProfile, powerProfile, deltas?,
+  //   }
+  // The outer `classification` is the *group of classification outputs*;
+  // the inner `classification` is the specific verdict string. Don't flatten.
+  const fv = fvRow
+    ? {
+        date: fvRow.date,
+        f0Rel: fvRow.f0Rel != null ? parseFloat(fvRow.f0Rel) : null,
+        v0: fvRow.v0 != null ? parseFloat(fvRow.v0) : null,
+        pmaxRel: fvRow.pmaxRel != null ? parseFloat(fvRow.pmaxRel) : null,
+        fvSlope: fvRow.fvSlope != null ? parseFloat(fvRow.fvSlope) : null,
+        rfPeak: fvRow.rfPeak != null ? parseFloat(fvRow.rfPeak) : null,
+        drf: fvRow.drf != null ? parseFloat(fvRow.drf) : null,
+        fitR2: fvRow.fitR2 != null ? parseFloat(fvRow.fitR2) : null,
+        classification: fvRow.analysisJson?.classification?.classification ?? null,
+        gap: fvRow.analysisJson?.optimalGap ?? null,
+        deltas: fvRow.analysisJson?.deltas ?? null,
+        trainingRecommendations:
+          fvRow.analysisJson?.classification?.trainingRecommendations ?? [],
+        notes: fvRow.notes ?? null,
+      }
+    : null;
+
+  const activeGoals = goalRows.map((g) => ({
+    metricCode: g.metric,
+    metricLabel: glossary[g.metric]?.label ?? g.metric,
+    goalType: g.goalType,
+    baselineValue: parseFloat(g.baselineValue),
+    currentValue: parseFloat(g.currentValue),
+    targetValue: parseFloat(g.targetValue),
+    targetDate: g.targetDate,
+    units: glossary[g.metric]?.units ?? '',
+    notes: g.notes ?? null,
+  }));
+
+  const recentWellness = wellnessRows.map((w) => ({
+    date: w.date,
+    submittedAt: w.submittedAt.toISOString(),
+    responses: (w.responses as Record<string, unknown>) ?? {},
+  }));
+
+  // birthYear → age (matches report-service pattern)
+  let age: number | null = null;
+  if (athleteRow.birthYear) {
+    age = new Date().getFullYear() - athleteRow.birthYear;
+  } else if (athleteRow.birthDate) {
+    const bd = new Date(athleteRow.birthDate);
+    age = Math.floor((Date.now() - bd.getTime()) / (365.25 * 24 * 3600 * 1000));
+  }
+
+  return {
+    generatedAt: new Date(),
+    athlete: {
+      id: athleteRow.id,
+      fullName: athleteRow.fullName ?? `${athleteRow.firstName ?? ''} ${athleteRow.lastName ?? ''}`.trim(),
+      age,
+      gender: athleteRow.gender ?? null,
+      graduationYear: athleteRow.graduationYear ?? null,
+      heightIn: athleteRow.height != null ? parseFloat(String(athleteRow.height)) : null,
+      weightLb: athleteRow.weight != null ? parseFloat(String(athleteRow.weight)) : null,
+      sports: Array.isArray(athleteRow.sports) ? athleteRow.sports : [],
+      positions: Array.isArray(athleteRow.positions) ? athleteRow.positions : [],
+      teams: teamRows,
+    },
+    organization: orgRow,
+    currentSnapshot: snapshot,
+    measurementHistory: history,
+    sprintFv: fv,
+    activeGoals,
+    recentWellness,
+    notes: {
+      medicalNotes: profileRow?.medicalNotes ?? null,
+      coachNotes: profileRow?.coachNotes ?? null,
+    },
+    metricGlossary: glossary,
+    warnings,
+  };
+}
+
+// ---------- Orchestrator ----------
+
+export async function buildAthleteLlmExport(
+  athleteId: string,
+  format: ExportFormat,
+  opts: { organizationId: string | null; monthsBack?: number },
+): Promise<{ content: string; filename: string; contentType: string }> {
+  const data = await gatherAthleteExportData(athleteId, opts.organizationId, {
+    monthsBack: opts.monthsBack,
+  });
+  const filename = filenameFor(data.athlete.fullName, format, data.generatedAt);
+
+  if (format === 'markdown') {
+    return {
+      content: renderMarkdown(data),
+      filename,
+      contentType: 'text/markdown; charset=utf-8',
+    };
+  }
+  return {
+    content: JSON.stringify(renderJson(data), null, 2),
+    filename,
+    contentType: 'application/json; charset=utf-8',
+  };
+}

--- a/packages/api/services/parsers/__tests__/dashr-csv-parser.test.ts
+++ b/packages/api/services/parsers/__tests__/dashr-csv-parser.test.ts
@@ -466,3 +466,77 @@ describe('FLY10_TIME derivation', () => {
     expect(fly10).toBeUndefined();
   });
 });
+
+// ============================================================================
+// Metric (meters) units support — 10/20/30/40m protocol
+// ============================================================================
+
+describe('DashrCsvParser — Metric units', () => {
+  it('maps a 40m Dash with Units=Metric to DASH_40M', () => {
+    // 40m dash with splits at 10, 20, 30 and final at 40 — all in meters
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,John,,Doe,Dash,,Metric,,1.850000,10.000000,,3.200000,20.000000,,4.550000,30.000000,,,,,,,,,,,5.800000,40.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const athlete = result.athletes[0];
+    expect(athlete).toBeDefined();
+
+    const dash = athlete.drills.find(d => d.metric === 'DASH_40M');
+    expect(dash).toBeDefined();
+    expect(dash!.value).toBe(5.8);
+
+    // Splits should also be in DASH_*M codes
+    const splitMetrics = (dash!.splits || []).map(s => s.metric).sort();
+    expect(splitMetrics).toEqual(['DASH_10M', 'DASH_20M', 'DASH_30M']);
+  });
+
+  it('maps shorter metric dashes (10m, 20m, 30m) correctly', () => {
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,Alex,,Reed,Dash,,Metric,,,,,,,,,,,,,,,,,,,,1.850000,10.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+      '01/01/2025 10:01:00,Alex,,Reed,Dash,,Metric,,,,,,,,,,,,,,,,,,,,3.200000,20.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+      '01/01/2025 10:02:00,Alex,,Reed,Dash,,Metric,,,,,,,,,,,,,,,,,,,,4.550000,30.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const metrics = result.athletes[0].drills.map(d => d.metric).sort();
+    expect(metrics).toContain('DASH_10M');
+    expect(metrics).toContain('DASH_20M');
+    expect(metrics).toContain('DASH_30M');
+    expect(metrics).not.toContain('DASH_10YD');
+  });
+
+  it('maps Flying 10m with Units=Metric to FLY10M_TIME', () => {
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,John,,Doe,Flying,,Metric,20.000000,,,,,,,,,,,,,,,,,,,1.150000,10.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const fly = result.athletes[0].drills.find(d => d.metric === 'FLY10M_TIME');
+    expect(fly).toBeDefined();
+    expect(fly!.value).toBe(1.15);
+  });
+
+  it('derives FLY10M_TIME from a 40m Dash 20m→30m segment', () => {
+    // 40m dash with 20m=3.20, 30m=4.55 → FLY10M = 1.35
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,John,,Doe,Dash,,Metric,,1.850000,10.000000,,3.200000,20.000000,,4.550000,30.000000,,,,,,,,,,,5.800000,40.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const fly = result.athletes[0].drills.find(d => d.metric === 'FLY10M_TIME');
+    expect(fly).toBeDefined();
+    // 4.55 - 3.20 = 1.35
+    expect(fly!.value).toBeCloseTo(1.35, 3);
+    // Metric unit system must not leak into yards fly10
+    const fly10Yd = result.athletes[0].drills.find(d => d.metric === 'FLY10_TIME');
+    expect(fly10Yd).toBeUndefined();
+  });
+
+  it('keeps Imperial-unit rows on the yards-metric path', () => {
+    // Sanity check: Metric path must not accidentally catch Imperial rows
+    const csv = makeCsv([
+      '01/01/2025 10:00:00,John,,Doe,Dash,,Imperial,,,,,,,,,,,,,,,,,,,,5.200000,40.000000,,,,,,,,,,,,,,,,,,,,,,,,,,,,,',
+    ]);
+    const result = parser.parse(csv);
+    const metrics = result.athletes[0].drills.map(d => d.metric);
+    expect(metrics).toContain('DASH_40YD');
+    expect(metrics).not.toContain('DASH_40M');
+  });
+});

--- a/packages/api/services/parsers/dashr-csv-parser.ts
+++ b/packages/api/services/parsers/dashr-csv-parser.ts
@@ -27,7 +27,12 @@ const OUTLIER_RANGES: Record<string, { min: number; max: number; label: string }
   DASH_20YD: { min: 2.0, max: 6.0, label: '20yd dash' },
   DASH_30YD: { min: 3.0, max: 8.0, label: '30yd dash' },
   DASH_40YD: { min: 4.0, max: 10.0, label: '40yd dash' },
+  DASH_10M: { min: 1.0, max: 4.0, label: '10m dash' },
+  DASH_20M: { min: 2.0, max: 6.0, label: '20m dash' },
+  DASH_30M: { min: 3.0, max: 8.0, label: '30m dash' },
+  DASH_40M: { min: 4.0, max: 10.0, label: '40m dash' },
   FLY10_TIME: { min: 0.8, max: 3.0, label: '10yd fly' },
+  FLY10M_TIME: { min: 0.8, max: 3.0, label: '10m fly' },
   AGILITY_505: { min: 1.5, max: 5.0, label: '505 agility' },
   AGILITY_505_L: { min: 1.5, max: 5.0, label: '505 agility (L)' },
   AGILITY_505_R: { min: 1.5, max: 5.0, label: '505 agility (R)' },
@@ -36,6 +41,15 @@ const OUTLIER_RANGES: Record<string, { min: number; max: number; label: string }
   AGILITY_5105_R: { min: 3.5, max: 8.0, label: '5-10-5 agility (R)' },
   RSI: { min: 0.1, max: 4.0, label: 'RSI' },
 };
+
+/**
+ * Returns the unit suffix to use for dash/fly metric codes based on the row's Units column.
+ * DashR exports "Imperial" or "Metric" in this field.
+ */
+function getDistanceUnit(row: DashrRow): 'YD' | 'M' {
+  const units = (row['Units'] || '').trim().toLowerCase();
+  return units === 'metric' ? 'M' : 'YD';
+}
 
 interface DashrRow {
   [key: string]: string;
@@ -173,22 +187,24 @@ function mapDrillType(row: DashrRow): string | null {
   const type = (row['Type'] || '').trim();
   const finalDist = parseFloat_(row['Final Distance']);
   const direction = (row['Direction'] || '').trim().toUpperCase();
+  const unit = getDistanceUnit(row);
 
   switch (type) {
     case 'Dash': {
-      // Map based on final distance — only known metric codes
-      if (finalDist === 10) return MetricType.DASH_10YD;
-      if (finalDist === 20) return MetricType.DASH_20YD;
-      if (finalDist === 30) return MetricType.DASH_30YD;
-      if (finalDist === 40) return MetricType.DASH_40YD;
+      // Map based on final distance — only known metric codes.
+      // Unit suffix (YD vs M) is controlled by the row's Units column.
+      if (finalDist === 10) return unit === 'M' ? MetricType.DASH_10M : MetricType.DASH_10YD;
+      if (finalDist === 20) return unit === 'M' ? MetricType.DASH_20M : MetricType.DASH_20YD;
+      if (finalDist === 30) return unit === 'M' ? MetricType.DASH_30M : MetricType.DASH_30YD;
+      if (finalDist === 40) return unit === 'M' ? MetricType.DASH_40M : MetricType.DASH_40YD;
       // Unknown dash distance — return null so it's skipped with a warning,
       // rather than creating a non-standard metric code in the database.
       return null;
     }
 
     case 'Flying': {
-      // Flying sprints: map to FLY10_TIME when Final Distance = 10
-      if (finalDist === 10) return MetricType.FLY10_TIME;
+      // Flying sprints: map to FLY10_TIME / FLY10M_TIME when Final Distance = 10
+      if (finalDist === 10) return unit === 'M' ? MetricType.FLY10M_TIME : MetricType.FLY10_TIME;
       // Other flying distances aren't standard metrics
       return null;
     }
@@ -220,12 +236,21 @@ function mapDrillType(row: DashrRow): string | null {
  */
 function extractSplits(row: DashrRow): ParsedSplit[] {
   const splits: ParsedSplit[] = [];
+  const unit = getDistanceUnit(row);
+
+  // NOTE: metric codes are built by template literal below (`DASH_${dist}${unit}`).
+  // Non-standard distances (e.g. a 15m split from an unusual DashR export) will
+  // silently produce metric codes that don't exist in site_metrics — they pass
+  // through to the measurements table (which has no FK on `metric`) but are
+  // orphaned from org-level enablement. This is pre-existing behaviour for the
+  // yards path and is retained for meters; if future exports ship unusual
+  // distances, validate against a known-code allowlist here.
 
   // Split 1: uses "Split Time 1" / "Split Distance 1"
   const split1Time = parseFloat_(row['Split Time 1']);
   const split1Dist = parseFloat_(row['Split Distance 1']);
   if (split1Time && split1Time > 0 && split1Dist && split1Dist > 0) {
-    const metric = `DASH_${split1Dist}YD`;
+    const metric = `DASH_${split1Dist}${unit}`;
     splits.push({ metric, value: split1Time, units: 's' });
   }
 
@@ -234,7 +259,7 @@ function extractSplits(row: DashrRow): ParsedSplit[] {
     const time = parseFloat_(row[`Start Time ${i}`]);
     const dist = parseFloat_(row[`Split Distance ${i}`]);
     if (time && time > 0 && dist && dist > 0) {
-      const metric = `DASH_${dist}YD`;
+      const metric = `DASH_${dist}${unit}`;
       splits.push({ metric, value: time, units: 's' });
     }
   }
@@ -273,15 +298,24 @@ function checkOutlier(metric: string, value: number): string | null {
 }
 
 /**
- * Derive FLY10_TIME from an athlete's dash drill splits.
+ * Derive FLY10_TIME / FLY10M_TIME from an athlete's dash drill splits.
  *
- * FLY10 = time at 30yd - time at 20yd (the "flying 10" segment at full speed).
- * Only derives when the athlete has no direct FLY10_TIME measurement.
- * When multiple candidates exist, picks the fastest (lowest) value.
+ * FLY10 = time at 30(yd|m) − time at 20(yd|m) — the "flying 10" segment
+ * after initial acceleration. A separate derivation runs per unit system;
+ * yards dashes produce FLY10_TIME, meters dashes produce FLY10M_TIME.
+ * When multiple candidates exist in the same unit, picks the fastest.
  */
-function deriveFly10ForAthlete(drills: ParsedDrillResult[]): ParsedDrillResult | null {
-  // Skip if athlete already has a direct FLY10_TIME
-  if (drills.some(d => d.metric === MetricType.FLY10_TIME)) return null;
+function deriveFly10ForAthlete(
+  drills: ParsedDrillResult[],
+  unit: 'YD' | 'M',
+): ParsedDrillResult | null {
+  const flyMetric = unit === 'M' ? MetricType.FLY10M_TIME : MetricType.FLY10_TIME;
+  const dash20 = unit === 'M' ? 'DASH_20M' : 'DASH_20YD';
+  const dash30 = unit === 'M' ? 'DASH_30M' : 'DASH_30YD';
+  const dash40 = unit === 'M' ? 'DASH_40M' : 'DASH_40YD';
+
+  // Skip if athlete already has a direct measurement in this unit system
+  if (drills.some(d => d.metric === flyMetric)) return null;
 
   const candidates: { value: number; source: string }[] = [];
 
@@ -292,22 +326,22 @@ function deriveFly10ForAthlete(drills: ParsedDrillResult[]): ParsedDrillResult |
     let time30: number | undefined;
     let source: string | undefined;
 
-    if (drill.metric === 'DASH_30YD') {
-      // 30yd dash: FLY10 = finalTime (30yd) - split at 20yd
-      const split20 = drill.splits.find(s => s.metric === 'DASH_20YD');
+    if (drill.metric === dash30) {
+      // 30(yd|m) dash: FLY10 = finalTime − split at 20(yd|m)
+      const split20 = drill.splits.find(s => s.metric === dash20);
       if (split20) {
         time20 = split20.value;
         time30 = drill.value;
-        source = 'DASH_30YD';
+        source = dash30;
       }
-    } else if (drill.metric === 'DASH_40YD') {
-      // 40yd dash: FLY10 = split at 30yd - split at 20yd
-      const split20 = drill.splits.find(s => s.metric === 'DASH_20YD');
-      const split30 = drill.splits.find(s => s.metric === 'DASH_30YD');
+    } else if (drill.metric === dash40) {
+      // 40(yd|m) dash: FLY10 = split at 30(yd|m) − split at 20(yd|m)
+      const split20 = drill.splits.find(s => s.metric === dash20);
+      const split30 = drill.splits.find(s => s.metric === dash30);
       if (split20 && split30) {
         time20 = split20.value;
         time30 = split30.value;
-        source = 'DASH_40YD';
+        source = dash40;
       }
     }
 
@@ -323,10 +357,10 @@ function deriveFly10ForAthlete(drills: ParsedDrillResult[]): ParsedDrillResult |
 
   // Pick fastest (lowest) FLY10
   const best = candidates.reduce((a, b) => (a.value <= b.value ? a : b));
-  const outlierReason = checkOutlier(MetricType.FLY10_TIME, best.value);
+  const outlierReason = checkOutlier(flyMetric, best.value);
 
   return {
-    metric: MetricType.FLY10_TIME,
+    metric: flyMetric,
     value: best.value,
     units: 's',
     derivedFrom: `${best.source} splits`,
@@ -495,12 +529,14 @@ export class DashrCsvParser implements DeviceImportParser {
       athleteMap.get(key)!.drills.push(drill);
     }
 
-    // Derive FLY10_TIME from dash splits when no direct measurement exists
+    // Derive FLY10_TIME / FLY10M_TIME from dash splits when no direct
+    // measurement exists. Each unit system is evaluated independently:
+    // an athlete with both yards dashes and a metric dash gets both derived.
     for (const [, athlete] of athleteMap) {
-      const fly10 = deriveFly10ForAthlete(athlete.drills);
-      if (fly10) {
-        athlete.drills.push(fly10);
-      }
+      const fly10Yd = deriveFly10ForAthlete(athlete.drills, 'YD');
+      if (fly10Yd) athlete.drills.push(fly10Yd);
+      const fly10M = deriveFly10ForAthlete(athlete.drills, 'M');
+      if (fly10M) athlete.drills.push(fly10M);
     }
 
     const athletes = Array.from(athleteMap.values());

--- a/packages/api/services/sprint-fv-service.ts
+++ b/packages/api/services/sprint-fv-service.ts
@@ -19,15 +19,32 @@ import { computeFvProfile } from './sprint-fv-computation';
 import { classifyProfile, computeOptimalGap, computeDeltas, analyzeAcceleration, analyzePower, validateParameters } from './sprint-fv-analysis';
 import type { SprintFvAnalysisJson } from '@shared/schema/tables/sprint-fv-profiles';
 
-// Hardcoded split metric codes — maps metric code to distance in the code's unit
-const SPLIT_METRICS: Record<string, number> = {
-  'DASH_5YD': 5,
-  'DASH_10YD': 10,
-  'DASH_20YD': 20,
-  'DASH_30YD': 30,
-};
+/**
+ * Split-metric code maps — indexed by distance unit.
+ *
+ * The Sprint F-V protocol uses 10/20/30/40 splits in either yards or meters.
+ * 5-yard splits are intentionally excluded: they sit in the region where
+ * start-protocol timing lag dominates, and their information is already
+ * implicit in the model's v(0)=0 assumption plus the 10y split.
+ */
+export const SPLIT_METRICS_YARDS = {
+  DASH_10YD: 10,
+  DASH_20YD: 20,
+  DASH_30YD: 30,
+  DASH_40YD: 40,
+} as const;
 
-const SPLIT_METRIC_CODES = Object.keys(SPLIT_METRICS);
+export const SPLIT_METRICS_METERS = {
+  DASH_10M: 10,
+  DASH_20M: 20,
+  DASH_30M: 30,
+  DASH_40M: 40,
+} as const;
+
+const SPLIT_METRIC_CODES: string[] = [
+  ...Object.keys(SPLIT_METRICS_YARDS),
+  ...Object.keys(SPLIT_METRICS_METERS),
+];
 const YARDS_TO_METERS = 0.9144;
 const MIN_SPLITS_REQUIRED = 3;
 
@@ -61,6 +78,94 @@ export class SprintFvValidationError extends Error {
     super(message);
     this.name = 'SprintFvValidationError';
   }
+}
+
+/**
+ * Minimal shape of a measurement row consumed by the split resolver.
+ * Keeping this narrower than the full drizzle row lets the algorithm be
+ * unit-tested without standing up a database.
+ */
+export interface SplitMeasurementInput {
+  id: string;
+  metric: string;
+  value: string;
+}
+
+export interface ResolvedSplits {
+  distanceUnit: 'yards' | 'meters';
+  splitTimes: Record<string, number>;
+  usedMeasurementIds: Record<string, string>;
+}
+
+/**
+ * Collapse a list of split measurements into a single session, picking the
+ * fastest time per distance and resolving the distance unit.
+ *
+ * Resolution rules:
+ *   - If ≥3 yards splits → yards
+ *   - Else if ≥3 meters splits → meters
+ *   - If BOTH have ≥3 → mixed-unit error (cannot silently pick one)
+ *   - Else → insufficient-splits error
+ */
+export function resolveSplitsFromMeasurements(
+  rows: readonly SplitMeasurementInput[],
+): ResolvedSplits {
+  const yardsSplits: Record<string, number> = {};
+  const yardsIds: Record<string, string> = {};
+  const metersSplits: Record<string, number> = {};
+  const metersIds: Record<string, string> = {};
+
+  for (const m of rows) {
+    const time = parseFloat(m.value);
+    if (!isFinite(time) || time <= 0) continue;
+
+    const yardsDistance = (SPLIT_METRICS_YARDS as Record<string, number>)[m.metric];
+    if (yardsDistance !== undefined) {
+      const key = String(yardsDistance);
+      if (!(key in yardsSplits) || time < yardsSplits[key]) {
+        yardsSplits[key] = time;
+        yardsIds[key] = m.id;
+      }
+      continue;
+    }
+
+    const metersDistance = (SPLIT_METRICS_METERS as Record<string, number>)[m.metric];
+    if (metersDistance !== undefined) {
+      const key = String(metersDistance);
+      if (!(key in metersSplits) || time < metersSplits[key]) {
+        metersSplits[key] = time;
+        metersIds[key] = m.id;
+      }
+    }
+  }
+
+  const yardsCount = Object.keys(yardsSplits).length;
+  const metersCount = Object.keys(metersSplits).length;
+
+  if (yardsCount >= MIN_SPLITS_REQUIRED && metersCount >= MIN_SPLITS_REQUIRED) {
+    const yardsList = Object.entries(yardsIds)
+      .map(([d, id]) => `DASH_${d}YD (${id})`)
+      .join(', ');
+    const metersList = Object.entries(metersIds)
+      .map(([d, id]) => `DASH_${d}M (${id})`)
+      .join(', ');
+    throw new SprintFvValidationError(
+      'Mixed yards and meters splits found for this athlete on this date. Sprint F-V profiles must use a single distance unit — please remove the stray measurements and try again. ' +
+        `Yards splits used: ${yardsList}. Meters splits used: ${metersList}.`,
+    );
+  }
+
+  if (yardsCount >= MIN_SPLITS_REQUIRED) {
+    return { distanceUnit: 'yards', splitTimes: yardsSplits, usedMeasurementIds: yardsIds };
+  }
+  if (metersCount >= MIN_SPLITS_REQUIRED) {
+    return { distanceUnit: 'meters', splitTimes: metersSplits, usedMeasurementIds: metersIds };
+  }
+
+  const best = Math.max(yardsCount, metersCount);
+  throw new SprintFvValidationError(
+    `Insufficient unique splits: found ${best} distinct distances, need at least ${MIN_SPLITS_REQUIRED}`,
+  );
 }
 
 export interface EligibleSession {
@@ -217,32 +322,11 @@ export class SprintFvService {
       }
     }
 
-    // 2. Build split times map — pick fastest time per distance (handles duplicate trials)
-    const splitTimes: Record<string, number> = {};
-    const usedMeasurementIds: Record<string, string> = {};
-    for (const m of splitMeasurements) {
-      const distance = SPLIT_METRICS[m.metric];
-      if (distance !== undefined) {
-        const time = parseFloat(m.value);
-        if (!isFinite(time) || time <= 0) continue;
-        const key = String(distance);
-        if (!(key in splitTimes) || time < splitTimes[key]) {
-          splitTimes[key] = time;
-          usedMeasurementIds[key] = m.id;
-        }
-      }
-    }
-
-    // 2b. Validate deduplicated split count (duplicates for same distance are collapsed above)
-    const uniqueSplitCount = Object.keys(splitTimes).length;
-    if (uniqueSplitCount < MIN_SPLITS_REQUIRED) {
-      throw new SprintFvValidationError(
-        `Insufficient unique splits: found ${uniqueSplitCount} distinct distances, need at least ${MIN_SPLITS_REQUIRED}`
-      );
-    }
-
-    // 3. Determine distance unit (all split metrics are in yards based on code names)
-    const distanceUnit = 'yards' as const;
+    // 2. Resolve splits — pick fastest per distance, determine yards vs meters unit,
+    // and reject mixed-unit sessions.
+    const { distanceUnit, splitTimes, usedMeasurementIds } = resolveSplitsFromMeasurements(
+      splitMeasurements.map(m => ({ id: m.id, metric: m.metric, value: m.value })),
+    );
 
     // 4. Get body mass
     let bodyMassKg: number;
@@ -309,9 +393,13 @@ export class SprintFvService {
       date = firstM.date;
     }
 
-    // 7. Compute sprint distance in meters for analysis
+    // 7. Compute sprint distance in meters for analysis.
+    // splitTimes keys are raw distances in the session's native unit, so meters
+    // sessions already have meter-valued keys and must not be re-converted.
     const maxDistance = Math.max(...Object.keys(splitTimes).map(Number));
-    const sprintDistanceM = maxDistance * YARDS_TO_METERS;
+    const sprintDistanceM = distanceUnit === 'meters'
+      ? maxDistance
+      : maxDistance * YARDS_TO_METERS;
 
     // 8. Run analysis engine
     const classification = classifyProfile(computed.f0Rel, computed.v0, sprintDistanceM);

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -365,7 +365,12 @@ export interface IStorage {
 
   // Site Settings (Global Settings)
   getSiteSettings(): Promise<SiteSettings | undefined>;
-  updateSiteSettings(settings: { aiModel: string; updatedBy: string | null }): Promise<SiteSettings>;
+  updateSiteSettings(settings: {
+    aiModel?: string;
+    wellnessModuleEnabled?: boolean;
+    sprintFvEnabled?: boolean;
+    updatedBy: string | null;
+  }): Promise<SiteSettings>;
 
   // Reports
   getReport(id: string): Promise<Report | undefined>;
@@ -5494,7 +5499,12 @@ export class DatabaseStorage implements IStorage {
     return settings || undefined;
   }
 
-  async updateSiteSettings(settings: { aiModel?: string; wellnessModuleEnabled?: boolean; updatedBy: string | null }): Promise<SiteSettings> {
+  async updateSiteSettings(settings: {
+    aiModel?: string;
+    wellnessModuleEnabled?: boolean;
+    sprintFvEnabled?: boolean;
+    updatedBy: string | null;
+  }): Promise<SiteSettings> {
     // Singleton pattern - check if settings exist
     const existing = await this.getSiteSettings();
 
@@ -5513,6 +5523,10 @@ export class DatabaseStorage implements IStorage {
         updateData.wellnessModuleEnabled = settings.wellnessModuleEnabled;
       }
 
+      if (settings.sprintFvEnabled !== undefined) {
+        updateData.sprintFvEnabled = settings.sprintFvEnabled;
+      }
+
       const [updated] = await db
         .update(siteSettings)
         .set(updateData)
@@ -5526,6 +5540,7 @@ export class DatabaseStorage implements IStorage {
         .values({
           aiModel: settings.aiModel || 'gpt-5-nano',
           wellnessModuleEnabled: settings.wellnessModuleEnabled ?? true,
+          sprintFvEnabled: settings.sprintFvEnabled ?? false,
           updatedBy: settings.updatedBy,
         })
         .returning();

--- a/packages/shared/schema/constants.ts
+++ b/packages/shared/schema/constants.ts
@@ -10,6 +10,7 @@ export const MAX_INSIGHTS_LENGTH = 10000;
 // Metric type constants (legacy compatibility)
 export const MetricType = {
   FLY10_TIME: 'FLY10_TIME',
+  FLY10M_TIME: 'FLY10M_TIME',
   VERTICAL_JUMP: 'VERTICAL_JUMP',
   AGILITY_505: 'AGILITY_505',
   AGILITY_505_L: 'AGILITY_505_L',
@@ -23,6 +24,10 @@ export const MetricType = {
   DASH_20YD: 'DASH_20YD',
   DASH_30YD: 'DASH_30YD',
   DASH_40YD: 'DASH_40YD',
+  DASH_10M: 'DASH_10M',
+  DASH_20M: 'DASH_20M',
+  DASH_30M: 'DASH_30M',
+  DASH_40M: 'DASH_40M',
   TOP_SPEED: 'TOP_SPEED',
   RSI: 'RSI',
 } as const;
@@ -33,6 +38,7 @@ export const MetricType = {
 // Defines metric types: lower_is_better, higher_is_better, tracking
 export const VALID_METRICS = [
   { key: 'FLY10_TIME', metricType: 'lower_is_better' },
+  { key: 'FLY10M_TIME', metricType: 'lower_is_better' },
   { key: 'VERTICAL_JUMP', metricType: 'higher_is_better' },
   { key: 'AGILITY_505', metricType: 'lower_is_better' },
   { key: 'AGILITY_505_L', metricType: 'lower_is_better' },
@@ -46,6 +52,10 @@ export const VALID_METRICS = [
   { key: 'DASH_20YD', metricType: 'lower_is_better' },
   { key: 'DASH_30YD', metricType: 'lower_is_better' },
   { key: 'DASH_40YD', metricType: 'lower_is_better' },
+  { key: 'DASH_10M', metricType: 'lower_is_better' },
+  { key: 'DASH_20M', metricType: 'lower_is_better' },
+  { key: 'DASH_30M', metricType: 'lower_is_better' },
+  { key: 'DASH_40M', metricType: 'lower_is_better' },
   { key: 'RSI', metricType: 'higher_is_better' },
   { key: 'TOP_SPEED', metricType: 'higher_is_better' },
   { key: 'HEIGHT', metricType: 'tracking' },

--- a/packages/shared/schema/tables/sprint-fv-profiles.ts
+++ b/packages/shared/schema/tables/sprint-fv-profiles.ts
@@ -2,15 +2,18 @@
  * Sprint Force-Velocity Profile Tables
  *
  * Stores computed JB Morin sprint F-V profiles derived from existing
- * split time measurements (DASH_5YD, DASH_10YD, DASH_20YD, DASH_30YD).
+ * split time measurements across the 10/20/30/40 distance protocol
+ * (DASH_10YD..DASH_40YD or DASH_10M..DASH_40M — yards and meters
+ * are tracked as parallel metric types).
  */
 
 import { sql } from "drizzle-orm";
 import { pgTable, text, varchar, decimal, timestamp, date, jsonb, index } from "drizzle-orm/pg-core";
 
 /**
- * Split times stored as JSON: distance (string) → time in seconds
- * e.g., { "5": 1.12, "10": 1.83, "20": 3.21, "30": 4.52 }
+ * Split times stored as JSON: distance (string, in the profile's distanceUnit) → time in seconds
+ * e.g., { "10": 1.70, "20": 2.95, "30": 4.18, "40": 5.30 }
+ * The distance key is unit-implicit; distanceUnit on the profile row disambiguates.
  */
 export type SplitTimesJson = Record<string, number>;
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -65,7 +65,7 @@
     "react-chartjs-2": "^5.3.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
-    "react-hook-form": "^7.55.0",
+    "react-hook-form": "^7.72.1",
     "react-icons": "^5.4.0",
     "react-joyride": "^2.9.3",
     "react-markdown": "^10.1.0",

--- a/packages/web/src/components/athletes/LlmExportButton.tsx
+++ b/packages/web/src/components/athletes/LlmExportButton.tsx
@@ -1,0 +1,188 @@
+/**
+ * LlmExportButton — split-button that exports an athlete's data for LLMs.
+ *
+ *   Primary action (left half): Copy Markdown to clipboard.
+ *     → On success the label swaps to "Copied ✓" for ~1.5s, then reverts.
+ *     → On clipboard unavailability it auto-falls back to a Markdown download
+ *       and shows "Couldn't copy — downloaded instead" briefly.
+ *
+ *   Secondary (right half): dropdown with explicit Markdown / JSON downloads.
+ *
+ * Visibility is decided by the parent. LLM export is a coaching tool, so only
+ * coaches, org admins, and site admins should render this button. Athletes,
+ * parents, and guests do not see it — the backend route enforces the same
+ * allowlist, so unauthorized requests are also denied at the API layer.
+ * We do not render disabled teasers for unauthorized viewers.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  Sparkles,
+  Check,
+  AlertCircle,
+  Loader2,
+  ChevronDown,
+  FileText,
+  FileJson,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import { useLlmExport } from '@/hooks/use-llm-export';
+import { useToast } from '@/hooks/use-toast';
+
+interface LlmExportButtonProps {
+  athleteId: string;
+  athleteName?: string | null;
+  className?: string;
+}
+
+type UiState = 'idle' | 'loading' | 'copied' | 'fallback' | 'error';
+
+const CONFIRMATION_MS = 1500;
+
+export function LlmExportButton({
+  athleteId,
+  athleteName,
+  className,
+}: LlmExportButtonProps) {
+  const { toast } = useToast();
+  const [state, setState] = useState<UiState>('idle');
+  const revertTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { copy, download, isDownloading } = useLlmExport({
+    athleteId,
+    athleteName,
+    onError: (err) => {
+      toast({
+        variant: 'destructive',
+        title: 'Export failed',
+        description: err.message || 'Please try again.',
+      });
+    },
+  });
+
+  // Clear any pending revert timer on unmount to avoid setState-after-unmount.
+  useEffect(() => {
+    return () => {
+      if (revertTimer.current) clearTimeout(revertTimer.current);
+    };
+  }, []);
+
+  const scheduleRevert = () => {
+    if (revertTimer.current) clearTimeout(revertTimer.current);
+    revertTimer.current = setTimeout(() => setState('idle'), CONFIRMATION_MS);
+  };
+
+  const handleCopy = async () => {
+    setState('loading');
+    const result = await copy();
+    if (!result.ok) {
+      setState('error');
+      scheduleRevert();
+      return;
+    }
+    setState(result.clipboardFallback ? 'fallback' : 'copied');
+    scheduleRevert();
+  };
+
+  const handleDownload = async (format: 'markdown' | 'json') => {
+    const ok = await download(format);
+    if (ok) {
+      toast({
+        title:
+          format === 'markdown' ? 'Markdown downloaded' : 'JSON downloaded',
+        description: 'Ready to paste into your LLM of choice.',
+      });
+    }
+  };
+
+  const {
+    Icon,
+    label,
+    iconClass,
+    disabled,
+  }: {
+    Icon: typeof Sparkles;
+    label: string;
+    iconClass?: string;
+    disabled?: boolean;
+  } = (() => {
+    switch (state) {
+      case 'loading':
+        return { Icon: Loader2, label: 'Preparing…', iconClass: 'animate-spin', disabled: true };
+      case 'copied':
+        return { Icon: Check, label: 'Copied ✓', iconClass: 'text-green-600' };
+      case 'fallback':
+        return {
+          Icon: AlertCircle,
+          label: "Couldn't copy — downloaded instead",
+          iconClass: 'text-amber-600',
+        };
+      case 'error':
+        return {
+          Icon: AlertCircle,
+          label: "Couldn't copy — try download",
+          iconClass: 'text-red-500',
+        };
+      default:
+        return { Icon: Sparkles, label: 'Copy for LLM' };
+    }
+  })();
+
+  return (
+    <div
+      className={cn('inline-flex rounded-md shadow-sm', className)}
+      role="group"
+      aria-label="Export athlete data for LLM"
+    >
+      <Button
+        type="button"
+        variant="outline"
+        className="rounded-r-none border-r-0"
+        disabled={disabled}
+        onClick={handleCopy}
+        aria-label="Copy athlete performance data to clipboard for use with an LLM"
+        data-testid="llm-export-copy"
+      >
+        <Icon className={cn('h-4 w-4 mr-2', iconClass)} />
+        <span aria-live="polite">{label}</span>
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            className="rounded-l-none px-2"
+            aria-label="Other export formats"
+            data-testid="llm-export-menu"
+            disabled={isDownloading}
+          >
+            <ChevronDown className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={() => handleDownload('markdown')}
+            data-testid="llm-export-download-markdown"
+          >
+            <FileText className="h-4 w-4 mr-2" />
+            Download as Markdown (.md)
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => handleDownload('json')}
+            data-testid="llm-export-download-json"
+          >
+            <FileJson className="h-4 w-4 mr-2" />
+            Download as JSON (.json)
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/packages/web/src/components/reports/IndividualReportView.tsx
+++ b/packages/web/src/components/reports/IndividualReportView.tsx
@@ -18,6 +18,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { TierBadge } from "@/components/benchmarks/TierBadge";
 import { FileDown, Share2, Send } from "lucide-react";
+import { LlmExportButton } from "@/components/athletes/LlmExportButton";
+import { useAuth } from "@/lib/auth";
 import { ShareReportDialog } from "./ShareReportDialog";
 import { SendReportToAthleteDialog } from "./SendReportToAthleteDialog";
 import { CoachingInsightsCard } from "./CoachingInsightsCard";
@@ -38,6 +40,11 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
   const generateReport = useGenerateReport(report.id);
   const [reportData, setReportData] = useState<any>(null);
   const { toast } = useToast();
+  const { user } = useAuth();
+
+  // LLM export is a coaching tool — athletes don't see the button even on their own report.
+  const canExportForLlm =
+    !!user && (user.isSiteAdmin || user.role === "coach" || user.role === "org_admin");
 
   // Determine if AI is enabled for this organization
   const { data: organization } = useQuery<{ aiEnabled?: boolean; aiEnabledBySiteAdmin?: boolean }>({
@@ -142,7 +149,17 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
                 Generated on {format(new Date(reportData.generatedAt), "PPP")}
               </p>
             </div>
-            <div className="flex gap-2">
+            <div className="flex gap-2 flex-wrap">
+              {canExportForLlm && athleteId && (
+                <LlmExportButton
+                  athleteId={athleteId}
+                  // The `AthletePerformance` DTO's `userName` is mapped from
+                  // the underlying user's `fullName` in report-service.ts:549
+                  // — it is the athlete's display name, not a login handle,
+                  // despite the field name suggesting otherwise.
+                  athleteName={athlete?.userName}
+                />
+              )}
               <Button variant="outline" onClick={handleDownloadPDF} disabled={isPdfDownloading}>
                 <FileDown className="h-4 w-4 mr-2" />
                 {isPdfDownloading ? "Downloading..." : "Export PDF"}

--- a/packages/web/src/components/sprint-fv/SprintFvSessionSelector.tsx
+++ b/packages/web/src/components/sprint-fv/SprintFvSessionSelector.tsx
@@ -60,8 +60,8 @@ export function SprintFvSessionSelector({ userId }: Props) {
       <Card className="border-dashed">
         <CardContent className="py-12 text-center">
           <p className="text-muted-foreground">
-            No sprint sessions found. Record split times (DASH_5YD through DASH_30YD)
-            to generate F-V profiles.
+            No sprint sessions found. Record split times at 10/20/30/40 yards or
+            meters on the same date to generate F-V profiles.
           </p>
         </CardContent>
       </Card>

--- a/packages/web/src/hooks/use-llm-export.ts
+++ b/packages/web/src/hooks/use-llm-export.ts
@@ -1,0 +1,178 @@
+/**
+ * Hook for the athlete LLM export feature.
+ *
+ * Two operating modes:
+ *   - "copy": fetch Markdown, write to navigator.clipboard (primary UX path).
+ *   - "download": fetch Markdown or JSON, trigger a blob download
+ *     (mirrors use-report-pdf.ts).
+ *
+ * If the clipboard API is unavailable (older browsers, insecure origins),
+ * `copy` falls back to `download` and signals the caller via the
+ * `clipboardFallback` flag on the return value.
+ */
+
+import { useCallback, useState } from 'react';
+
+export type LlmExportFormat = 'markdown' | 'json';
+
+interface UseLlmExportOptions {
+  athleteId: string;
+  athleteName?: string | null;
+  onError?: (error: Error) => void;
+}
+
+interface CopyResult {
+  ok: boolean;
+  clipboardFallback?: boolean;
+}
+
+interface UseLlmExportReturn {
+  copy: () => Promise<CopyResult>;
+  download: (format: LlmExportFormat) => Promise<boolean>;
+  isDownloading: boolean;
+}
+
+const EXPORT_URL = (athleteId: string, format: LlmExportFormat) =>
+  `/api/athletes/${athleteId}/llm-export?format=${format}`;
+
+const SLUG_FALLBACK = 'athlete';
+
+function slugify(name: string | null | undefined): string {
+  if (!name) return SLUG_FALLBACK;
+  const withoutDiacritics = name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+  // Keep this in sync with `filenameFor` in
+  // packages/api/services/llm-export-service.ts: pipes are stripped
+  // *without* replacement (so `a|b` → `ab`, not `a-b`) before the generic
+  // non-alphanumeric collapse. This matters because the server populates
+  // `Content-Disposition` with its slug, and if the clipboard-fallback
+  // path runs, we want the client-generated filename to match byte-for-byte.
+  const withoutPipes = withoutDiacritics.replace(/\|/g, '');
+  return (
+    withoutPipes
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || SLUG_FALLBACK
+  );
+}
+
+/**
+ * Format today's date in ISO yyyy-mm-dd (UTC) to match the server's
+ * `filenameFor` output. Clipboard-fallback downloads go through the client's
+ * fallback path rather than surfacing `Content-Disposition`, so we mirror the
+ * server's filename convention exactly to keep artifacts consistent.
+ */
+function todayIsoUtc(): string {
+  const now = new Date();
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(now.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function filenameFromResponse(
+  response: Response,
+  fallback: string,
+): string {
+  const header = response.headers.get('content-disposition');
+  if (!header) return fallback;
+  const match = /filename="([^"]+)"/.exec(header);
+  return match?.[1] ?? fallback;
+}
+
+async function fetchExport(
+  athleteId: string,
+  format: LlmExportFormat,
+): Promise<Response> {
+  const res = await fetch(EXPORT_URL(athleteId, format), {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    let message = `Export failed (${res.status})`;
+    try {
+      const body = await res.json();
+      if (body?.message) message = body.message;
+    } catch {
+      /* non-json error body — keep the status-based message */
+    }
+    throw new Error(message);
+  }
+  return res;
+}
+
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const url = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(anchor);
+}
+
+export function useLlmExport({
+  athleteId,
+  athleteName,
+  onError,
+}: UseLlmExportOptions): UseLlmExportReturn {
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const copy = useCallback(async (): Promise<CopyResult> => {
+    try {
+      const response = await fetchExport(athleteId, 'markdown');
+      const text = await response.text();
+
+      const canUseClipboard =
+        typeof navigator !== 'undefined' &&
+        !!navigator.clipboard &&
+        typeof navigator.clipboard.writeText === 'function' &&
+        window.isSecureContext;
+
+      if (canUseClipboard) {
+        await navigator.clipboard.writeText(text);
+        return { ok: true };
+      }
+
+      // Clipboard unavailable — fall back to download so the coach still gets the data.
+      const filename = filenameFromResponse(
+        response,
+        `${slugify(athleteName)}-${todayIsoUtc()}.md`,
+      );
+      triggerBlobDownload(new Blob([text], { type: 'text/markdown' }), filename);
+      return { ok: true, clipboardFallback: true };
+    } catch (err) {
+      const error =
+        err instanceof Error ? err : new Error('Failed to copy export');
+      onError?.(error);
+      return { ok: false };
+    }
+  }, [athleteId, athleteName, onError]);
+
+  const download = useCallback(
+    async (format: LlmExportFormat): Promise<boolean> => {
+      setIsDownloading(true);
+      try {
+        const response = await fetchExport(athleteId, format);
+        const blob = await response.blob();
+        const ext = format === 'markdown' ? 'md' : 'json';
+        const fallback = `${slugify(athleteName)}-${todayIsoUtc()}.${ext}`;
+        const filename = filenameFromResponse(response, fallback);
+        triggerBlobDownload(blob, filename);
+        return true;
+      } catch (err) {
+        const error =
+          err instanceof Error ? err : new Error('Failed to download export');
+        onError?.(error);
+        return false;
+      } finally {
+        setIsDownloading(false);
+      }
+    },
+    [athleteId, athleteName, onError],
+  );
+
+  return { copy, download, isDownloading };
+}

--- a/packages/web/src/hooks/useFormErrors.ts
+++ b/packages/web/src/hooks/useFormErrors.ts
@@ -4,12 +4,18 @@ import type { FormError } from "@/components/ui/form-error-summary";
 export function useFormErrors() {
   const { formState: { errors } } = useFormContext();
 
-  // Convert React Hook Form errors to FormError array
-  const formErrors: FormError[] = Object.entries(errors).map(([field, error]) => ({
-    field,
-    message: (error?.message as string) || "This field is required",
-    ref: error?.ref as React.RefObject<HTMLElement> | undefined,
-  }));
+  // react-hook-form's FieldErrors values are a union (FieldError | nested shapes).
+  // Only FieldError carries `ref`; narrow via property check before accessing it.
+  const formErrors: FormError[] = Object.entries(errors).map(([field, error]) => {
+    const ref = error && typeof error === "object" && "ref" in error
+      ? (error.ref as React.RefObject<HTMLElement> | undefined)
+      : undefined;
+    return {
+      field,
+      message: (error?.message as string) || "This field is required",
+      ref,
+    };
+  });
 
   const scrollToError = (field: string) => {
     const error = formErrors.find(e => e.field === field);

--- a/packages/web/src/pages/athlete-profile.tsx
+++ b/packages/web/src/pages/athlete-profile.tsx
@@ -13,6 +13,7 @@ import { ArrowLeft, Calendar, MapPin, Trophy, TrendingUp, User, Zap, Edit, Plus,
 import { calculateFly10Speed } from "@/lib/speed-utils";
 import AthleteModal from "@/components/athlete-modal";
 import AthleteMeasurementForm from "@/components/athlete-measurement-form";
+import { LlmExportButton } from "@/components/athletes/LlmExportButton";
 import { useAuth } from "@/lib/auth";
 import { useToast } from "@/hooks/use-toast";
 import { useForm } from "react-hook-form";
@@ -170,6 +171,12 @@ export default function AthleteProfile() {
 
   // Check if user can edit measurements (coaches and site admins)
   const canEditMeasurements = user?.role === "coach" || user?.role === "org_admin" || user?.isSiteAdmin;
+
+  // LLM export is a coaching tool — only coaches, org admins, and site admins.
+  // Athletes (including self-view) do not see the button.
+  const canExportForLlm =
+    !!user &&
+    (user.isSiteAdmin || user.role === "coach" || user.role === "org_admin");
 
   // Calculate dashboard data (memoized to avoid recalculation on every render)
   // IMPORTANT: Must be before any early returns to comply with Rules of Hooks
@@ -376,8 +383,8 @@ export default function AthleteProfile() {
             )}
           </div>
         </div>
-        <div className="flex space-x-3">
-          <Button 
+        <div className="flex space-x-3 flex-wrap gap-y-2">
+          <Button
             onClick={() => setShowEditModal(true)}
             variant="outline"
             data-testid="button-edit-athlete"
@@ -385,8 +392,14 @@ export default function AthleteProfile() {
             <Edit className="h-4 w-4 mr-2" />
             Edit Athlete
           </Button>
+          {canExportForLlm && athleteId && (
+            <LlmExportButton
+              athleteId={athleteId}
+              athleteName={athlete?.fullName}
+            />
+          )}
           {canEditMeasurements && (
-            <Button 
+            <Button
               onClick={() => setShowAddMeasurementModal(true)}
               data-testid="button-add-measurement"
             >

--- a/tests/e2e/athlete-llm-export.spec.ts
+++ b/tests/e2e/athlete-llm-export.spec.ts
@@ -1,0 +1,337 @@
+import { test, expect, type Page } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { loginAsDefaultUser, loginAs } from './helpers/auth';
+import { canTestRoleAuthorization, hasUserCredentials } from './fixtures/test-users';
+
+/**
+ * LLM EXPORT FEATURE: End-to-End Tests
+ *
+ * Covers the split-button the coach uses to hand an athlete's data to an LLM.
+ *
+ * What we exercise:
+ *  - Copy-to-clipboard primary action (with the 1.5s "Copied ✓" confirmation)
+ *  - Dropdown → Download as Markdown (.md)
+ *  - Dropdown → Download as JSON (.json) + payload shape
+ *  - Role gating: the button is ABSENT (not disabled) for athletes viewing themselves
+ *  - Keyboard accessibility: Tab/Enter to copy, chevron dropdown reachable
+ *
+ * Surface under test: the Individual Report view. The button lives on both the
+ * report view and the athlete profile — the report view is the higher-traffic
+ * path for coaches and easier to scaffold deterministically from a test.
+ */
+
+const STAGING_URL = process.env.STAGING_URL || 'http://localhost:5000';
+
+function generateTestReport() {
+  const uniqueId = Date.now().toString(36) + Math.random().toString(36).substring(2);
+  return {
+    name: `LLM Export Test ${uniqueId}`,
+    description: `E2E test report created at ${new Date().toISOString()}`,
+  };
+}
+
+async function getUserOrgId(page: Page): Promise<string | null> {
+  return await page.evaluate(() => {
+    const authData = localStorage.getItem('auth');
+    if (authData) {
+      const parsed = JSON.parse(authData);
+      return parsed.organizationContext || null;
+    }
+    return null;
+  });
+}
+
+/**
+ * Pull a usable athlete id from the org so the individual report has a real target.
+ * Returns null when no athletes exist — the caller should skip the test in that case
+ * rather than fail noisily (empty staging orgs are a legitimate environment state).
+ */
+async function getFirstAthleteId(page: Page, organizationId: string | null): Promise<string | null> {
+  const res = await page.request.get(`${STAGING_URL}/api/athletes`);
+  if (!res.ok()) return null;
+  const athletes = await res.json();
+  if (!Array.isArray(athletes) || athletes.length === 0) return null;
+  if (organizationId) {
+    const inOrg = athletes.find((a: any) =>
+      a.organizationId === organizationId || a.organizations?.some?.((o: any) => o.id === organizationId),
+    );
+    if (inOrg?.id) return inOrg.id;
+  }
+  return athletes[0]?.id ?? null;
+}
+
+/**
+ * Scaffold an individual report for a given athlete and return its id.
+ * Mirrors the pattern used in report-pdf-export.spec.ts — we skip the wizard
+ * and POST directly to keep the test focused on the export button, not creation.
+ */
+async function createIndividualReport(
+  page: Page,
+  athleteId: string,
+  organizationId: string | null,
+): Promise<string> {
+  const testReport = generateTestReport();
+  const res = await page.request.post(`${STAGING_URL}/api/reports`, {
+    data: {
+      name: testReport.name,
+      description: testReport.description,
+      reportType: 'individual',
+      organizationId,
+      config: {
+        athleteId,
+        timeframe: { type: 'preset', preset: 'season' },
+        metrics: ['FLY10_TIME'],
+      },
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`Failed to create report: ${res.status()} ${await res.text()}`);
+  }
+  const data = await res.json();
+  return data.id;
+}
+
+test.describe('Athlete LLM Export - End-to-End', () => {
+  let createdReportIds: string[] = [];
+
+  test.beforeEach(async ({ page, context }) => {
+    await loginAsDefaultUser(page);
+    createdReportIds = [];
+
+    // Clipboard read/write permission must be granted BEFORE we navigate,
+    // otherwise navigator.clipboard.readText() throws NotAllowedError in Chromium.
+    try {
+      await context.grantPermissions(['clipboard-read', 'clipboard-write'], { origin: STAGING_URL });
+    } catch (err) {
+      // Some browsers don't support clipboard permissions; tests that require
+      // clipboard readback will handle the failure individually.
+      console.warn('Clipboard permissions not granted:', err instanceof Error ? err.message : err);
+    }
+  });
+
+  test.afterEach(async ({ page }) => {
+    for (const reportId of createdReportIds) {
+      try {
+        await page.request.delete(`${STAGING_URL}/api/reports/${reportId}`);
+      } catch (error) {
+        console.warn(`Failed to cleanup report ${reportId}:`, error);
+      }
+    }
+  });
+
+  test('renders the split-button on an individual report for a coach', async ({ page }) => {
+    const orgId = await getUserOrgId(page);
+    const athleteId = await getFirstAthleteId(page, orgId);
+    test.skip(!athleteId, 'No athletes available in the org — cannot scaffold an individual report.');
+
+    const reportId = await createIndividualReport(page, athleteId!, orgId);
+    createdReportIds.push(reportId);
+
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+
+    // Both halves of the split button should be present.
+    await expect(page.getByTestId('llm-export-copy')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('llm-export-menu')).toBeVisible();
+  });
+
+  test('copy-for-LLM writes a Markdown export to the clipboard', async ({ page }) => {
+    const orgId = await getUserOrgId(page);
+    const athleteId = await getFirstAthleteId(page, orgId);
+    test.skip(!athleteId, 'No athletes available in the org — cannot scaffold an individual report.');
+
+    const reportId = await createIndividualReport(page, athleteId!, orgId);
+    createdReportIds.push(reportId);
+
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+
+    const copyButton = page.getByTestId('llm-export-copy');
+    await expect(copyButton).toBeVisible({ timeout: 10000 });
+
+    await copyButton.click();
+
+    // Gate the clipboard read on the UI confirmation, not on the network response.
+    // page.waitForResponse resolves when bytes hit the wire — but the hook still
+    // has to parse response.text() and then await clipboard.writeText() before
+    // the clipboard is actually populated. The "Copied" label is set after
+    // writeText resolves, so it's the true readiness signal.
+    await expect(copyButton).toContainText('Copied', { timeout: 5000 });
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    // Shape-level assertion: catches content regressions (missing sections) without
+    // coupling the test to every markdown formatting tweak.
+    expect(clipboardText).toContain('# Athlete Performance Export');
+    expect(clipboardText).toContain('## Athlete Profile');
+    expect(clipboardText).toContain('## Metric Glossary');
+    expect(clipboardText.length).toBeGreaterThan(100);
+  });
+
+  test('the button shows "Copied ✓" briefly and reverts to idle', async ({ page }) => {
+    const orgId = await getUserOrgId(page);
+    const athleteId = await getFirstAthleteId(page, orgId);
+    test.skip(!athleteId, 'No athletes available in the org — cannot scaffold an individual report.');
+
+    const reportId = await createIndividualReport(page, athleteId!, orgId);
+    createdReportIds.push(reportId);
+
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+
+    const copyButton = page.getByTestId('llm-export-copy');
+    await expect(copyButton).toBeVisible({ timeout: 10000 });
+    await expect(copyButton).toContainText('Copy for LLM');
+
+    await copyButton.click();
+
+    // Confirmation appears within ~1s and holds for ~1.5s (CONFIRMATION_MS in LlmExportButton.tsx).
+    await expect(copyButton).toContainText('Copied', { timeout: 3000 });
+
+    // Then reverts — within ~3s of click we should see the idle label again.
+    await expect(copyButton).toContainText('Copy for LLM', { timeout: 5000 });
+  });
+
+  test('dropdown → Download as Markdown triggers a .md download', async ({ page }) => {
+    const orgId = await getUserOrgId(page);
+    const athleteId = await getFirstAthleteId(page, orgId);
+    test.skip(!athleteId, 'No athletes available in the org — cannot scaffold an individual report.');
+
+    const reportId = await createIndividualReport(page, athleteId!, orgId);
+    createdReportIds.push(reportId);
+
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('llm-export-menu').click();
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByTestId('llm-export-download-markdown').click();
+    const download = await downloadPromise;
+
+    const filename = download.suggestedFilename();
+    // Filename convention from llm-export-service: <slug>-<YYYY-MM-DD>.md
+    // where slug is at least one character of [a-z0-9-] (slugify falls back to "athlete").
+    expect(filename).toMatch(/^[a-z0-9-]+-\d{4}-\d{2}-\d{2}\.md$/);
+
+    const path = await download.path();
+    expect(path).toBeTruthy();
+    const contents = readFileSync(path!, 'utf-8');
+    expect(contents).toContain('# Athlete Performance Export');
+    expect(contents).toContain('## Athlete Profile');
+  });
+
+  test('dropdown → Download as JSON triggers a .json download with the expected shape', async ({ page }) => {
+    const orgId = await getUserOrgId(page);
+    const athleteId = await getFirstAthleteId(page, orgId);
+    test.skip(!athleteId, 'No athletes available in the org — cannot scaffold an individual report.');
+
+    const reportId = await createIndividualReport(page, athleteId!, orgId);
+    createdReportIds.push(reportId);
+
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('llm-export-menu').click();
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByTestId('llm-export-download-json').click();
+    const download = await downloadPromise;
+
+    const filename = download.suggestedFilename();
+    expect(filename).toMatch(/^[a-z0-9-]+-\d{4}-\d{2}-\d{2}\.json$/);
+
+    const path = await download.path();
+    const contents = readFileSync(path!, 'utf-8');
+    const parsed = JSON.parse(contents);
+
+    // Sanity-check the AthleteLlmExport shape without asserting every field — the
+    // unit test covers exhaustive shape. E2E only needs to confirm the pipe is live.
+    expect(parsed).toHaveProperty('generatedAt');
+    expect(parsed).toHaveProperty('athlete');
+    expect(parsed.athlete).toHaveProperty('id');
+    expect(parsed.athlete).toHaveProperty('fullName');
+    expect(parsed).toHaveProperty('currentSnapshot');
+    expect(parsed).toHaveProperty('measurementHistory');
+    expect(parsed).toHaveProperty('activeGoals');
+    expect(parsed).toHaveProperty('recentWellness');
+    expect(parsed).toHaveProperty('metricGlossary');
+  });
+
+  test('keyboard flow: Tab focuses the copy button, Enter triggers copy', async ({ page }) => {
+    const orgId = await getUserOrgId(page);
+    const athleteId = await getFirstAthleteId(page, orgId);
+    test.skip(!athleteId, 'No athletes available in the org — cannot scaffold an individual report.');
+
+    const reportId = await createIndividualReport(page, athleteId!, orgId);
+    createdReportIds.push(reportId);
+
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+
+    const copyButton = page.getByTestId('llm-export-copy');
+    await expect(copyButton).toBeVisible({ timeout: 10000 });
+
+    // Focus the button programmatically rather than tab-counting — the page has
+    // many focusable elements before this button and counting tabs is a recipe
+    // for flaky tests. Keyboard-triggered activation is what we're testing.
+    await copyButton.focus();
+    await expect(copyButton).toBeFocused();
+
+    await page.keyboard.press('Enter');
+
+    // "Copied" label is the deterministic readiness signal — it's set after the
+    // hook finishes fetching AND writing to the clipboard.
+    await expect(copyButton).toContainText('Copied', { timeout: 5000 });
+  });
+
+  test('happy-path API call via coach session returns a Markdown body', async ({ page }) => {
+    // Happy-path safety net: if a regression wires the button to the wrong URL
+    // or a middleware change breaks the allowlist for coaches, this catches it.
+    // True athlete-role denial lives in tests/integration/llm-export.test.ts,
+    // which has real DB fixtures and doesn't need a live athlete session.
+    const orgId = await getUserOrgId(page);
+    const athleteId = await getFirstAthleteId(page, orgId);
+    test.skip(!athleteId, 'No athletes available in the org — cannot scaffold an individual report.');
+
+    const res = await page.request.get(
+      `${STAGING_URL}/api/athletes/${athleteId}/llm-export?format=markdown`,
+    );
+    expect(res.ok()).toBeTruthy();
+    expect(res.headers()['content-type']).toMatch(/^text\/markdown/);
+    const body = await res.text();
+    expect(body).toContain('# Athlete Performance Export');
+  });
+});
+
+/**
+ * Role-gating block: verify the button is ABSENT (not disabled) for athletes
+ * viewing their own profile. Requires separate athlete credentials to be
+ * configured — skipped in environments with only a single admin account.
+ *
+ * Defense-in-depth: the API route also enforces the allowlist, so a regression
+ * here would be caught by tests/integration/llm-export.test.ts. This E2E block
+ * guards the UX contract that athletes never see a teaser of a tool they
+ * cannot use.
+ */
+test.describe('Athlete LLM Export - Role Gating', () => {
+  test.skip(
+    !canTestRoleAuthorization('coach', 'athlete') || !hasUserCredentials('athlete'),
+    'Requires distinct coach and athlete credentials (E2E_COACH_* and E2E_ATHLETE_*).',
+  );
+
+  test('the button is NOT rendered for an athlete viewing their own report', async ({ page }) => {
+    await loginAs(page, 'athlete');
+
+    // Athletes do get their own reports page at /athlete-dashboard or /dashboard;
+    // if an athlete somehow lands on an individual report for themselves, the
+    // LlmExportButton should not be in the DOM.
+    await page.goto(`${STAGING_URL}/dashboard`);
+    await page.waitForLoadState('networkidle');
+
+    // Assert absence across the entire page — the button should not leak into
+    // any view an athlete can reach. toHaveCount(0) beats toBeHidden() here
+    // because toBeHidden passes for display:none tease buttons too.
+    await expect(page.getByTestId('llm-export-copy')).toHaveCount(0);
+    await expect(page.getByTestId('llm-export-menu')).toHaveCount(0);
+  });
+});

--- a/tests/integration/llm-export.test.ts
+++ b/tests/integration/llm-export.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Integration tests for the LLM export route.
+ *
+ * Verifies:
+ *   - auth gate (401 without session)
+ *   - cross-org access denial (403)
+ *   - markdown + json format selection
+ *   - Content-Type and Content-Disposition headers
+ *   - missing-data resilience (athlete with no measurements still renders all sections)
+ */
+
+// Env must be set before any imports that read process.env.
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET =
+  'test-secret-key-for-integration-tests-only-at-least-32-characters-long';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+process.env.BYPASS_GENERAL_RATE_LIMIT = 'true';
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
+import request from 'supertest';
+import express, { type Express } from 'express';
+import { db } from '../../packages/api/db';
+import {
+  organizations,
+  users,
+  userOrganizations,
+} from '@shared/schema';
+import { and, eq } from 'drizzle-orm';
+import bcrypt from 'bcrypt';
+import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+import { storage } from '../../packages/api/storage';
+
+async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, BCRYPT_SALT_ROUNDS);
+}
+
+let app: Express;
+let testOrg: any;
+let otherOrg: any;
+let testCoach: any;
+let otherCoach: any;
+let testOrgAdmin: any;
+let testAthlete: any;
+let siteAdmin: any;
+let coachAuthCookie: string;
+let otherCoachAuthCookie: string;
+let orgAdminAuthCookie: string;
+let athleteAuthCookie: string;
+let siteAdminAuthCookie: string;
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  await registerRoutes(app);
+});
+
+beforeEach(async () => {
+  const suffix = `${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  [testOrg] = await db
+    .insert(organizations)
+    .values({
+      name: `LLM Export Org ${suffix}`,
+      description: 'Test org for llm export integration tests',
+      isActive: true,
+    })
+    .returning();
+
+  [otherOrg] = await db
+    .insert(organizations)
+    .values({
+      name: `Other Org ${suffix}`,
+      description: 'Outside org',
+      isActive: true,
+    })
+    .returning();
+
+  const hashedPassword = await hashPassword('TestCoach123!');
+
+  [testCoach] = await db
+    .insert(users)
+    .values({
+      username: `llmexport_coach_${suffix}`,
+      emails: [`llmexport_coach_${suffix}@test.com`],
+      password: hashedPassword,
+      firstName: 'Coach',
+      lastName: 'One',
+      fullName: 'Coach One',
+    })
+    .returning();
+
+  [otherCoach] = await db
+    .insert(users)
+    .values({
+      username: `llmexport_other_${suffix}`,
+      emails: [`llmexport_other_${suffix}@test.com`],
+      password: hashedPassword,
+      firstName: 'Coach',
+      lastName: 'Two',
+      fullName: 'Coach Two',
+    })
+    .returning();
+
+  [testOrgAdmin] = await db
+    .insert(users)
+    .values({
+      username: `llmexport_orgadmin_${suffix}`,
+      emails: [`llmexport_orgadmin_${suffix}@test.com`],
+      password: hashedPassword,
+      firstName: 'Org',
+      lastName: 'Admin',
+      fullName: 'Org Admin',
+    })
+    .returning();
+
+  [testAthlete] = await db
+    .insert(users)
+    .values({
+      username: `llmexport_athlete_${suffix}`,
+      emails: [`llmexport_athlete_${suffix}@test.com`],
+      password: hashedPassword,
+      firstName: 'Jane',
+      lastName: 'Doe',
+      fullName: 'Jane Doe',
+    })
+    .returning();
+
+  [siteAdmin] = await db
+    .insert(users)
+    .values({
+      username: `llmexport_siteadmin_${suffix}`,
+      emails: [`llmexport_siteadmin_${suffix}@test.com`],
+      password: hashedPassword,
+      firstName: 'Site',
+      lastName: 'Admin',
+      fullName: 'Site Admin',
+      isSiteAdmin: true,
+    })
+    .returning();
+
+  // These users have no `role` column set on `users` — it's only set on
+  // `userOrganizations`. At login, `determineUserRoleAndContext` resolves
+  // the session role from the first `userOrganizations` row for the user,
+  // which is how `req.session.user.role` picks up 'coach' / 'org_admin' /
+  // 'athlete' below. If that resolution ever moves back to `users.role`,
+  // these fixtures would silently stop reflecting the intended role.
+  await db.insert(userOrganizations).values([
+    { userId: testCoach.id, organizationId: testOrg.id, role: 'coach' },
+    { userId: testOrgAdmin.id, organizationId: testOrg.id, role: 'org_admin' },
+    { userId: testAthlete.id, organizationId: testOrg.id, role: 'athlete' },
+    { userId: otherCoach.id, organizationId: otherOrg.id, role: 'coach' },
+  ]);
+
+  // Assert login status on every fixture login. A silent 401 here would let
+  // subsequent tests fail with a cryptic "Cannot read property '0' of undefined"
+  // when they try to read set-cookie — hard to diagnose. Explicit assertions
+  // fail the test at the actual point of fixture drift.
+  const coachLogin = await request(app).post('/api/auth/login').send({
+    username: testCoach.username,
+    password: 'TestCoach123!',
+  });
+  expect(coachLogin.status).toBe(200);
+  coachAuthCookie = coachLogin.headers['set-cookie'][0];
+
+  const otherCoachLogin = await request(app).post('/api/auth/login').send({
+    username: otherCoach.username,
+    password: 'TestCoach123!',
+  });
+  expect(otherCoachLogin.status).toBe(200);
+  otherCoachAuthCookie = otherCoachLogin.headers['set-cookie'][0];
+
+  const orgAdminLogin = await request(app).post('/api/auth/login').send({
+    username: testOrgAdmin.username,
+    password: 'TestCoach123!',
+  });
+  expect(orgAdminLogin.status).toBe(200);
+  orgAdminAuthCookie = orgAdminLogin.headers['set-cookie'][0];
+
+  const athleteLogin = await request(app).post('/api/auth/login').send({
+    username: testAthlete.username,
+    password: 'TestCoach123!',
+  });
+  expect(athleteLogin.status).toBe(200);
+  athleteAuthCookie = athleteLogin.headers['set-cookie'][0];
+
+  const siteAdminLogin = await request(app).post('/api/auth/login').send({
+    username: siteAdmin.username,
+    password: 'TestCoach123!',
+  });
+  expect(siteAdminLogin.status).toBe(200);
+  siteAdminAuthCookie = siteAdminLogin.headers['set-cookie'][0];
+});
+
+afterEach(async () => {
+  const userIds = [testCoach, otherCoach, testOrgAdmin, testAthlete, siteAdmin]
+    .filter(Boolean)
+    .map((u) => u.id);
+  if (userIds.length > 0) {
+    for (const id of userIds) {
+      await db
+        .delete(userOrganizations)
+        .where(eq(userOrganizations.userId, id));
+      await db.delete(users).where(eq(users.id, id));
+    }
+  }
+  for (const org of [testOrg, otherOrg].filter(Boolean)) {
+    await db.delete(organizations).where(eq(organizations.id, org.id));
+  }
+  testOrg = undefined;
+  otherOrg = undefined;
+  testCoach = undefined;
+  otherCoach = undefined;
+  testOrgAdmin = undefined;
+  testAthlete = undefined;
+  siteAdmin = undefined;
+});
+
+describe('GET /api/athletes/:id/llm-export', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get(
+      `/api/athletes/${testAthlete.id}/llm-export`,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 markdown by default', async () => {
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', coachAuthCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^text\/markdown/);
+    expect(res.headers['content-disposition']).toMatch(
+      /attachment; filename="jane-doe-\d{4}-\d{2}-\d{2}\.md"/,
+    );
+    expect(res.text).toMatch(/^# Athlete Performance Export — Jane Doe/m);
+  });
+
+  it('returns 200 JSON when format=json', async () => {
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export?format=json`)
+      .set('Cookie', coachAuthCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^application\/json/);
+    expect(res.headers['content-disposition']).toMatch(
+      /attachment; filename="jane-doe-\d{4}-\d{2}-\d{2}\.json"/,
+    );
+
+    const body = JSON.parse(res.text);
+    expect(body.athlete.fullName).toBe('Jane Doe');
+    expect(body.athlete.id).toBe(testAthlete.id);
+    // Empty-athlete safety: sections exist, arrays/maps are empty, no crash.
+    expect(body.currentSnapshot).toEqual([]);
+    expect(body.measurementHistory).toEqual({});
+    expect(body.sprintFv).toBeNull();
+    expect(body.activeGoals).toEqual([]);
+    expect(body.recentWellness).toEqual([]);
+  });
+
+  it('returns 400 for an unsupported format', async () => {
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export?format=pdf`)
+      .set('Cookie', coachAuthCookie);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 (not 500) for a non-UUID athlete id', async () => {
+    // Regression: without an up-front UUID guard, postgres raises
+    // "invalid input syntax for type uuid" when the route-level
+    // `storage.getAthlete(athleteId)` hits a UUID column with garbage
+    // input. That error is not caught by the `AthleteNotFoundError`
+    // branch and surfaces as a generic 500, which is both a poor UX and
+    // a weak signal (a deliberate 404 is harder to distinguish from
+    // "athlete exists but you can't read it" — consistent with the
+    // existing role-check-before-lookup design).
+    const res = await request(app)
+      .get('/api/athletes/not-a-uuid/llm-export')
+      .set('Cookie', coachAuthCookie);
+    expect(res.status).toBe(404);
+    expect(res.body.message).toMatch(/athlete not found/i);
+  });
+
+  it('returns 403 when a coach has lost all org memberships since login (userOrgs.length === 0)', async () => {
+    // Simulate a session that persists past a permission revocation: the coach
+    // logged in while a member of testOrg, then had that membership removed
+    // (e.g. offboarded from the org). Their session still carries role='coach'
+    // but getCachedUserOrganizations now returns empty. The route should
+    // short-circuit on that lookup, not fall through to the shared-org check.
+    //
+    // Security-audit requirement: a revoked coach probing the endpoint must
+    // leave an authorization_failed event in the audit log so the pattern is
+    // detectable (repeated probes from a deactivated account is a signal).
+    await db
+      .delete(userOrganizations)
+      .where(
+        and(
+          eq(userOrganizations.userId, testCoach.id),
+          eq(userOrganizations.organizationId, testOrg.id),
+        ),
+      );
+
+    const createSecurityEventSpy = vi
+      .spyOn(storage, 'createSecurityEvent')
+      .mockResolvedValue(undefined as any);
+
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', coachAuthCookie);
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/no organization access/i);
+
+    expect(createSecurityEventSpy).toHaveBeenCalledTimes(1);
+    const [securityEvent] = createSecurityEventSpy.mock.calls[0];
+    expect(securityEvent.eventType).toBe('authorization_failed');
+    expect(securityEvent.userId).toBe(testCoach.id);
+    expect(securityEvent.eventData).toContain('"resource":"athlete"');
+    expect(securityEvent.eventData).toContain('"action":"read"');
+
+    createSecurityEventSpy.mockRestore();
+  });
+
+  it('returns 403 when a coach from another org requests the athlete', async () => {
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', otherCoachAuthCookie);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 and audits when a coach probes an athlete with no org/team affiliation', async () => {
+    // Third 403 branch: the requesting coach is valid, but the target
+    // athlete is unaffiliated (no userOrganizations rows, no userTeams).
+    // Must return 403 AND emit an authorization_failed audit event — a
+    // coach sweeping unaffiliated athletes is a detection signal on par
+    // with cross-org probes and revoked-coach probes.
+    await db
+      .delete(userOrganizations)
+      .where(eq(userOrganizations.userId, testAthlete.id));
+
+    const createSecurityEventSpy = vi
+      .spyOn(storage, 'createSecurityEvent')
+      .mockResolvedValue(undefined as any);
+
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', coachAuthCookie);
+    expect(res.status).toBe(403);
+    expect(res.body.message).toBe('Access denied');
+
+    expect(createSecurityEventSpy).toHaveBeenCalledTimes(1);
+    const [securityEvent] = createSecurityEventSpy.mock.calls[0];
+    expect(securityEvent.eventType).toBe('authorization_failed');
+    expect(securityEvent.userId).toBe(testCoach.id);
+    expect(securityEvent.eventData).toContain('"resource":"athlete"');
+    expect(securityEvent.eventData).toContain('"action":"read"');
+    // Branch-distinguishing signal: attemptedOrgId is absent on the
+    // unaffiliated-athlete branch (the cross-org branch always populates
+    // it). Defenders reading the audit log can disambiguate the two
+    // 403 branches by presence/absence of this field.
+    expect(securityEvent.eventData).not.toContain('"attemptedOrgId"');
+
+    createSecurityEventSpy.mockRestore();
+  });
+
+  it('returns 403 for an athlete attempting to export their own profile (policy denial — coaching tool only)', async () => {
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', athleteAuthCookie);
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/coaches and organization admins/i);
+  });
+
+  it('returns 200 for an org_admin exporting an in-org athlete', async () => {
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', orgAdminAuthCookie);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^text\/markdown/);
+    expect(res.text).toMatch(/^# Athlete Performance Export — Jane Doe/m);
+  });
+
+  it('returns 200 for a site admin exporting any athlete', async () => {
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', siteAdminAuthCookie);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^text\/markdown/);
+  });
+
+  it('returns 200 for a site admin exporting an athlete with no org affiliation', async () => {
+    // Edge case: the route's site-admin branch falls back to
+    // `targetOrganizationId = null` when the athlete is unaffiliated
+    // (no userOrganizations rows). An independent athlete — e.g. a
+    // self-registered user who hasn't accepted an org invitation yet —
+    // must still be exportable by site admins, not trip a 500 from a
+    // non-null assertion downstream.
+    await db
+      .delete(userOrganizations)
+      .where(eq(userOrganizations.userId, testAthlete.id));
+
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', siteAdminAuthCookie);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^text\/markdown/);
+    expect(res.text).toMatch(/^# Athlete Performance Export — Jane Doe/m);
+  });
+
+  it('returns 404 for a non-existent athlete id', async () => {
+    const fakeId = '00000000-0000-0000-0000-000000000000';
+    const res = await request(app)
+      .get(`/api/athletes/${fakeId}/llm-export`)
+      .set('Cookie', coachAuthCookie);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 (not 404) when a role-denied user probes a non-existent athlete id', async () => {
+    // An athlete-role caller must not be able to use 404 vs 403 as an
+    // existence oracle. Role denial should take precedence over resource
+    // lookup, so a caller without permission sees the same 403 whether the
+    // target exists or not.
+    const fakeId = '00000000-0000-0000-0000-000000000000';
+    const res = await request(app)
+      .get(`/api/athletes/${fakeId}/llm-export`)
+      .set('Cookie', athleteAuthCookie);
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/coaches and organization admins/i);
+  });
+
+  it('renders every H2 section placeholder even when athlete has no data', async () => {
+    const res = await request(app)
+      .get(`/api/athletes/${testAthlete.id}/llm-export`)
+      .set('Cookie', coachAuthCookie);
+    expect(res.status).toBe(200);
+    for (const section of [
+      '## Athlete Profile',
+      '## Current Performance Snapshot',
+      '## 12-Month Measurement History',
+      '## Sprint Force-Velocity Profile',
+      '## Active Goals',
+      '## Recent Wellness',
+      '## Medical & Coach Notes',
+      '## Metric Glossary',
+    ]) {
+      expect(res.text).toContain(section);
+    }
+  });
+});

--- a/tests/integration/sprint-fv-routes.test.ts
+++ b/tests/integration/sprint-fv-routes.test.ts
@@ -149,12 +149,12 @@ describe('Sprint F-V Profile Integration Tests', () => {
       role: 'coach',
     });
 
-    // Insert split time measurements for the athlete
+    // Insert split time measurements for the athlete (10/20/30/40 protocol).
     const splitMetrics = [
-      { metric: 'DASH_5YD', value: '1.10' },
       { metric: 'DASH_10YD', value: '1.82' },
       { metric: 'DASH_20YD', value: '3.15' },
       { metric: 'DASH_30YD', value: '4.45' },
+      { metric: 'DASH_40YD', value: '5.75' },
     ];
 
     for (const m of splitMetrics) {
@@ -210,10 +210,10 @@ describe('Sprint F-V Profile Integration Tests', () => {
 
       const session = res.body.sessions[0];
       expect(session.date).toBe(TEST_DATE);
-      expect(session.availableSplits).toContain('DASH_5YD');
       expect(session.availableSplits).toContain('DASH_10YD');
       expect(session.availableSplits).toContain('DASH_20YD');
       expect(session.availableSplits).toContain('DASH_30YD');
+      expect(session.availableSplits).toContain('DASH_40YD');
       expect(session.hasWeight).toBe(true);
       expect(session.profileExists).toBe(false);
     });


### PR DESCRIPTION
## Release Readiness

**Proposed version**: `v0.20.0` (MINOR — two additive features, no breaking API contract changes)
**Previous release**: `v0.19.1`
**Scope**: 33 files changed, +3445 / -187 lines
**Commits on develop not in main**: 9 (1 headline feat, 1 sprint-fv feat, 1 fix, 6 dep/CI bumps)

### Verdict: GO — with two **required pre-deploy operator actions** called out below

### Quality gates
- [x] `npm run check` clean (per PR #378, #387 descriptions)
- [x] Unit + integration suites passing (195/195 targeted; 6857/0 full per PR #387)
- [x] New features are test-covered: LLM export ships 21 unit + 7 integration + E2E tests; Sprint F-V 10/20/30/40 ships 14 new pure-function tests plus updated fixtures
- [x] Site settings fix (#376) ships regression tests that fail on `main` pre-fix
- [x] No destructive migrations — 0122 and 0123 are both idempotent (`DROP CONSTRAINT IF EXISTS` / `ON CONFLICT DO NOTHING`)
- [x] Dependency bumps are all semver-minor (react-hook-form, @anthropic-ai/sdk) or test-only (supertest); CI actions updates are non-runtime

### REQUIRED operator actions before / after deploy

1. **Pre-deploy — delete legacy Sprint F-V profiles.** PR #387 changes the protocol from 5/10/20/30 yd to 10/20/30/40 yd. Existing rows in `sprint_fv_profiles` were fit to the old splits, so their `optimalSlope` classifications are no longer meaningful. No backward-compatibility shim is provided. Operator should run `DELETE FROM sprint_fv_profiles;` before users see the new UI, then users re-generate profiles from 10/20/30/40 measurements.
2. **Post-deploy — apply migrations.** Manual SQL migrations 0122 and 0123 ship in this release. Run `npm run db:migrate:manual` (or the equivalent on Railway) after deploy. 0122 is the fix for the audit-log `23514` CHECK violation that currently blocks toggling the Sprint F-V flag at `/admin`.
3. **Tag + GitHub release.** After merge, create `v0.20.0` tag on `main` and draft the release notes from this PR body.

### Not blocking, but worth noting
- Root `package.json` version string remains `0.2.0` (unchanged) — that field hasn't tracked shipping versions since early in the project; git tags and GitHub releases are the source of truth. Consider bumping it to match in a follow-up if useful for any tooling that reads it.
- Pre-existing `exceljs` type error from PR #373 is still present (noted in #376); unrelated to this release.
- Manual QA checkboxes in #378 and #387 remain unchecked in their PR bodies — call out with QA Lead if a staging smoke is required before flipping traffic.

---

## Changelog

### Features
- **LLM export for athlete program design** (#378) — `GET /api/athletes/:id/llm-export?format=markdown|json` assembles demographics, 12-month measurement history, Sprint F-V profile, active goals, recent wellness, and medical/coach notes into a paste-into-LLM artifact. New split-button on the athlete profile and Individual Report views with `Copy for LLM` (clipboard + blob-download fallback) and explicit Markdown/JSON download options. Rate-limited at 30 req / 15 min; permission gate mirrors `GET /api/athletes/:id`. Partial-data resilience: per-query failures degrade to a `warnings` array rather than 500.
- **Sprint F-V 10/20/30/40 protocol + meters support** (#387) — Switches the Morin Sprint Force-Velocity protocol from 5/10/20/30 yd (where τ hit its 0.7s floor and inflated F0rel) to the standard combine 10/20/30/40. Adds parallel metric-unit metrics (`DASH_10M`/`DASH_20M`/`DASH_30M`/`DASH_40M`/`FLY10M_TIME`) alongside the existing yards metrics. DashR CSV parser becomes unit-aware — Imperial rows produce yards codes, Metric rows produce meters codes. New pure `resolveSplitsFromMeasurements()` picks the unit per session, errors on mixed yards+meters. **Note:** legacy `sprint_fv_profiles` rows must be deleted pre-deploy (see operator actions above).

### Fixes
- **Sprint F-V toggle now persists** (#376) — `storage.updateSiteSettings` silently dropped `sprintFvEnabled` because it wasn't named in the input-object contract, so toggling the flag at `/admin` only bumped `updated_at` without changing the column. Adds the field to both branches (UPDATE + INSERT) and tightens the `IStorage` interface (which was also missing `wellnessModuleEnabled`). Two regression tests added that fail on base pre-fix.
- **Sprint F-V meters sessions no longer mis-classify** (part of #387) — `sprintDistanceM` was double-applying the yards→meters conversion for sessions that were already in meters, producing `36.6m` for a 40m session and corrupting `classifyProfile` / `computeOptimalGap` / `analyzeAcceleration` / `analyzePower`. Now conditional on `distanceUnit === 'meters'`.
- **Audit-constraint fix for Sprint F-V flag** (migration 0122, part of #387) — Adds `site_sprint_fv_module_toggled` to the `audit_logs_action_valid` CHECK constraint. PR #355 registered the action in the route handler but never migrated the constraint, so toggle requests raised Postgres error 23514.

### Dependencies
- Bump `react-hook-form` 7.66.0 → 7.72.1 (#382) — narrowed `FieldErrors` discriminated union; includes a follow-up type fix in `useFormErrors.ts` (`"ref" in error` guard before cast).
- Bump `@anthropic-ai/sdk` 0.69.0 → 0.90.0 (#383).
- Bump `supertest` 6.3.4 → 7.2.2 (dev-dep, #385).

### CI / Build
- Bump `peter-evans/find-comment` 3 → 4 (#381).
- Bump `actions/download-artifact` 4 → 8 (#380).
- Bump `actions/github-script` 8 → 9 (#379).

### Operator-facing changes
- **New API route**: `GET /api/athletes/:id/llm-export` (coach + self; rate-limited 30/15min).
- **New DB migrations**: `0122` (audit action) and `0123` (meter-unit site_metrics seed) — both idempotent, apply via `npm run db:migrate:manual`.
- **New metric codes** visible in metric pickers / org-metric admin: `DASH_10M`, `DASH_20M`, `DASH_30M`, `DASH_40M`, `FLY10M_TIME` (all `lower_is_better`, category `speed`).
- **No new environment variables** in this release.
- **No new feature flags** in this release (the Sprint F-V flag itself was introduced in #355; this release fixes its toggle persistence and audit path).

---

## Test plan

- [ ] Post-deploy: hit `/api/athletes/:id/llm-export?format=markdown` as a coach for an athlete with measurements + F-V profile + active goal; verify Markdown renders all H2 sections, includes a `Prompt suggestion:` trailer, no `[object Object]`.
- [ ] Post-deploy: repeat with `?format=json`; verify valid JSON matching `AthleteLlmExport`.
- [ ] Post-deploy: as a different-org coach, verify 403 on the same athlete ID.
- [ ] Post-deploy: import a DashR CSV with `Units: Metric` at 40m; verify `DASH_40M` + auto-derived `FLY10M_TIME` rows land.
- [ ] Post-deploy: generate a Sprint F-V profile from 10/20/30/40 yd measurements; verify `distanceUnit: 'yards'` and `sprintDistanceM ≈ 36.58`.
- [ ] Post-deploy: toggle Sprint F-V at `/admin`, reload, confirm the switch stays on; flip off, reload, confirm stays off. Confirm `audit_logs` row was written without 23514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)