### PR TITLE
feat: add Jotform waiver webhook intake

### DIFF
--- a/packages/api/__tests__/jotform-webhook-routes.test.ts
+++ b/packages/api/__tests__/jotform-webhook-routes.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Unit tests for the Jotform waiver webhook (issue #370).
+ *
+ * These tests use an in-memory `WaiverStore` so they exercise the full route
+ * + service code path WITHOUT requiring a database. Coverage:
+ *   - bad/missing secret
+ *   - missing submissionID / rawRequest
+ *   - malformed rawRequest JSON
+ *   - valid payload (creates submission, creates athlete user, audit log)
+ *   - duplicate submission (idempotent — no double-create)
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+import crypto from "crypto";
+import type {
+  WaiverStore,
+  JotformWaiverEnvelope,
+} from "../services/waiver-service";
+import type {
+  WaiverSubmission,
+  InsertWaiverSubmission,
+  User,
+  InsertUser,
+  InsertAuditLog,
+} from "@shared/schema";
+import { registerWebhookRoutes } from "../routes/webhook-routes";
+
+const SHARED_SECRET = "s3cret-test-token";
+
+function buildInMemoryStore() {
+  const submissions = new Map<string, WaiverSubmission>();
+  const users = new Map<string, User>();
+  const usersByEmail = new Map<string, User>();
+  const auditLogs: InsertAuditLog[] = [];
+
+  let nextId = 0;
+  const id = () => `id-${++nextId}`;
+
+  const store: WaiverStore = {
+    async findBySubmissionId(submissionId) {
+      for (const s of submissions.values()) {
+        if (s.submissionId === submissionId) return s;
+      }
+      return undefined;
+    },
+    async createSubmission(data: InsertWaiverSubmission) {
+      const row = {
+        id: id(),
+        submissionId: data.submissionId,
+        formId: data.formId ?? null,
+        source: data.source ?? "jotform",
+        athleteUserId: data.athleteUserId ?? null,
+        athleteEmail: data.athleteEmail ?? null,
+        athleteFirstName: data.athleteFirstName ?? null,
+        athleteLastName: data.athleteLastName ?? null,
+        athleteBirthDate: (data.athleteBirthDate ?? null) as any,
+        parentName: data.parentName ?? null,
+        parentEmail: data.parentEmail ?? null,
+        parentPhone: data.parentPhone ?? null,
+        pdfUrl: data.pdfUrl ?? null,
+        signedAt: data.signedAt ?? null,
+        status: data.status ?? "received",
+        errorMessage: data.errorMessage ?? null,
+        rawPayload: data.rawPayload as any,
+        processedAt: data.processedAt ?? null,
+        createdAt: new Date(),
+      } as WaiverSubmission;
+      submissions.set(row.id, row);
+      return row;
+    },
+    async markProcessed(rowId, athleteUserId) {
+      const row = submissions.get(rowId);
+      if (!row) throw new Error(`unknown submission ${rowId}`);
+      submissions.set(rowId, {
+        ...row,
+        status: "processed",
+        processedAt: new Date(),
+        athleteUserId: athleteUserId ?? null,
+        errorMessage: null,
+      });
+    },
+    async markFailed(rowId, errorMessage) {
+      const row = submissions.get(rowId);
+      if (!row) throw new Error(`unknown submission ${rowId}`);
+      submissions.set(rowId, { ...row, status: "failed", errorMessage });
+    },
+    async findUserByEmail(email) {
+      return usersByEmail.get(email.toLowerCase());
+    },
+    async createUser(data: InsertUser) {
+      const d = data as any;
+      const created = {
+        id: id(),
+        username: d.username,
+        emails: d.emails ?? [],
+        password: d.password ?? null,
+        firstName: d.firstName,
+        lastName: d.lastName,
+        fullName: `${d.firstName} ${d.lastName}`.trim(),
+        isSiteAdmin: d.isSiteAdmin ?? false,
+        isActive: d.isActive ?? true,
+        createdAt: new Date(),
+      } as unknown as User;
+      users.set(created.id, created);
+      for (const e of created.emails ?? []) usersByEmail.set(e.toLowerCase(), created);
+      return created;
+    },
+    async createAuditLog(data: InsertAuditLog) {
+      auditLogs.push(data);
+    },
+  };
+
+  return { store, submissions, users, usersByEmail, auditLogs };
+}
+
+function buildApp(store: WaiverStore, opts?: { secret?: string | undefined }) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json());
+  registerWebhookRoutes(app, {
+    store,
+    getConfiguredSecret: () => (opts && "secret" in opts ? opts.secret : SHARED_SECRET),
+  });
+  return app;
+}
+
+function jotformBody(overrides: Partial<{ submissionID: string; formID: string; rawRequest: string | object }> = {}) {
+  const defaults = {
+    submissionID: "5551234567890",
+    formID: "form-abc",
+    rawRequest: JSON.stringify({
+      name: { first: "Pat", last: "Athlete" },
+      email: "pat.athlete@example.com",
+      dob: "2010-04-15",
+      parentName: "Sam Athlete",
+      parentEmail: "sam.athlete@example.com",
+      parentPhone: "555-0100",
+      pdfUrl: "https://www.jotform.com/uploads/abc/waiver.pdf",
+      signedAt: "2024-09-01T12:00:00Z",
+    }),
+  };
+  return { ...defaults, ...overrides };
+}
+
+describe("POST /api/webhooks/jotform-waiver", () => {
+  let infra: ReturnType<typeof buildInMemoryStore>;
+  let app: express.Express;
+
+  beforeEach(() => {
+    infra = buildInMemoryStore();
+    app = buildApp(infra.store);
+  });
+
+  it("rejects when shared secret is missing", async () => {
+    const res = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .type("form")
+      .send(jotformBody());
+    expect(res.status).toBe(401);
+    expect(res.body.ok).toBe(false);
+    expect(infra.submissions.size).toBe(0);
+  });
+
+  it("rejects when shared secret is wrong", async () => {
+    const res = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: "not-the-secret" })
+      .type("form")
+      .send(jotformBody());
+    expect(res.status).toBe(401);
+    expect(infra.submissions.size).toBe(0);
+  });
+
+  it("returns 503 when no shared secret is configured", async () => {
+    const unconfiguredApp = buildApp(infra.store, { secret: undefined });
+    const res = await request(unconfiguredApp)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: "anything" })
+      .type("form")
+      .send(jotformBody());
+    expect(res.status).toBe(503);
+    expect(infra.submissions.size).toBe(0);
+  });
+
+  it("returns 400 when submissionID is missing", async () => {
+    const body = jotformBody();
+    delete (body as any).submissionID;
+    const res = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: SHARED_SECRET })
+      .type("form")
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/submissionID/i);
+    expect(infra.submissions.size).toBe(0);
+  });
+
+  it("returns 400 when rawRequest is missing", async () => {
+    const body = jotformBody();
+    delete (body as any).rawRequest;
+    const res = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: SHARED_SECRET })
+      .type("form")
+      .send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/rawRequest/i);
+    expect(infra.submissions.size).toBe(0);
+  });
+
+  it("returns 400 when rawRequest JSON is malformed", async () => {
+    const res = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: SHARED_SECRET })
+      .type("form")
+      .send({ submissionID: "abc", rawRequest: "{not-json" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/malformed/i);
+    expect(infra.submissions.size).toBe(0);
+  });
+
+  it("processes a valid payload and creates an athlete user", async () => {
+    const res = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: SHARED_SECRET })
+      .type("form")
+      .send(jotformBody());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.status).toBe("created");
+    expect(res.body.submissionId).toBe("5551234567890");
+    expect(res.body.athleteUserId).toBeTypeOf("string");
+
+    expect(infra.submissions.size).toBe(1);
+    const [submission] = Array.from(infra.submissions.values());
+    expect(submission.status).toBe("processed");
+    expect(submission.athleteEmail).toBe("pat.athlete@example.com");
+    expect(submission.athleteFirstName).toBe("Pat");
+    expect(submission.athleteLastName).toBe("Athlete");
+    expect(submission.parentEmail).toBe("sam.athlete@example.com");
+    expect(submission.parentPhone).toBe("555-0100");
+    expect(submission.pdfUrl).toBe("https://www.jotform.com/uploads/abc/waiver.pdf");
+    expect(submission.athleteBirthDate).toBe("2010-04-15");
+    // Raw payload preserved (minus secret)
+    expect(submission.rawPayload).toMatchObject({ submissionID: "5551234567890" });
+    expect((submission.rawPayload as any).secret).toBeUndefined();
+
+    expect(infra.users.size).toBe(1);
+    const [createdUser] = Array.from(infra.users.values());
+    expect(createdUser.emails).toContain("pat.athlete@example.com");
+
+    expect(infra.auditLogs).toHaveLength(1);
+    expect(infra.auditLogs[0]).toMatchObject({
+      action: "waiver_submission_received",
+      resourceType: "waiver_submission",
+      resourceId: submission.id,
+    });
+  });
+
+  it("is idempotent on duplicate submissionID — no double-create", async () => {
+    const body = jotformBody({ submissionID: "dup-1" });
+
+    const first = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: SHARED_SECRET })
+      .type("form")
+      .send(body);
+    expect(first.status).toBe(200);
+    expect(first.body.status).toBe("created");
+
+    const second = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: SHARED_SECRET })
+      .type("form")
+      .send(body);
+    expect(second.status).toBe(200);
+    expect(second.body.status).toBe("duplicate");
+    expect(second.body.submissionId).toBe("dup-1");
+
+    // Exactly one submission, one user, one audit log entry — no doubles.
+    expect(infra.submissions.size).toBe(1);
+    expect(infra.users.size).toBe(1);
+    expect(infra.auditLogs).toHaveLength(1);
+  });
+
+  it("matches an existing user by email rather than creating a new one", async () => {
+    // Pre-seed an existing user with the athlete's email.
+    const existing = await infra.store.createUser({
+      username: "preexisting",
+      emails: ["pat.athlete@example.com"],
+      firstName: "Pat",
+      lastName: "Existing",
+      fullName: "Pat Existing",
+    } as InsertUser);
+
+    const res = await request(app)
+      .post("/api/webhooks/jotform-waiver")
+      .query({ secret: SHARED_SECRET })
+      .type("form")
+      .send(jotformBody({ submissionID: "match-1" }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.athleteUserId).toBe(existing.id);
+    // Still exactly one user — no duplicate created.
+    expect(infra.users.size).toBe(1);
+    const [submission] = Array.from(infra.submissions.values());
+    expect(submission.athleteUserId).toBe(existing.id);
+  });
+
+  it("uses constant-time secret comparison (smoke test)", () => {
+    // Sanity check that timingSafeEqual works for our SHARED_SECRET length.
+    // Not strictly a webhook behavior, but documents the assumption.
+    const a = Buffer.from(SHARED_SECRET);
+    const b = Buffer.from(SHARED_SECRET);
+    expect(crypto.timingSafeEqual(a, b)).toBe(true);
+  });
+});

--- a/packages/api/routes/index.ts
+++ b/packages/api/routes/index.ts
@@ -45,6 +45,7 @@ import { registerPushNotificationRoutes } from "./push-notification-routes";
 import { registerNotificationPreferencesRoutes } from "./notification-preferences-routes";
 import { registerOrgNotificationRoutes } from "./org-notification-routes";
 import { registerAdminNotificationRoutes } from "./admin-notification-routes";
+import { registerWebhookRoutes } from "./webhook-routes";
 
 /**
  * Register all application routes
@@ -177,6 +178,9 @@ export function registerAllRoutes(app: Express) {
 
   // Event report routes (event-specific reports with event percentiles)
   registerEventReportRoutes(app);
+
+  // External webhook routes (Jotform waiver intake — issue #370)
+  registerWebhookRoutes(app);
 
   console.log("✅ All routes registered successfully");
 }

--- a/packages/api/routes/webhook-routes.ts
+++ b/packages/api/routes/webhook-routes.ts
@@ -1,0 +1,175 @@
+/**
+ * Webhook routes — external systems POST here.
+ *
+ * Currently exposes:
+ *   POST /api/webhooks/jotform-waiver — Jotform sends form-encoded body with
+ *     `submissionID` and `rawRequest` (a JSON string of the form answers).
+ *     Authentication is via shared secret query param (`?secret=...`).
+ *
+ * Implementation notes:
+ *   - The route is intentionally CSRF/cookie-free (Jotform is unauthenticated
+ *     to our session). The shared secret is the only auth mechanism.
+ *   - The handler uses constant-time comparison on the secret to avoid timing
+ *     attacks.
+ *   - Idempotency, parsing and persistence are delegated to `waiver-service`
+ *     so the route file stays thin and unit-testable in isolation.
+ */
+
+import type { Express, Request, Response } from "express";
+import crypto from "crypto";
+import {
+  processJotformWaiver,
+  defaultWaiverStore,
+  type WaiverStore,
+  type JotformWaiverEnvelope,
+} from "../services/waiver-service";
+
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+function readSecret(req: Request): string | undefined {
+  // Accept either ?secret=... (per the issue spec) or X-Webhook-Secret header
+  // for parity with other webhook conventions.
+  const fromQuery = req.query?.secret;
+  if (typeof fromQuery === "string" && fromQuery.length > 0) return fromQuery;
+  const fromHeader = req.get("x-webhook-secret");
+  if (typeof fromHeader === "string" && fromHeader.length > 0) return fromHeader;
+  return undefined;
+}
+
+function readSubmissionId(body: any): string | undefined {
+  // Jotform documents the field as `submissionID` (capital ID); accept the
+  // common variants too in case of forwarders that lowercase keys.
+  const candidates = [body?.submissionID, body?.submissionId, body?.submission_id];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim() !== "") return c.trim();
+  }
+  return undefined;
+}
+
+function readRawRequest(body: any): { parsed: Record<string, unknown> } | { error: string } {
+  // Jotform ships rawRequest as a JSON string in the form-encoded body.
+  // Some forwarders may already decode it into an object; handle both.
+  const value = body?.rawRequest ?? body?.raw_request;
+  if (value == null) return { error: "Missing rawRequest" };
+  if (typeof value === "object" && !Array.isArray(value)) return { parsed: value as Record<string, unknown> };
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return { parsed: parsed as Record<string, unknown> };
+      }
+      return { error: "rawRequest JSON must be an object" };
+    } catch (_e) {
+      return { error: "Malformed rawRequest JSON" };
+    }
+  }
+  return { error: "Unsupported rawRequest type" };
+}
+
+export interface RegisterWebhookRoutesOptions {
+  /** Override the underlying store (used in tests). */
+  store?: WaiverStore;
+  /** Override the configured shared secret (used in tests). */
+  getConfiguredSecret?: () => string | undefined;
+}
+
+export function registerWebhookRoutes(app: Express, options: RegisterWebhookRoutesOptions = {}) {
+  const store = options.store ?? defaultWaiverStore;
+  const getConfiguredSecret = options.getConfiguredSecret
+    ?? (() => process.env.JOTFORM_WEBHOOK_SECRET);
+
+  app.post("/api/webhooks/jotform-waiver", async (req: Request, res: Response) => {
+    const configured = getConfiguredSecret();
+    if (!configured) {
+      // Fail closed: if the secret is unset, the webhook is effectively
+      // disabled. This avoids a "no-secret-configured" state silently
+      // allowing every request through.
+      console.error("[webhook:jotform-waiver] JOTFORM_WEBHOOK_SECRET is not configured");
+      return res.status(503).json({ ok: false, error: "Webhook is not configured" });
+    }
+
+    const provided = readSecret(req);
+    if (!provided || !constantTimeEquals(provided, configured)) {
+      return res.status(401).json({ ok: false, error: "Invalid secret" });
+    }
+
+    const submissionId = readSubmissionId(req.body);
+    if (!submissionId) {
+      return res.status(400).json({ ok: false, error: "Missing submissionID" });
+    }
+
+    const rawResult = readRawRequest(req.body);
+    if ("error" in rawResult) {
+      // Persisting bad payloads is intentional skip: we have nothing reliable
+      // to key idempotency on except submissionID, and the body wasn't usable.
+      // Log the rejection with enough context for manual inspection.
+      console.warn("[webhook:jotform-waiver] Rejecting request", {
+        submissionId,
+        reason: rawResult.error,
+      });
+      return res.status(400).json({ ok: false, error: rawResult.error });
+    }
+
+    const envelope: JotformWaiverEnvelope = {
+      submissionId,
+      formId: typeof req.body?.formID === "string" ? req.body.formID
+        : typeof req.body?.formId === "string" ? req.body.formId
+        : null,
+      rawRequest: rawResult.parsed,
+      // Keep the full envelope (including formID, submissionID, etc.) for
+      // recovery — strip only the secret which we already validated.
+      fullPayload: redactSecret(req.body),
+    };
+
+    try {
+      const result = await processJotformWaiver(envelope, store, {
+        ipAddress: req.ip,
+        userAgent: req.get("user-agent"),
+      });
+
+      // Map service result to HTTP status.
+      // 200: created or duplicate (Jotform should treat both as success so it
+      //      stops retrying). 500 only on unrecoverable processing failure.
+      if (result.status === "failed") {
+        return res.status(500).json({
+          ok: false,
+          status: result.status,
+          submissionId: result.submissionId,
+          message: result.message,
+        });
+      }
+      return res.status(200).json({
+        ok: true,
+        status: result.status,
+        submissionId: result.submissionId,
+        athleteUserId: result.athleteUserId,
+      });
+    } catch (err) {
+      // Defensive: processJotformWaiver catches its own errors, but log raw
+      // payload context here too in case the route layer itself throws.
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("[webhook:jotform-waiver] Unhandled processing error", {
+        submissionId,
+        error: message,
+        rawPayloadPreview: typeof req.body === "object"
+          ? Object.keys(req.body).slice(0, 20)
+          : typeof req.body,
+      });
+      return res.status(500).json({ ok: false, error: "Internal error", submissionId });
+    }
+  });
+}
+
+function redactSecret(body: any): Record<string, unknown> {
+  if (!body || typeof body !== "object") return {};
+  const copy: Record<string, unknown> = { ...body };
+  // Defense-in-depth: even though Jotform sends the secret in the query
+  // string, some forwarders include both — never persist secret values.
+  delete copy.secret;
+  return copy;
+}

--- a/packages/api/services/waiver-service.ts
+++ b/packages/api/services/waiver-service.ts
@@ -1,0 +1,366 @@
+/**
+ * Waiver Service — Jotform webhook intake
+ *
+ * Processes a single Jotform waiver submission:
+ *   1. Idempotency: short-circuit if `submission_id` was already received.
+ *   2. Persist the raw payload to `waiver_submissions` so failures can be
+ *      replayed/repaired manually.
+ *   3. Match or create the athlete user by email.
+ *   4. Mark the submission as processed and emit an audit log entry that
+ *      doubles as an internal admin notification (existing pattern in this
+ *      codebase — see `notifyNewMeasurement` / membership-request audit logs).
+ *
+ * Parent/guardian information is denormalized onto the submission row.
+ * AthleteMetrics has no parent/guardian domain yet; introducing one would
+ * exceed the scope of issue #370. The parent fields are intentionally kept
+ * intact on the submission so a future migration can extract them.
+ *
+ * TODO: download the actual PDF binary from `pdfUrl`. Today we record the
+ * Jotform-hosted URL only; binary attachment plumbing does not exist yet
+ * in this repo.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { storage } from "../storage";
+import {
+  waiverSubmissions,
+  type WaiverSubmission,
+  type InsertWaiverSubmission,
+  users,
+  type User,
+  type InsertUser,
+  type InsertAuditLog,
+} from "@shared/schema";
+
+/**
+ * Parsed view of a Jotform webhook envelope. The webhook ships
+ * `submissionID` + `rawRequest` (a JSON string of the form's answers); the
+ * route handler is responsible for parsing those before handing them to the
+ * service.
+ */
+export interface JotformWaiverEnvelope {
+  submissionId: string;
+  formId?: string | null;
+  /** Parsed Jotform `rawRequest` JSON — keys are unique per form. */
+  rawRequest: Record<string, unknown>;
+  /** Original combined payload (rawRequest plus envelope) — preserved as-is. */
+  fullPayload: Record<string, unknown>;
+}
+
+export interface ProcessJotformWaiverContext {
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export interface ProcessJotformWaiverResult {
+  status: "created" | "duplicate" | "failed";
+  submissionId: string;
+  submission?: WaiverSubmission;
+  athleteUserId?: string;
+  message?: string;
+}
+
+/**
+ * Subset of storage/db calls the service needs. Concrete implementations
+ * use Drizzle/storage; tests inject in-memory fakes so we can exercise the
+ * full happy path without a database.
+ */
+export interface WaiverStore {
+  findBySubmissionId(submissionId: string): Promise<WaiverSubmission | undefined>;
+  createSubmission(data: InsertWaiverSubmission): Promise<WaiverSubmission>;
+  markProcessed(id: string, athleteUserId: string | null): Promise<void>;
+  markFailed(id: string, errorMessage: string): Promise<void>;
+  findUserByEmail(email: string): Promise<User | undefined>;
+  createUser(data: InsertUser): Promise<User>;
+  createAuditLog(data: InsertAuditLog): Promise<void>;
+}
+
+export const defaultWaiverStore: WaiverStore = {
+  async findBySubmissionId(submissionId) {
+    const rows = await db
+      .select()
+      .from(waiverSubmissions)
+      .where(eq(waiverSubmissions.submissionId, submissionId))
+      .limit(1);
+    return rows[0];
+  },
+  async createSubmission(data) {
+    const [row] = await db.insert(waiverSubmissions).values(data).returning();
+    return row;
+  },
+  async markProcessed(id, athleteUserId) {
+    await db
+      .update(waiverSubmissions)
+      .set({
+        status: "processed",
+        processedAt: new Date(),
+        athleteUserId: athleteUserId ?? null,
+        errorMessage: null,
+      })
+      .where(eq(waiverSubmissions.id, id));
+  },
+  async markFailed(id, errorMessage) {
+    await db
+      .update(waiverSubmissions)
+      .set({ status: "failed", errorMessage })
+      .where(eq(waiverSubmissions.id, id));
+  },
+  async findUserByEmail(email) {
+    return await storage.getUserByEmail(email);
+  },
+  async createUser(data) {
+    return await storage.createUser(data);
+  },
+  async createAuditLog(data) {
+    await storage.createAuditLog(data);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Field extraction helpers — Jotform field keys vary per form (e.g. `q3_name`,
+// `name`, `email3`). We try a small set of common keys and accept whichever
+// one is present. Operators can extend this list as new forms are added.
+// ---------------------------------------------------------------------------
+
+const ATHLETE_EMAIL_KEYS = ["athleteEmail", "email", "email3"];
+const ATHLETE_NAME_KEYS = ["athleteName", "name", "fullName"];
+const ATHLETE_FIRST_NAME_KEYS = ["athleteFirst", "firstName"];
+const ATHLETE_LAST_NAME_KEYS = ["athleteLast", "lastName"];
+const ATHLETE_BIRTH_DATE_KEYS = ["athleteBirthDate", "birthDate", "dob", "dateOfBirth"];
+const PARENT_NAME_KEYS = ["parentName", "guardianName", "parent"];
+const PARENT_EMAIL_KEYS = ["parentEmail", "guardianEmail"];
+const PARENT_PHONE_KEYS = ["parentPhone", "guardianPhone", "phone"];
+const PDF_URL_KEYS = ["pdfUrl", "pdf", "documentUrl"];
+const SIGNED_AT_KEYS = ["signedAt", "signedDate", "createdAt"];
+
+function pickString(raw: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const v = raw[key];
+    if (typeof v === "string" && v.trim() !== "") return v.trim();
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      // Jotform "name"/"address" style fields are objects with parts.
+      const obj = v as Record<string, unknown>;
+      const parts = ["first", "last", "full", "value"]
+        .map((k) => obj[k])
+        .filter((p): p is string => typeof p === "string" && p.trim() !== "");
+      if (parts.length > 0) return parts.join(" ").trim();
+    }
+  }
+  return undefined;
+}
+
+function pickFirstLast(raw: Record<string, unknown>, keys: string[]): { first?: string; last?: string } {
+  for (const key of keys) {
+    const v = raw[key];
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      const obj = v as Record<string, unknown>;
+      const first = typeof obj.first === "string" ? obj.first.trim() : undefined;
+      const last = typeof obj.last === "string" ? obj.last.trim() : undefined;
+      if (first || last) return { first, last };
+    }
+  }
+  return {};
+}
+
+function parseDateSafe(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  // Jotform "date" fields can be "YYYY-MM-DD" or "MM/DD/YYYY". Try ISO first.
+  const isoMatch = value.match(/^\d{4}-\d{2}-\d{2}/);
+  if (isoMatch) return isoMatch[0];
+  const us = value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (us) {
+    const [_, m, d, y] = us;
+    return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}`;
+  }
+  return undefined;
+}
+
+function parseTimestampSafe(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const t = Date.parse(value);
+  return Number.isNaN(t) ? undefined : new Date(t);
+}
+
+interface ExtractedFields {
+  athleteEmail?: string;
+  athleteFirstName?: string;
+  athleteLastName?: string;
+  athleteBirthDate?: string;
+  parentName?: string;
+  parentEmail?: string;
+  parentPhone?: string;
+  pdfUrl?: string;
+  signedAt?: Date;
+}
+
+export function extractWaiverFields(raw: Record<string, unknown>): ExtractedFields {
+  const email = pickString(raw, ATHLETE_EMAIL_KEYS);
+  const fullName = pickString(raw, ATHLETE_NAME_KEYS);
+  let first = pickString(raw, ATHLETE_FIRST_NAME_KEYS);
+  let last = pickString(raw, ATHLETE_LAST_NAME_KEYS);
+  if (!first || !last) {
+    const fl = pickFirstLast(raw, ATHLETE_NAME_KEYS);
+    first = first ?? fl.first;
+    last = last ?? fl.last;
+  }
+  if ((!first || !last) && fullName) {
+    const parts = fullName.split(/\s+/);
+    if (!first) first = parts[0];
+    if (!last && parts.length > 1) last = parts.slice(1).join(" ");
+  }
+
+  return {
+    athleteEmail: email?.toLowerCase(),
+    athleteFirstName: first,
+    athleteLastName: last,
+    athleteBirthDate: parseDateSafe(pickString(raw, ATHLETE_BIRTH_DATE_KEYS)),
+    parentName: pickString(raw, PARENT_NAME_KEYS),
+    parentEmail: pickString(raw, PARENT_EMAIL_KEYS)?.toLowerCase(),
+    parentPhone: pickString(raw, PARENT_PHONE_KEYS),
+    pdfUrl: pickString(raw, PDF_URL_KEYS),
+    signedAt: parseTimestampSafe(pickString(raw, SIGNED_AT_KEYS)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Username helpers — derive a stable, unique-ish username from the email so
+// we can satisfy the NOT NULL+UNIQUE constraint on users.username for athletes
+// auto-created from waiver intake. Uniqueness is handled later by appending a
+// suffix on collision.
+// ---------------------------------------------------------------------------
+
+function deriveUsername(email: string, submissionId: string): string {
+  const local = email.split("@")[0]?.toLowerCase() ?? "athlete";
+  const cleaned = local.replace(/[^a-z0-9_]/g, "_").slice(0, 24);
+  // Use last 6 chars of submissionId as a stable disambiguator so retried
+  // webhooks for the same submission produce the same username candidate.
+  const suffix = submissionId.slice(-6).replace(/[^a-zA-Z0-9]/g, "x");
+  return `${cleaned || "athlete"}_${suffix}`.toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export async function processJotformWaiver(
+  envelope: JotformWaiverEnvelope,
+  store: WaiverStore = defaultWaiverStore,
+  context: ProcessJotformWaiverContext = {},
+): Promise<ProcessJotformWaiverResult> {
+  const { submissionId } = envelope;
+
+  // 1. Idempotency.
+  const existing = await store.findBySubmissionId(submissionId);
+  if (existing) {
+    return {
+      status: "duplicate",
+      submissionId,
+      submission: existing,
+      athleteUserId: existing.athleteUserId ?? undefined,
+      message: "Submission already processed",
+    };
+  }
+
+  // 2. Field extraction.
+  const fields = extractWaiverFields(envelope.rawRequest);
+
+  // 3. Persist the raw payload up front so we always have the data even if
+  //    user creation fails downstream.
+  const submission = await store.createSubmission({
+    submissionId,
+    formId: envelope.formId ?? null,
+    source: "jotform",
+    athleteEmail: fields.athleteEmail ?? null,
+    athleteFirstName: fields.athleteFirstName ?? null,
+    athleteLastName: fields.athleteLastName ?? null,
+    athleteBirthDate: fields.athleteBirthDate ?? null,
+    parentName: fields.parentName ?? null,
+    parentEmail: fields.parentEmail ?? null,
+    parentPhone: fields.parentPhone ?? null,
+    pdfUrl: fields.pdfUrl ?? null,
+    signedAt: fields.signedAt ?? null,
+    rawPayload: envelope.fullPayload as any,
+    status: "received",
+  });
+
+  // 4. Match-or-create the athlete user.
+  try {
+    let athleteUserId: string | null = null;
+
+    if (fields.athleteEmail) {
+      const matched = await store.findUserByEmail(fields.athleteEmail);
+      if (matched) {
+        athleteUserId = matched.id;
+      } else {
+        const first = fields.athleteFirstName ?? "Waiver";
+        const last = fields.athleteLastName ?? "Athlete";
+        // `fullName` and `birthYear` are computed inside storage.createUser,
+        // so we deliberately do not provide them here. `password` is also
+        // computed (placeholder hash inserted for invitation-pending accounts).
+        const created = await store.createUser({
+          username: deriveUsername(fields.athleteEmail, submissionId),
+          emails: [fields.athleteEmail],
+          firstName: first,
+          lastName: last,
+          isActive: true,
+          isSiteAdmin: false,
+        } as unknown as InsertUser);
+        athleteUserId = created.id;
+      }
+    }
+
+    await store.markProcessed(submission.id, athleteUserId);
+
+    // 5. Internal admin notification via audit log (consistent with
+    //    membership-request and OAuth flows that all use audit logs as their
+    //    "internal notification" channel today).
+    await store.createAuditLog({
+      userId: athleteUserId ?? null,
+      action: "waiver_submission_received",
+      resourceType: "waiver_submission",
+      resourceId: submission.id,
+      details: JSON.stringify({
+        submissionId,
+        formId: envelope.formId ?? null,
+        athleteEmail: fields.athleteEmail ?? null,
+        athleteName: [fields.athleteFirstName, fields.athleteLastName].filter(Boolean).join(" ") || null,
+        parentName: fields.parentName ?? null,
+        parentEmail: fields.parentEmail ?? null,
+        pdfUrl: fields.pdfUrl ?? null,
+        athleteAutoCreated: !!athleteUserId && !fields.athleteEmail
+          ? false
+          : (athleteUserId ? "see athlete_user_id" : false),
+        timestamp: new Date().toISOString(),
+      }),
+      ipAddress: context.ipAddress ?? null,
+      userAgent: context.userAgent ?? null,
+    } as InsertAuditLog);
+
+    return {
+      status: "created",
+      submissionId,
+      submission: { ...submission, athleteUserId, status: "processed" },
+      athleteUserId: athleteUserId ?? undefined,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Failure is logged with enough context (submission row + raw payload)
+    // for a human to manually recover.
+    console.error("[waiver-service] Failed to process Jotform waiver", {
+      submissionId,
+      error: message,
+    });
+    try {
+      await store.markFailed(submission.id, message);
+    } catch (markErr) {
+      console.error("[waiver-service] Additionally failed to mark submission failed", markErr);
+    }
+    return {
+      status: "failed",
+      submissionId,
+      submission,
+      message,
+    };
+  }
+}

--- a/packages/shared/migrations/0024_add_waiver_submissions.sql
+++ b/packages/shared/migrations/0024_add_waiver_submissions.sql
@@ -1,0 +1,37 @@
+-- Migration: Add waiver_submissions table for Jotform webhook intake (issue #370)
+--
+-- Tracks raw waiver submissions received via external webhooks. The unique
+-- constraint on submission_id provides idempotency for retried webhook deliveries.
+-- Raw payload is preserved for manual recovery if downstream processing fails.
+
+CREATE TABLE IF NOT EXISTS waiver_submissions (
+  id              VARCHAR PRIMARY KEY DEFAULT gen_random_uuid(),
+  submission_id   TEXT NOT NULL UNIQUE,
+  form_id         TEXT,
+  source          TEXT NOT NULL DEFAULT 'jotform',
+  athlete_user_id VARCHAR REFERENCES users(id) ON DELETE SET NULL,
+  athlete_email   TEXT,
+  athlete_first_name TEXT,
+  athlete_last_name  TEXT,
+  athlete_birth_date DATE,
+  parent_name     TEXT,
+  parent_email    TEXT,
+  parent_phone    TEXT,
+  pdf_url         TEXT,
+  signed_at       TIMESTAMP,
+  status          TEXT NOT NULL DEFAULT 'received'
+                  CHECK (status IN ('received', 'processed', 'failed')),
+  error_message   TEXT,
+  raw_payload     JSONB NOT NULL,
+  processed_at    TIMESTAMP,
+  created_at      TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS waiver_submissions_athlete_user_id_idx
+  ON waiver_submissions (athlete_user_id);
+CREATE INDEX IF NOT EXISTS waiver_submissions_athlete_email_idx
+  ON waiver_submissions (athlete_email);
+CREATE INDEX IF NOT EXISTS waiver_submissions_status_idx
+  ON waiver_submissions (status);
+CREATE INDEX IF NOT EXISTS waiver_submissions_created_at_idx
+  ON waiver_submissions (created_at);

--- a/packages/shared/schema/enums.ts
+++ b/packages/shared/schema/enums.ts
@@ -125,3 +125,12 @@ export const registrationStatusEnum = ['pending', 'approved', 'waitlisted', 'dec
  * Event invitation status enum
  */
 export const eventInvitationStatusEnum = ['pending', 'accepted', 'declined', 'expired', 'cancelled'] as const;
+
+/**
+ * Waiver submission status enum (Jotform webhook intake)
+ * - received: payload accepted and persisted, processing not yet finished
+ * - processed: athlete record created/matched and waiver linked successfully
+ * - failed: processing raised an error after persisting the raw payload
+ */
+export const waiverSubmissionStatusEnum = ['received', 'processed', 'failed'] as const;
+export type WaiverSubmissionStatus = (typeof waiverSubmissionStatusEnum)[number];

--- a/packages/shared/schema/tables/index.ts
+++ b/packages/shared/schema/tables/index.ts
@@ -17,3 +17,4 @@ export * from "./gamification";
 export * from "./global-athletes";
 export * from "./notifications";
 export * from "./events";
+export * from "./waivers";

--- a/packages/shared/schema/tables/waivers.ts
+++ b/packages/shared/schema/tables/waivers.ts
@@ -1,0 +1,58 @@
+/**
+ * Waiver Tables
+ *
+ * waiverSubmissions tracks intake of athlete waivers received via external
+ * webhooks (currently Jotform). Each Jotform submission is persisted with
+ * its raw payload for replay/recovery, and idempotency is enforced via the
+ * unique submissionId column.
+ *
+ * Parent/guardian information is intentionally stored as denormalized fields
+ * on this table rather than as a separate domain — this is a vertical slice
+ * for the issue #370 webhook intake. A dedicated parent/guardian domain can
+ * be extracted later if/when other features require it.
+ */
+
+import { sql } from "drizzle-orm";
+import { pgTable, text, varchar, timestamp, date, jsonb, index } from "drizzle-orm/pg-core";
+import { waiverSubmissionStatusEnum } from "../enums";
+import { users } from "./core";
+
+export const waiverSubmissions = pgTable("waiver_submissions", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  // External submission identifier from Jotform (used for idempotency)
+  submissionId: text("submission_id").notNull().unique(),
+  // Optional Jotform form id (so multiple waiver forms can be distinguished later)
+  formId: text("form_id"),
+  source: text("source").default("jotform").notNull(),
+  // Athlete the waiver pertains to (set after we create or match the user)
+  athleteUserId: varchar("athlete_user_id").references(() => users.id, { onDelete: "set null" }),
+  athleteEmail: text("athlete_email"),
+  athleteFirstName: text("athlete_first_name"),
+  athleteLastName: text("athlete_last_name"),
+  athleteBirthDate: date("athlete_birth_date"),
+  // Parent/guardian fields stored inline (no dedicated domain yet)
+  parentName: text("parent_name"),
+  parentEmail: text("parent_email"),
+  parentPhone: text("parent_phone"),
+  // Waiver document metadata. We persist the Jotform-hosted PDF URL today;
+  // actually downloading and re-hosting the PDF binary is intentionally
+  // deferred — see TODO in waiver-service.ts.
+  pdfUrl: text("pdf_url"),
+  signedAt: timestamp("signed_at"),
+  // Lifecycle
+  status: text("status", { enum: waiverSubmissionStatusEnum }).default("received").notNull(),
+  errorMessage: text("error_message"),
+  // Full raw payload (Jotform `rawRequest` parsed JSON plus envelope) for
+  // manual recovery if processing fails partway through.
+  rawPayload: jsonb("raw_payload").notNull(),
+  processedAt: timestamp("processed_at"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (table) => ({
+  athleteUserIdx: index("waiver_submissions_athlete_user_id_idx").on(table.athleteUserId),
+  athleteEmailIdx: index("waiver_submissions_athlete_email_idx").on(table.athleteEmail),
+  statusIdx: index("waiver_submissions_status_idx").on(table.status),
+  createdAtIdx: index("waiver_submissions_created_at_idx").on(table.createdAt),
+}));
+
+export type WaiverSubmission = typeof waiverSubmissions.$inferSelect;
+export type InsertWaiverSubmission = typeof waiverSubmissions.$inferInsert;


### PR DESCRIPTION
## Summary
- add `POST /api/webhooks/jotform-waiver` with shared-secret auth
- persist Jotform submissions in a new `waiver_submissions` table with idempotency on `submissionID`
- match existing athletes by email or auto-create a user, then log `waiver_submission_received`
- add focused webhook tests for happy path, duplicates, malformed payloads, and secret failures

## Notes
- this is a safe vertical slice for issue #370, since AthleteMetrics does not yet have a full parent/guardian/waiver domain model
- the implementation stores the Jotform-hosted PDF URL and raw payload metadata for manual recovery; it does not yet download and re-host the PDF binary
- internal notification currently rides on the existing audit-log pattern

## Verification
- `npx vitest --run packages/api/__tests__/jotform-webhook-routes.test.ts`
