### PR TITLE
fix(schema): tier_group_id declared as uuid (closes #398)

### DIFF
--- a/packages/shared/schema-original.ts
+++ b/packages/shared/schema-original.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { pgTable, text, varchar, integer, decimal, timestamp, date, boolean, unique, index, jsonb, time } from "drizzle-orm/pg-core";
+import { pgTable, text, varchar, uuid, integer, decimal, timestamp, date, boolean, unique, index, jsonb, time } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -279,7 +279,7 @@ export const siteBenchmarks = pgTable("site_benchmarks", {
   minValue: decimal("min_value", { precision: 10, scale: 2 }),
   maxValue: decimal("max_value", { precision: 10, scale: 2 }),
   // Tier grouping fields (migration 0077)
-  tierGroupId: varchar("tier_group_id"),
+  tierGroupId: uuid("tier_group_id"),
   tierOrder: integer("tier_order"),
   tierName: varchar("tier_name", { length: 50 }),
   tierColor: varchar("tier_color", { length: 20 }),
@@ -337,7 +337,7 @@ export const customBenchmarks = pgTable("custom_benchmarks", {
   minValue: decimal("min_value", { precision: 10, scale: 2 }),
   maxValue: decimal("max_value", { precision: 10, scale: 2 }),
   // Tier grouping fields (migration 0077)
-  tierGroupId: varchar("tier_group_id"),
+  tierGroupId: uuid("tier_group_id"),
   tierOrder: integer("tier_order"),
   tierName: varchar("tier_name", { length: 50 }),
   tierColor: varchar("tier_color", { length: 20 }),

--- a/packages/shared/schema/tables/benchmarks.ts
+++ b/packages/shared/schema/tables/benchmarks.ts
@@ -5,7 +5,7 @@
  */
 
 import { sql } from "drizzle-orm";
-import { pgTable, varchar, integer, decimal, timestamp, boolean, unique, index, text, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, varchar, uuid, integer, decimal, timestamp, boolean, unique, index, text, jsonb } from "drizzle-orm/pg-core";
 import { organizationTypeEnum } from "../enums";
 import { organizations, users } from "./core";
 import { siteMetrics } from "./metrics";
@@ -22,7 +22,7 @@ export const siteBenchmarks = pgTable("site_benchmarks", {
   minValue: decimal("min_value", { precision: 10, scale: 2 }),
   maxValue: decimal("max_value", { precision: 10, scale: 2 }),
   // Tier grouping fields (migration 0077)
-  tierGroupId: varchar("tier_group_id"),
+  tierGroupId: uuid("tier_group_id"),
   tierOrder: integer("tier_order"),
   tierName: varchar("tier_name", { length: 50 }),
   tierColor: varchar("tier_color", { length: 20 }),
@@ -81,7 +81,7 @@ export const customBenchmarks = pgTable("custom_benchmarks", {
   minValue: decimal("min_value", { precision: 10, scale: 2 }),
   maxValue: decimal("max_value", { precision: 10, scale: 2 }),
   // Tier grouping fields (migration 0077)
-  tierGroupId: varchar("tier_group_id"),
+  tierGroupId: uuid("tier_group_id"),
   tierOrder: integer("tier_order"),
   tierName: varchar("tier_name", { length: 50 }),
   tierColor: varchar("tier_color", { length: 20 }),


### PR DESCRIPTION
## Summary
- Declare `site_benchmarks.tier_group_id` and `custom_benchmarks.tier_group_id` as `uuid` in the Drizzle schema, matching the actual PostgreSQL column type from migration `0077_add_tier_grouping.sql`.
- Closes #398.

## Why
- Drizzle previously declared the column as `varchar`; the actual DB column is `uuid` (per `migrations/0077_add_tier_grouping.sql`).
- `npm run db:push` would propose a destructive `ALTER COLUMN TYPE varchar` migration to "reconcile" the drift, silently downgrading the column's native UUID type.
- Zod input validation already uses `z.string().uuid()` upstream — this fix completes the three-way alignment (Drizzle / Zod / DB).

## Test plan
- [x] `npm run check` passes (TypeScript clean)
- [x] `npx vitest run tests/migrations/` passes — 36 passed, 1 intentionally skipped
- [x] No callsite breakage: all `eq(siteBenchmarks.tierGroupId, …)` / `eq(customBenchmarks.tierGroupId, …)` queries pass UUIDs sourced from `crypto.randomUUID()` (server: `benchmark-service.ts:346`; client: `BenchmarkForm.tsx:482`)
- [ ] **Recommended pre-merge:** run `DATABASE_URL=<dev_url> npm run db:push` and confirm it reports no schema changes (proves Drizzle and DB now agree)

## Diff scope
4 line-pairs across 2 files:

| File | Change |
|---|---|
| `packages/shared/schema/tables/benchmarks.ts` | Add `uuid` to imports; swap `varchar` → `uuid` for `tierGroupId` (×2) |
| `packages/shared/schema-original.ts` | Same swap on the legacy re-export source (×2) |

## Future improvement (out of scope for this PR)
A small assertion test against `information_schema.columns` confirming `tier_group_id` resolves to type `uuid` would prevent re-introducing this exact drift. Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)