### PR TITLE
feat(metrics): bilateral 5-0-5 + LSI screening migration (AM-FEAT-008)

### DIFF
--- a/migrations/0128_add_bilateral_505_lsi_metrics.sql
+++ b/migrations/0128_add_bilateral_505_lsi_metrics.sql
@@ -108,7 +108,7 @@ INSERT INTO site_benchmarks (
    'AGILITY_505_LSI',
    'LSI Monitor (90-95%)',
    'LSI 90–95%. Borderline; bias bilateral loading toward weak side. Source: Bishop et al.',
-   'range', 90, 95,
+   'range', 90, 94.999,
    'a505a505-0128-4505-9151-aaaaaaaaaaaa'::uuid, 2, 'Monitor', 'yellow',
    'Female', true, true, 2),
 
@@ -116,7 +116,7 @@ INSERT INTO site_benchmarks (
    'AGILITY_505_LSI',
    'LSI Elevated Risk (<90%)',
    'LSI < 90% — clinically meaningful asymmetry. Targeted unilateral strength on weak side; do not progress to high-intensity reactive work until corrected. Sources: Bishop, Hewett, Dos''Santos.',
-   'range', 0, 90,
+   'range', 0, 89.999,
    'a505a505-0128-4505-9151-aaaaaaaaaaaa'::uuid, 3, 'Elevated Risk', 'red',
    'Female', true, true, 3)
 ON CONFLICT (metric_code, name) DO UPDATE SET

--- a/migrations/0128_add_bilateral_505_lsi_metrics.sql
+++ b/migrations/0128_add_bilateral_505_lsi_metrics.sql
@@ -1,0 +1,287 @@
+-- Migration 0128: Bilateral 5-0-5 + Limb Symmetry Index (LSI) Screening
+--
+-- Spec: AM-FEAT-008 (/home/hulla/devel/bta-company/specs/AM-FEAT-008_bilateral-505-lsi.md)
+--
+-- Adds the LSI derived metric and screening benchmark set for bilateral
+-- asymmetry detection. Per-leg base metrics AGILITY_505_L / AGILITY_505_R
+-- already exist (seeded by migration 0107).
+--
+-- Bilateral asymmetry (>10% LSI / >0.15s absolute difference) is the
+-- contemporary clinical predictor of non-contact ACL, hamstring, and adductor
+-- injury in female soccer athletes. See /docs/benchmarks/cod-research-context.md §9
+-- (Bishop et al. on LSI cutoffs; Hewett et al. ACL prospective; Dos'Santos
+-- on 180° turn biomechanics).
+--
+-- Block layout:
+--   A — AGILITY_505_LSI derived metric definition
+--   B — Screening benchmark set (Female Bilateral Asymmetry Screening)
+--   C — Three LSI tier rows (Normal / Monitor / Elevated Risk)
+--   D — Wire LSI tiers into the screening set
+--   E — Per-leg AGILITY_505_L / _R tier copies derived from existing
+--       AGILITY_505 tier rows (no-op if AM-FEAT-007 hasn't landed yet)
+--   F — Per-leg benchmark_set_items mirroring AGILITY_505 set memberships
+--
+-- All inserts are idempotent (ON CONFLICT DO UPDATE) per spec §Acceptance.
+
+-- ============================================================================
+-- Block A — AGILITY_505_LSI derived metric
+-- ============================================================================
+INSERT INTO site_metrics (
+  code, label, category, unit, metric_type, is_system_default, is_active,
+  display_order, description, decimal_precision, color, icon,
+  validation_min, validation_max,
+  is_derived, formula, dependent_metrics, calculation_config
+) VALUES (
+  'AGILITY_505_LSI',
+  '5-0-5 Limb Symmetry Index',
+  'agility',
+  '%',
+  'higher_is_better',
+  true, true,
+  40,
+  'Limb Symmetry Index between left- and right-foot 5-0-5 turn times. Computed as (faster_leg / slower_leg) × 100. 100% = perfectly symmetric; <90% indicates clinically meaningful asymmetry and elevated lower-limb injury risk per Bishop et al., Hewett et al., and Dos''Santos et al. See cod-research-context.md §9.',
+  1, 'green', 'Activity',
+  0, 100,
+  true,
+  '(min(AGILITY_505_L, AGILITY_505_R) / max(AGILITY_505_L, AGILITY_505_R)) * 100',
+  ARRAY['AGILITY_505_L', 'AGILITY_505_R'],
+  '{"dateMatchStrategy":"same_date","missingSourceBehavior":"skip"}'::jsonb
+)
+ON CONFLICT (code) DO UPDATE SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  formula = EXCLUDED.formula,
+  dependent_metrics = EXCLUDED.dependent_metrics,
+  calculation_config = EXCLUDED.calculation_config,
+  is_derived = EXCLUDED.is_derived,
+  metric_type = EXCLUDED.metric_type,
+  unit = EXCLUDED.unit,
+  validation_min = EXCLUDED.validation_min,
+  validation_max = EXCLUDED.validation_max,
+  is_active = true;
+
+-- ============================================================================
+-- Block B — Screening benchmark set
+-- ============================================================================
+INSERT INTO benchmark_sets (
+  id, organization_id, name, description, sport, level, gender,
+  is_template, is_active
+) VALUES (
+  'set-screening-female-bilateral-asymmetry',
+  NULL,
+  'Female Bilateral Asymmetry Screening',
+  'Screening tiers for AGILITY_505_LSI applying to female athletes in soccer and volleyball. Tiers reflect clinical injury-risk thresholds, not competitive levels. Sources: Bishop et al. (LSI cutoffs in athletic populations), Hewett et al. (prospective ACL injury studies), Dos''Santos et al. (180° turn biomechanics). See cod-research-context.md §9.',
+  NULL,
+  NULL,
+  'Female',
+  true, true
+)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  gender = EXCLUDED.gender,
+  is_template = EXCLUDED.is_template,
+  is_active = true,
+  updated_at = NOW();
+
+-- ============================================================================
+-- Block C — LSI tier rows (Normal / Monitor / Elevated Risk)
+--
+-- All three rows share tier_group_id 'tg-screening-asym-lsi'.
+-- LSI is higher_is_better, so tier_order 1 = best (highest LSI = most symmetric).
+-- ============================================================================
+INSERT INTO site_benchmarks (
+  id, metric_code, name, description,
+  comparison_operator, min_value, max_value,
+  tier_group_id, tier_order, tier_name, tier_color,
+  gender, is_system_default, is_active, display_order
+) VALUES
+  ('bench-screening-asym-lsi-normal',
+   'AGILITY_505_LSI',
+   'LSI Normal (>=95%)',
+   'LSI ≥ 95%. Within expected range; continue programming. Source: Bishop et al.',
+   'range', 95, 100,
+   'a505a505-0128-4505-9151-aaaaaaaaaaaa'::uuid, 1, 'Normal', 'green',
+   'Female', true, true, 1),
+
+  ('bench-screening-asym-lsi-monitor',
+   'AGILITY_505_LSI',
+   'LSI Monitor (90-95%)',
+   'LSI 90–95%. Borderline; bias bilateral loading toward weak side. Source: Bishop et al.',
+   'range', 90, 95,
+   'a505a505-0128-4505-9151-aaaaaaaaaaaa'::uuid, 2, 'Monitor', 'yellow',
+   'Female', true, true, 2),
+
+  ('bench-screening-asym-lsi-elevated',
+   'AGILITY_505_LSI',
+   'LSI Elevated Risk (<90%)',
+   'LSI < 90% — clinically meaningful asymmetry. Targeted unilateral strength on weak side; do not progress to high-intensity reactive work until corrected. Sources: Bishop, Hewett, Dos''Santos.',
+   'range', 0, 90,
+   'a505a505-0128-4505-9151-aaaaaaaaaaaa'::uuid, 3, 'Elevated Risk', 'red',
+   'Female', true, true, 3)
+ON CONFLICT (metric_code, name) DO UPDATE SET
+  description = EXCLUDED.description,
+  min_value = EXCLUDED.min_value,
+  max_value = EXCLUDED.max_value,
+  comparison_operator = EXCLUDED.comparison_operator,
+  tier_group_id = EXCLUDED.tier_group_id,
+  tier_order = EXCLUDED.tier_order,
+  tier_color = EXCLUDED.tier_color,
+  is_active = true;
+
+-- ============================================================================
+-- Block D — Wire LSI tier rows into the screening set
+-- ============================================================================
+INSERT INTO benchmark_set_items (id, set_id, benchmark_id, benchmark_type, display_order)
+VALUES
+  ('bsi-screening-asym-lsi-normal',   'set-screening-female-bilateral-asymmetry', 'bench-screening-asym-lsi-normal',   'site', 1),
+  ('bsi-screening-asym-lsi-monitor',  'set-screening-female-bilateral-asymmetry', 'bench-screening-asym-lsi-monitor',  'site', 2),
+  ('bsi-screening-asym-lsi-elevated', 'set-screening-female-bilateral-asymmetry', 'bench-screening-asym-lsi-elevated', 'site', 3)
+ON CONFLICT (set_id, benchmark_id, benchmark_type) DO UPDATE SET
+  display_order = EXCLUDED.display_order;
+
+-- ============================================================================
+-- Block E — Per-leg tier copies from existing AGILITY_505 rows
+--
+-- Generates AGILITY_505_L and AGILITY_505_R tier-group copies of every
+-- AGILITY_505 site_benchmarks row that AM-FEAT-007 created. Robust to
+-- whatever IDs / set memberships AM-FEAT-007 chooses — runs as a no-op
+-- if no AGILITY_505 tier rows exist yet.
+--
+-- Deterministic ID derivation:
+--   id            : <source id>-l  / <source id>-r        (varchar)
+--   tier_group_id : md5(<source uuid>::text || '-l')::uuid (uuid; PostgreSQL
+--                   accepts 32-hex-char strings as UUIDs without hyphens, and
+--                   md5() returns exactly that — no extensions required.)
+--
+-- Name disambiguation: append ' (Left)' / ' (Right)' to the source name,
+-- which preserves the uniqueness constraint on (metric_code, name).
+-- ============================================================================
+INSERT INTO site_benchmarks (
+  id, metric_code, name, description,
+  comparison_operator, benchmark_value, min_value, max_value,
+  tier_group_id, tier_order, tier_name, tier_color,
+  applicable_org_types,
+  gender, age_min, age_max, sport, position, level,
+  is_system_default, is_active, display_order,
+  benchmark_source, peer_percentile_target, peer_filter_criteria,
+  color, icon
+)
+SELECT
+  src.id || '-l',
+  'AGILITY_505_L',
+  src.name || ' (Left)',
+  COALESCE(src.description, '') || ' Applies to left-foot pivot.',
+  src.comparison_operator, src.benchmark_value, src.min_value, src.max_value,
+  md5(src.tier_group_id::text || '-l')::uuid,
+  src.tier_order, src.tier_name, src.tier_color,
+  src.applicable_org_types,
+  src.gender, src.age_min, src.age_max, src.sport, src.position, src.level,
+  src.is_system_default, src.is_active, src.display_order,
+  src.benchmark_source, src.peer_percentile_target, src.peer_filter_criteria,
+  src.color, src.icon
+FROM site_benchmarks src
+WHERE src.metric_code = 'AGILITY_505'
+  AND src.tier_group_id IS NOT NULL
+ON CONFLICT (metric_code, name) DO UPDATE SET
+  description = EXCLUDED.description,
+  benchmark_value = EXCLUDED.benchmark_value,
+  min_value = EXCLUDED.min_value,
+  max_value = EXCLUDED.max_value,
+  tier_order = EXCLUDED.tier_order,
+  tier_color = EXCLUDED.tier_color,
+  is_active = EXCLUDED.is_active;
+
+INSERT INTO site_benchmarks (
+  id, metric_code, name, description,
+  comparison_operator, benchmark_value, min_value, max_value,
+  tier_group_id, tier_order, tier_name, tier_color,
+  applicable_org_types,
+  gender, age_min, age_max, sport, position, level,
+  is_system_default, is_active, display_order,
+  benchmark_source, peer_percentile_target, peer_filter_criteria,
+  color, icon
+)
+SELECT
+  src.id || '-r',
+  'AGILITY_505_R',
+  src.name || ' (Right)',
+  COALESCE(src.description, '') || ' Applies to right-foot pivot.',
+  src.comparison_operator, src.benchmark_value, src.min_value, src.max_value,
+  md5(src.tier_group_id::text || '-r')::uuid,
+  src.tier_order, src.tier_name, src.tier_color,
+  src.applicable_org_types,
+  src.gender, src.age_min, src.age_max, src.sport, src.position, src.level,
+  src.is_system_default, src.is_active, src.display_order,
+  src.benchmark_source, src.peer_percentile_target, src.peer_filter_criteria,
+  src.color, src.icon
+FROM site_benchmarks src
+WHERE src.metric_code = 'AGILITY_505'
+  AND src.tier_group_id IS NOT NULL
+ON CONFLICT (metric_code, name) DO UPDATE SET
+  description = EXCLUDED.description,
+  benchmark_value = EXCLUDED.benchmark_value,
+  min_value = EXCLUDED.min_value,
+  max_value = EXCLUDED.max_value,
+  tier_order = EXCLUDED.tier_order,
+  tier_color = EXCLUDED.tier_color,
+  is_active = EXCLUDED.is_active;
+
+-- ============================================================================
+-- Block F — Per-leg benchmark_set_items mirroring AGILITY_505 memberships
+--
+-- For every existing benchmark_set_items row that points at an AGILITY_505
+-- site_benchmark, create two parallel rows pointing at the freshly-seeded
+-- _L and _R copies. ID derivation matches Block E: <source bsi id>-l / -r.
+-- ============================================================================
+INSERT INTO benchmark_set_items (
+  id, set_id, benchmark_id, benchmark_type, display_order, custom_label
+)
+SELECT
+  bsi.id || '-l',
+  bsi.set_id,
+  bsi.benchmark_id || '-l',
+  'site',
+  bsi.display_order,
+  bsi.custom_label
+FROM benchmark_set_items bsi
+JOIN site_benchmarks sb
+  ON bsi.benchmark_id = sb.id
+ AND bsi.benchmark_type = 'site'
+WHERE sb.metric_code = 'AGILITY_505'
+ON CONFLICT (set_id, benchmark_id, benchmark_type) DO UPDATE SET
+  display_order = EXCLUDED.display_order,
+  custom_label = EXCLUDED.custom_label;
+
+INSERT INTO benchmark_set_items (
+  id, set_id, benchmark_id, benchmark_type, display_order, custom_label
+)
+SELECT
+  bsi.id || '-r',
+  bsi.set_id,
+  bsi.benchmark_id || '-r',
+  'site',
+  bsi.display_order,
+  bsi.custom_label
+FROM benchmark_set_items bsi
+JOIN site_benchmarks sb
+  ON bsi.benchmark_id = sb.id
+ AND bsi.benchmark_type = 'site'
+WHERE sb.metric_code = 'AGILITY_505'
+ON CONFLICT (set_id, benchmark_id, benchmark_type) DO UPDATE SET
+  display_order = EXCLUDED.display_order,
+  custom_label = EXCLUDED.custom_label;
+
+DO $$
+DECLARE
+  v_lsi_tiers      INTEGER;
+  v_per_leg_rows   INTEGER;
+  v_per_leg_items  INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_lsi_tiers FROM site_benchmarks WHERE tier_group_id = 'a505a505-0128-4505-9151-aaaaaaaaaaaa'::uuid;
+  SELECT COUNT(*) INTO v_per_leg_rows FROM site_benchmarks WHERE metric_code IN ('AGILITY_505_L', 'AGILITY_505_R');
+  SELECT COUNT(*) INTO v_per_leg_items FROM benchmark_set_items WHERE id LIKE '%-l' OR id LIKE '%-r';
+
+  RAISE NOTICE 'Migration 0128 complete: AGILITY_505_LSI derived metric, % LSI tier rows, % per-leg site_benchmarks rows, % per-leg benchmark_set_items rows.',
+    v_lsi_tiers, v_per_leg_rows, v_per_leg_items;
+END $$;

--- a/migrations/0128_add_bilateral_505_lsi_metrics_down.sql
+++ b/migrations/0128_add_bilateral_505_lsi_metrics_down.sql
@@ -1,0 +1,72 @@
+-- Down Migration 0128: Reverse Bilateral 5-0-5 + LSI Screening
+--
+-- Reverses migration 0128 in dependency-safe order:
+--   Step 1 — benchmark_set_items rows (Blocks D + F)        [soft refs, no FK]
+--   Step 2 — site_benchmarks rows (Blocks C + E)            [referenced by step 1]
+--   Step 3 — benchmark_sets row (Block B)
+--   Step 4 — site_metrics row (Block A)                     [last; ON DELETE CASCADE
+--                                                            on site_benchmarks.metric_code
+--                                                            would otherwise pre-empt step 2]
+--
+-- Idempotent: each DELETE is bounded by deterministic IDs or metric_code filters,
+-- so re-running this is a no-op once the rows are gone.
+
+-- ============================================================================
+-- Step 1a — Block F reversal: per-leg benchmark_set_items rows
+-- Match by benchmark_type + the metric_code of the referenced site_benchmark,
+-- which is more robust than relying on ID suffix patterns alone.
+-- ============================================================================
+DELETE FROM benchmark_set_items
+ WHERE benchmark_type = 'site'
+   AND benchmark_id IN (
+     SELECT id
+       FROM site_benchmarks
+      WHERE metric_code IN ('AGILITY_505_L', 'AGILITY_505_R')
+   );
+
+-- ============================================================================
+-- Step 1b — Block D reversal: LSI tier benchmark_set_items rows
+-- ============================================================================
+DELETE FROM benchmark_set_items
+ WHERE id IN (
+   'bsi-screening-asym-lsi-normal',
+   'bsi-screening-asym-lsi-monitor',
+   'bsi-screening-asym-lsi-elevated'
+ );
+
+-- ============================================================================
+-- Step 2a — Block E reversal: per-leg AGILITY_505_L / _R tier rows
+-- The tier_group_id IS NOT NULL filter scopes the delete to tier-group rows
+-- and avoids touching any single-value benchmarks that may exist for these
+-- codes (defensive — none should, but the filter is essentially free).
+-- ============================================================================
+DELETE FROM site_benchmarks
+ WHERE metric_code IN ('AGILITY_505_L', 'AGILITY_505_R')
+   AND tier_group_id IS NOT NULL;
+
+-- ============================================================================
+-- Step 2b — Block C reversal: LSI tier rows
+-- ============================================================================
+DELETE FROM site_benchmarks
+ WHERE id IN (
+   'bench-screening-asym-lsi-normal',
+   'bench-screening-asym-lsi-monitor',
+   'bench-screening-asym-lsi-elevated'
+ );
+
+-- ============================================================================
+-- Step 3 — Block B reversal: screening benchmark set
+-- ============================================================================
+DELETE FROM benchmark_sets
+ WHERE id = 'set-screening-female-bilateral-asymmetry';
+
+-- ============================================================================
+-- Step 4 — Block A reversal: LSI derived metric
+-- ============================================================================
+DELETE FROM site_metrics
+ WHERE code = 'AGILITY_505_LSI';
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 0128 (down): Removed AGILITY_505_LSI derived metric, screening benchmark set, LSI tier rows, and all per-leg AGILITY_505_L / _R tier copies.';
+END $$;

--- a/migrations/0128_add_bilateral_505_lsi_metrics_down.sql
+++ b/migrations/0128_add_bilateral_505_lsi_metrics_down.sql
@@ -22,6 +22,7 @@ DELETE FROM benchmark_set_items
      SELECT id
        FROM site_benchmarks
       WHERE metric_code IN ('AGILITY_505_L', 'AGILITY_505_R')
+        AND tier_group_id IS NOT NULL
    );
 
 -- ============================================================================

--- a/tests/migrations/0128-bilateral-505-lsi.test.ts
+++ b/tests/migrations/0128-bilateral-505-lsi.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Test suite for Migration 0128: Bilateral 5-0-5 + LSI Screening
+ *
+ * Three layers of validation:
+ *   1. Static SQL file analysis  — runs unconditionally, no DB needed
+ *   2. Live DB row inspection    — gracefully skips if migration not applied
+ *   3. Formula evaluation        — verifies LSI formula via evaluateFormula()
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { db } from '../../packages/api/db';
+import { sql } from 'drizzle-orm';
+import { evaluateFormula, validateFormula } from '../../packages/api/services/formula-service';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../..');
+
+const UP_SQL_PATH = path.join(projectRoot, 'migrations', '0128_add_bilateral_505_lsi_metrics.sql');
+const DOWN_SQL_PATH = path.join(projectRoot, 'migrations', '0128_add_bilateral_505_lsi_metrics_down.sql');
+
+const LSI_FORMULA = '(min(AGILITY_505_L, AGILITY_505_R) / max(AGILITY_505_L, AGILITY_505_R)) * 100';
+const LSI_TIER_GROUP_UUID = 'a505a505-0128-4505-9151-aaaaaaaaaaaa';
+
+describe('Migration 0128: Bilateral 5-0-5 + LSI Screening', () => {
+  // ==========================================================================
+  // Layer 1 — Static SQL file analysis
+  // ==========================================================================
+  describe('Up-migration SQL file', () => {
+    let upSql: string;
+
+    it('exists at expected path', () => {
+      expect(fs.existsSync(UP_SQL_PATH)).toBe(true);
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      expect(upSql.length).toBeGreaterThan(0);
+    });
+
+    it('declares the AGILITY_505_LSI derived metric (Block A)', () => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      expect(upSql).toMatch(/INSERT INTO site_metrics/);
+      expect(upSql).toContain("'AGILITY_505_LSI'");
+      expect(upSql).toContain("'higher_is_better'");
+      expect(upSql).toContain("'%'");
+      expect(upSql).toContain(LSI_FORMULA);
+      expect(upSql).toContain("ARRAY['AGILITY_505_L', 'AGILITY_505_R']");
+      expect(upSql).toContain('"dateMatchStrategy":"same_date"');
+    });
+
+    it('creates the screening benchmark set with deterministic ID (Block B)', () => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      expect(upSql).toMatch(/INSERT INTO benchmark_sets/);
+      expect(upSql).toContain("'set-screening-female-bilateral-asymmetry'");
+      expect(upSql).toContain("'Female'");
+    });
+
+    it('seeds three LSI tier rows sharing a fixed UUID tier_group_id (Block C)', () => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      expect(upSql).toContain("'bench-screening-asym-lsi-normal'");
+      expect(upSql).toContain("'bench-screening-asym-lsi-monitor'");
+      expect(upSql).toContain("'bench-screening-asym-lsi-elevated'");
+      // tier_group_id must be a real UUID (the column is uuid-typed in the DB)
+      expect(upSql).toContain(LSI_TIER_GROUP_UUID);
+      // All three tier rows share the same tier_group_id
+      const tgMatches = upSql.match(new RegExp(LSI_TIER_GROUP_UUID, 'g')) || [];
+      expect(tgMatches.length).toBeGreaterThanOrEqual(3);
+      // Tier ranges per spec
+      expect(upSql).toMatch(/'range', 95, 100/);  // Normal
+      expect(upSql).toMatch(/'range', 90, 95/);   // Monitor
+      expect(upSql).toMatch(/'range', 0, 90/);    // Elevated Risk
+    });
+
+    it('wires LSI tiers into the screening set (Block D)', () => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      expect(upSql).toContain("'bsi-screening-asym-lsi-normal'");
+      expect(upSql).toContain("'bsi-screening-asym-lsi-monitor'");
+      expect(upSql).toContain("'bsi-screening-asym-lsi-elevated'");
+    });
+
+    it('projects per-leg tier copies via INSERT … SELECT (Block E)', () => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      // Two parallel inserts: one for _L, one for _R
+      const lSelectMatches = upSql.match(/SELECT\s+src\.id \|\| '-l'/g) || [];
+      const rSelectMatches = upSql.match(/SELECT\s+src\.id \|\| '-r'/g) || [];
+      expect(lSelectMatches.length).toBe(1);
+      expect(rSelectMatches.length).toBe(1);
+      expect(upSql).toContain("'AGILITY_505_L'");
+      expect(upSql).toContain("'AGILITY_505_R'");
+      expect(upSql).toContain("WHERE src.metric_code = 'AGILITY_505'");
+    });
+
+    it('projects per-leg benchmark_set_items rows (Block F)', () => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      expect(upSql).toMatch(/bsi\.id \|\| '-l'/);
+      expect(upSql).toMatch(/bsi\.id \|\| '-r'/);
+      expect(upSql).toMatch(/bsi\.benchmark_id \|\| '-l'/);
+      expect(upSql).toMatch(/bsi\.benchmark_id \|\| '-r'/);
+    });
+
+    it('uses ON CONFLICT … DO UPDATE for every INSERT (idempotency)', () => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      // Strip line comments to avoid matching prose like "(ON CONFLICT DO UPDATE)" in headers.
+      const sqlOnly = upSql
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('--'))
+        .join('\n');
+      const insertCount = (sqlOnly.match(/INSERT INTO/g) || []).length;
+      // Real ON CONFLICT clauses always have a target column list in parens.
+      const conflictCount = (sqlOnly.match(/ON CONFLICT \([^)]+\)\s+DO UPDATE/g) || []).length;
+      // Block A, B, C, D, E (×2), F (×2) = 8 INSERTs
+      expect(insertCount).toBe(8);
+      expect(conflictCount).toBe(insertCount);
+    });
+
+    it('does not contain DROP TABLE or destructive operations', () => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+      expect(upSql).not.toMatch(/DROP TABLE/i);
+      expect(upSql).not.toMatch(/TRUNCATE/i);
+      expect(upSql).not.toMatch(/DELETE FROM/i);
+    });
+  });
+
+  describe('Down-migration SQL file', () => {
+    let downSql: string;
+
+    it('exists at expected path', () => {
+      expect(fs.existsSync(DOWN_SQL_PATH)).toBe(true);
+      downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
+      expect(downSql.length).toBeGreaterThan(0);
+    });
+
+    it('reverses every block by deterministic ID or scoped metric_code', () => {
+      downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
+
+      // Block F → benchmark_set_items by metric_code-scoped subquery
+      expect(downSql).toMatch(
+        /DELETE FROM benchmark_set_items[\s\S]*metric_code IN \('AGILITY_505_L', 'AGILITY_505_R'\)/,
+      );
+
+      // Block D → 3 deterministic IDs
+      expect(downSql).toContain("'bsi-screening-asym-lsi-normal'");
+      expect(downSql).toContain("'bsi-screening-asym-lsi-monitor'");
+      expect(downSql).toContain("'bsi-screening-asym-lsi-elevated'");
+
+      // Block E → site_benchmarks where metric_code IN (_L, _R) AND tier_group_id IS NOT NULL
+      expect(downSql).toMatch(
+        /DELETE FROM site_benchmarks[\s\S]*metric_code IN \('AGILITY_505_L', 'AGILITY_505_R'\)[\s\S]*tier_group_id IS NOT NULL/,
+      );
+
+      // Block C → 3 deterministic IDs
+      expect(downSql).toContain("'bench-screening-asym-lsi-normal'");
+      expect(downSql).toContain("'bench-screening-asym-lsi-monitor'");
+      expect(downSql).toContain("'bench-screening-asym-lsi-elevated'");
+
+      // Block B → benchmark_sets row
+      expect(downSql).toContain("'set-screening-female-bilateral-asymmetry'");
+
+      // Block A → site_metrics row
+      expect(downSql).toMatch(/DELETE FROM site_metrics[\s\S]*'AGILITY_505_LSI'/);
+    });
+
+    it('orders deletes safely (set_items before benchmarks before metric)', () => {
+      downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
+      const setItemsIdx = downSql.indexOf('DELETE FROM benchmark_set_items');
+      const siteBenchIdx = downSql.indexOf('DELETE FROM site_benchmarks');
+      const benchSetIdx = downSql.indexOf('DELETE FROM benchmark_sets');
+      const siteMetricIdx = downSql.indexOf('DELETE FROM site_metrics');
+
+      expect(setItemsIdx).toBeLessThan(siteBenchIdx);
+      expect(siteBenchIdx).toBeLessThan(benchSetIdx);
+      expect(benchSetIdx).toBeLessThan(siteMetricIdx);
+    });
+  });
+
+  // ==========================================================================
+  // Layer 2 — Formula correctness (pure JS, no DB)
+  // ==========================================================================
+  describe('LSI formula evaluation', () => {
+    it('parses and validates against AGILITY_505_L / AGILITY_505_R', () => {
+      const result = validateFormula(LSI_FORMULA, ['AGILITY_505_L', 'AGILITY_505_R']);
+      expect(result.errors).toEqual([]);
+      expect(result.valid).toBe(true);
+      expect(result.referencedMetrics.sort()).toEqual(['agility_505_l', 'agility_505_r']);
+    });
+
+    it('matches spec sanity check: L=2.50, R=2.80 → LSI ≈ 89.286%', () => {
+      const lsi = evaluateFormula(LSI_FORMULA, {
+        AGILITY_505_L: 2.50,
+        AGILITY_505_R: 2.80,
+      });
+      expect(lsi).not.toBeNull();
+      expect(lsi).toBeCloseTo(89.286, 2);
+    });
+
+    it('produces 100% for perfectly symmetric times', () => {
+      const lsi = evaluateFormula(LSI_FORMULA, {
+        AGILITY_505_L: 2.55,
+        AGILITY_505_R: 2.55,
+      });
+      expect(lsi).toBe(100);
+    });
+
+    it('is symmetric: swapping L and R gives the same LSI', () => {
+      const a = evaluateFormula(LSI_FORMULA, { AGILITY_505_L: 2.40, AGILITY_505_R: 2.60 });
+      const b = evaluateFormula(LSI_FORMULA, { AGILITY_505_L: 2.60, AGILITY_505_R: 2.40 });
+      expect(a).toEqual(b);
+    });
+
+    it('places LSI = 89.286% in the Elevated Risk tier (<90%)', () => {
+      const lsi = evaluateFormula(LSI_FORMULA, { AGILITY_505_L: 2.50, AGILITY_505_R: 2.80 })!;
+      // Elevated Risk: min_value=0, max_value=90 (exclusive at 90 per spec)
+      expect(lsi).toBeLessThan(90);
+    });
+
+    it('places LSI = 92% in the Monitor tier (90-95%)', () => {
+      // L = 2.30, R = 2.50 → 2.30/2.50 * 100 = 92
+      const lsi = evaluateFormula(LSI_FORMULA, { AGILITY_505_L: 2.30, AGILITY_505_R: 2.50 })!;
+      expect(lsi).toBeGreaterThanOrEqual(90);
+      expect(lsi).toBeLessThan(95);
+    });
+
+    it('places LSI = 96% in the Normal tier (≥95%)', () => {
+      // L = 2.40, R = 2.50 → 2.40/2.50 * 100 = 96
+      const lsi = evaluateFormula(LSI_FORMULA, { AGILITY_505_L: 2.40, AGILITY_505_R: 2.50 })!;
+      expect(lsi).toBeGreaterThanOrEqual(95);
+    });
+  });
+
+  // ==========================================================================
+  // Layer 3 — Live DB inspection (skips if migration not applied)
+  // ==========================================================================
+  describe('Database state (when migration is applied)', () => {
+    it('AGILITY_505_LSI is registered as a derived metric', async () => {
+      try {
+        const result = await db.execute(sql`
+          SELECT code, is_derived, formula, dependent_metrics, calculation_config, metric_type, unit
+            FROM site_metrics
+           WHERE code = 'AGILITY_505_LSI'
+        `);
+        if (!result.rows || result.rows.length === 0) {
+          console.warn('AGILITY_505_LSI not found - migration 0128 may not have been applied');
+          return;
+        }
+        const row = result.rows[0] as any;
+        expect(row.is_derived).toBe(true);
+        expect(row.formula).toBe(LSI_FORMULA);
+        expect(row.dependent_metrics).toEqual(['AGILITY_505_L', 'AGILITY_505_R']);
+        expect(row.calculation_config).toMatchObject({ dateMatchStrategy: 'same_date' });
+        expect(row.metric_type).toBe('higher_is_better');
+        expect(row.unit).toBe('%');
+      } catch (error) {
+        console.warn('DB query failed (DB may not be reachable):', (error as Error).message);
+      }
+    });
+
+    it('screening benchmark set exists with Female gender', async () => {
+      try {
+        const result = await db.execute(sql`
+          SELECT id, gender, is_template, is_active
+            FROM benchmark_sets
+           WHERE id = 'set-screening-female-bilateral-asymmetry'
+        `);
+        if (!result.rows || result.rows.length === 0) {
+          console.warn('Screening set not found - migration 0128 may not have been applied');
+          return;
+        }
+        const row = result.rows[0] as any;
+        expect(row.gender).toBe('Female');
+        expect(row.is_template).toBe(true);
+        expect(row.is_active).toBe(true);
+      } catch (error) {
+        console.warn('DB query failed:', (error as Error).message);
+      }
+    });
+
+    it('exactly 3 LSI tier rows share the LSI tier_group_id', async () => {
+      try {
+        const result = await db.execute(sql`
+          SELECT tier_name, tier_order, min_value, max_value, tier_color
+            FROM site_benchmarks
+           WHERE tier_group_id = ${LSI_TIER_GROUP_UUID}::uuid
+           ORDER BY tier_order
+        `);
+        if (!result.rows || result.rows.length === 0) {
+          console.warn('LSI tier rows not found - migration 0128 may not have been applied');
+          return;
+        }
+        expect(result.rows).toHaveLength(3);
+
+        const [normal, monitor, elevated] = result.rows as any[];
+        expect(normal.tier_name).toBe('Normal');
+        expect(normal.tier_color).toBe('green');
+        expect(Number(normal.min_value)).toBe(95);
+        expect(Number(normal.max_value)).toBe(100);
+
+        expect(monitor.tier_name).toBe('Monitor');
+        expect(monitor.tier_color).toBe('yellow');
+        expect(Number(monitor.min_value)).toBe(90);
+        expect(Number(monitor.max_value)).toBe(95);
+
+        expect(elevated.tier_name).toBe('Elevated Risk');
+        expect(elevated.tier_color).toBe('red');
+        expect(Number(elevated.min_value)).toBe(0);
+        expect(Number(elevated.max_value)).toBe(90);
+      } catch (error) {
+        console.warn('DB query failed:', (error as Error).message);
+      }
+    });
+
+    it('LSI tiers are wired into the screening set (3 benchmark_set_items)', async () => {
+      try {
+        const result = await db.execute(sql`
+          SELECT bsi.benchmark_id, bsi.benchmark_type, bsi.display_order
+            FROM benchmark_set_items bsi
+           WHERE bsi.set_id = 'set-screening-female-bilateral-asymmetry'
+           ORDER BY bsi.display_order
+        `);
+        if (!result.rows || result.rows.length === 0) {
+          console.warn('Screening set items not found - migration 0128 may not have been applied');
+          return;
+        }
+        expect(result.rows).toHaveLength(3);
+        const ids = result.rows.map((r: any) => r.benchmark_id);
+        expect(ids).toContain('bench-screening-asym-lsi-normal');
+        expect(ids).toContain('bench-screening-asym-lsi-monitor');
+        expect(ids).toContain('bench-screening-asym-lsi-elevated');
+      } catch (error) {
+        console.warn('DB query failed:', (error as Error).message);
+      }
+    });
+
+    it('per-leg AGILITY_505_L / _R rows match AGILITY_505 row count (when AM-FEAT-007 applied)', async () => {
+      try {
+        const result = await db.execute(sql`
+          SELECT metric_code, COUNT(*)::int AS n
+            FROM site_benchmarks
+           WHERE metric_code IN ('AGILITY_505', 'AGILITY_505_L', 'AGILITY_505_R')
+             AND tier_group_id IS NOT NULL
+           GROUP BY metric_code
+        `);
+        if (!result.rows || result.rows.length === 0) {
+          console.warn('No AGILITY_505 tier rows found - AM-FEAT-007 may not have been applied');
+          return;
+        }
+        const counts = Object.fromEntries(
+          (result.rows as any[]).map((r) => [r.metric_code, r.n]),
+        );
+        // If AM-FEAT-007 is applied, _L and _R counts must match the AGILITY_505 count
+        if (counts['AGILITY_505']) {
+          expect(counts['AGILITY_505_L']).toBe(counts['AGILITY_505']);
+          expect(counts['AGILITY_505_R']).toBe(counts['AGILITY_505']);
+        }
+      } catch (error) {
+        console.warn('DB query failed:', (error as Error).message);
+      }
+    });
+  });
+});

--- a/tests/migrations/0128-bilateral-505-lsi.test.ts
+++ b/tests/migrations/0128-bilateral-505-lsi.test.ts
@@ -65,10 +65,10 @@ describe('Migration 0128: Bilateral 5-0-5 + LSI Screening', () => {
       // All three tier rows share the same tier_group_id
       const tgMatches = upSql.match(new RegExp(LSI_TIER_GROUP_UUID, 'g')) || [];
       expect(tgMatches.length).toBeGreaterThanOrEqual(3);
-      // Tier ranges per spec
-      expect(upSql).toMatch(/'range', 95, 100/);  // Normal
-      expect(upSql).toMatch(/'range', 90, 95/);   // Monitor
-      expect(upSql).toMatch(/'range', 0, 90/);    // Elevated Risk
+      // Tier ranges per spec — bounds must be non-overlapping given inclusive evaluation
+      expect(upSql).toMatch(/'range', 95, 100/);         // Normal:        95 ≤ LSI ≤ 100
+      expect(upSql).toMatch(/'range', 90, 94\.999/);     // Monitor:       90 ≤ LSI ≤ 94.999
+      expect(upSql).toMatch(/'range', 0, 89\.999/);      // Elevated Risk:  0 ≤ LSI ≤ 89.999
     });
 
     it('wires LSI tiers into the screening set (Block D)', () => {
@@ -133,9 +133,9 @@ describe('Migration 0128: Bilateral 5-0-5 + LSI Screening', () => {
     it('reverses every block by deterministic ID or scoped metric_code', () => {
       downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
 
-      // Block F → benchmark_set_items by metric_code-scoped subquery
+      // Block F → benchmark_set_items scoped by tier-only _L/_R benchmarks
       expect(downSql).toMatch(
-        /DELETE FROM benchmark_set_items[\s\S]*metric_code IN \('AGILITY_505_L', 'AGILITY_505_R'\)/,
+        /DELETE FROM benchmark_set_items[\s\S]*metric_code IN \('AGILITY_505_L', 'AGILITY_505_R'\)[\s\S]*tier_group_id IS NOT NULL/,
       );
 
       // Block D → 3 deterministic IDs
@@ -232,127 +232,137 @@ describe('Migration 0128: Bilateral 5-0-5 + LSI Screening', () => {
   // ==========================================================================
   describe('Database state (when migration is applied)', () => {
     it('AGILITY_505_LSI is registered as a derived metric', async () => {
+      let result;
       try {
-        const result = await db.execute(sql`
+        result = await db.execute(sql`
           SELECT code, is_derived, formula, dependent_metrics, calculation_config, metric_type, unit
             FROM site_metrics
            WHERE code = 'AGILITY_505_LSI'
         `);
-        if (!result.rows || result.rows.length === 0) {
-          console.warn('AGILITY_505_LSI not found - migration 0128 may not have been applied');
-          return;
-        }
-        const row = result.rows[0] as any;
-        expect(row.is_derived).toBe(true);
-        expect(row.formula).toBe(LSI_FORMULA);
-        expect(row.dependent_metrics).toEqual(['AGILITY_505_L', 'AGILITY_505_R']);
-        expect(row.calculation_config).toMatchObject({ dateMatchStrategy: 'same_date' });
-        expect(row.metric_type).toBe('higher_is_better');
-        expect(row.unit).toBe('%');
       } catch (error) {
         console.warn('DB query failed (DB may not be reachable):', (error as Error).message);
+        return;
       }
+      if (!result.rows || result.rows.length === 0) {
+        console.warn('AGILITY_505_LSI not found - migration 0128 may not have been applied');
+        return;
+      }
+      const row = result.rows[0] as any;
+      expect(row.is_derived).toBe(true);
+      expect(row.formula).toBe(LSI_FORMULA);
+      expect(row.dependent_metrics).toEqual(['AGILITY_505_L', 'AGILITY_505_R']);
+      expect(row.calculation_config).toMatchObject({ dateMatchStrategy: 'same_date' });
+      expect(row.metric_type).toBe('higher_is_better');
+      expect(row.unit).toBe('%');
     });
 
     it('screening benchmark set exists with Female gender', async () => {
+      let result;
       try {
-        const result = await db.execute(sql`
+        result = await db.execute(sql`
           SELECT id, gender, is_template, is_active
             FROM benchmark_sets
            WHERE id = 'set-screening-female-bilateral-asymmetry'
         `);
-        if (!result.rows || result.rows.length === 0) {
-          console.warn('Screening set not found - migration 0128 may not have been applied');
-          return;
-        }
-        const row = result.rows[0] as any;
-        expect(row.gender).toBe('Female');
-        expect(row.is_template).toBe(true);
-        expect(row.is_active).toBe(true);
       } catch (error) {
         console.warn('DB query failed:', (error as Error).message);
+        return;
       }
+      if (!result.rows || result.rows.length === 0) {
+        console.warn('Screening set not found - migration 0128 may not have been applied');
+        return;
+      }
+      const row = result.rows[0] as any;
+      expect(row.gender).toBe('Female');
+      expect(row.is_template).toBe(true);
+      expect(row.is_active).toBe(true);
     });
 
     it('exactly 3 LSI tier rows share the LSI tier_group_id', async () => {
+      let result;
       try {
-        const result = await db.execute(sql`
+        result = await db.execute(sql`
           SELECT tier_name, tier_order, min_value, max_value, tier_color
             FROM site_benchmarks
            WHERE tier_group_id = ${LSI_TIER_GROUP_UUID}::uuid
            ORDER BY tier_order
         `);
-        if (!result.rows || result.rows.length === 0) {
-          console.warn('LSI tier rows not found - migration 0128 may not have been applied');
-          return;
-        }
-        expect(result.rows).toHaveLength(3);
-
-        const [normal, monitor, elevated] = result.rows as any[];
-        expect(normal.tier_name).toBe('Normal');
-        expect(normal.tier_color).toBe('green');
-        expect(Number(normal.min_value)).toBe(95);
-        expect(Number(normal.max_value)).toBe(100);
-
-        expect(monitor.tier_name).toBe('Monitor');
-        expect(monitor.tier_color).toBe('yellow');
-        expect(Number(monitor.min_value)).toBe(90);
-        expect(Number(monitor.max_value)).toBe(95);
-
-        expect(elevated.tier_name).toBe('Elevated Risk');
-        expect(elevated.tier_color).toBe('red');
-        expect(Number(elevated.min_value)).toBe(0);
-        expect(Number(elevated.max_value)).toBe(90);
       } catch (error) {
         console.warn('DB query failed:', (error as Error).message);
+        return;
       }
+      if (!result.rows || result.rows.length === 0) {
+        console.warn('LSI tier rows not found - migration 0128 may not have been applied');
+        return;
+      }
+      expect(result.rows).toHaveLength(3);
+
+      const [normal, monitor, elevated] = result.rows as any[];
+      expect(normal.tier_name).toBe('Normal');
+      expect(normal.tier_color).toBe('green');
+      expect(Number(normal.min_value)).toBe(95);
+      expect(Number(normal.max_value)).toBe(100);
+
+      expect(monitor.tier_name).toBe('Monitor');
+      expect(monitor.tier_color).toBe('yellow');
+      expect(Number(monitor.min_value)).toBe(90);
+      expect(Number(monitor.max_value)).toBe(94.999);
+
+      expect(elevated.tier_name).toBe('Elevated Risk');
+      expect(elevated.tier_color).toBe('red');
+      expect(Number(elevated.min_value)).toBe(0);
+      expect(Number(elevated.max_value)).toBe(89.999);
     });
 
     it('LSI tiers are wired into the screening set (3 benchmark_set_items)', async () => {
+      let result;
       try {
-        const result = await db.execute(sql`
+        result = await db.execute(sql`
           SELECT bsi.benchmark_id, bsi.benchmark_type, bsi.display_order
             FROM benchmark_set_items bsi
            WHERE bsi.set_id = 'set-screening-female-bilateral-asymmetry'
            ORDER BY bsi.display_order
         `);
-        if (!result.rows || result.rows.length === 0) {
-          console.warn('Screening set items not found - migration 0128 may not have been applied');
-          return;
-        }
-        expect(result.rows).toHaveLength(3);
-        const ids = result.rows.map((r: any) => r.benchmark_id);
-        expect(ids).toContain('bench-screening-asym-lsi-normal');
-        expect(ids).toContain('bench-screening-asym-lsi-monitor');
-        expect(ids).toContain('bench-screening-asym-lsi-elevated');
       } catch (error) {
         console.warn('DB query failed:', (error as Error).message);
+        return;
       }
+      if (!result.rows || result.rows.length === 0) {
+        console.warn('Screening set items not found - migration 0128 may not have been applied');
+        return;
+      }
+      expect(result.rows).toHaveLength(3);
+      const ids = result.rows.map((r: any) => r.benchmark_id);
+      expect(ids).toContain('bench-screening-asym-lsi-normal');
+      expect(ids).toContain('bench-screening-asym-lsi-monitor');
+      expect(ids).toContain('bench-screening-asym-lsi-elevated');
     });
 
     it('per-leg AGILITY_505_L / _R rows match AGILITY_505 row count (when AM-FEAT-007 applied)', async () => {
+      let result;
       try {
-        const result = await db.execute(sql`
+        result = await db.execute(sql`
           SELECT metric_code, COUNT(*)::int AS n
             FROM site_benchmarks
            WHERE metric_code IN ('AGILITY_505', 'AGILITY_505_L', 'AGILITY_505_R')
              AND tier_group_id IS NOT NULL
            GROUP BY metric_code
         `);
-        if (!result.rows || result.rows.length === 0) {
-          console.warn('No AGILITY_505 tier rows found - AM-FEAT-007 may not have been applied');
-          return;
-        }
-        const counts = Object.fromEntries(
-          (result.rows as any[]).map((r) => [r.metric_code, r.n]),
-        );
-        // If AM-FEAT-007 is applied, _L and _R counts must match the AGILITY_505 count
-        if (counts['AGILITY_505']) {
-          expect(counts['AGILITY_505_L']).toBe(counts['AGILITY_505']);
-          expect(counts['AGILITY_505_R']).toBe(counts['AGILITY_505']);
-        }
       } catch (error) {
         console.warn('DB query failed:', (error as Error).message);
+        return;
+      }
+      if (!result.rows || result.rows.length === 0) {
+        console.warn('No AGILITY_505 tier rows found - AM-FEAT-007 may not have been applied');
+        return;
+      }
+      const counts = Object.fromEntries(
+        (result.rows as any[]).map((r) => [r.metric_code, r.n]),
+      );
+      // If AM-FEAT-007 is applied, _L and _R counts must match the AGILITY_505 count
+      if (counts['AGILITY_505']) {
+        expect(counts['AGILITY_505_L']).toBe(counts['AGILITY_505']);
+        expect(counts['AGILITY_505_R']).toBe(counts['AGILITY_505']);
       }
     });
   });


### PR DESCRIPTION
## Summary

Implements the migration layer of [AM-FEAT-008](https://github.com/johnahull/AthleteMetrics/blob/develop/bta-company/specs/AM-FEAT-008_bilateral-505-lsi.md) — bilateral 5-0-5 testing with the Limb Symmetry Index (LSI) as a clinical screening metric for non-contact ACL / hamstring / adductor injury risk in female athletes.

- New derived metric `AGILITY_505_LSI` reusing the existing `AGILITY_505_L` / `_R` base codes from migration 0107
- New screening benchmark set `set-screening-female-bilateral-asymmetry` with 3 risk tiers (Normal ≥95% / Monitor 90-95% / Elevated Risk <90%)
- Per-leg tier rows projected from any existing `AGILITY_505` tier rows (graceful no-op until [AM-FEAT-007](https://github.com/johnahull/AthleteMetrics/blob/develop/bta-company/specs/AM-FEAT-007_d1-hs-benchmark-sets.md) lands its D1 / HS benchmark sets)

## Why

Bilateral asymmetry — the time difference between turning off the left vs. right foot — is the contemporary clinical predictor of non-contact ACL, hamstring, and adductor injury in female soccer athletes (>10% LSI / >0.15s absolute difference is the elevated-risk threshold). Female ACL injury rates run 4-6× male, so this matters disproportionately for BTA's audience. The fix is small in code (run the test twice, compute a ratio) and large in operational value (unlocks ACL screening on the FIERCE Spring 2026 eval one-pager).

## What's in the migration

| Block | Purpose |
|---|---|
| A | `AGILITY_505_LSI` derived metric with formula `(min(L,R) / max(L,R)) * 100` |
| B | `set-screening-female-bilateral-asymmetry` benchmark set |
| C | 3 LSI tier rows sharing one fixed UUID `tier_group_id` |
| D | Wire LSI tiers into the screening set (3 `benchmark_set_items`) |
| E | Per-leg AGILITY_505_L / _R tier copies via `INSERT … SELECT` |
| F | Per-leg `benchmark_set_items` mirroring AGILITY_505 set memberships |

All 8 INSERTs use `ON CONFLICT … DO UPDATE` for idempotency. Down migration reverses in dependency-safe order.

## Test plan

- [x] `npx vitest run tests/migrations/0128-bilateral-505-lsi.test.ts` — **24/24 pass** (includes the spec sanity check L=2.50, R=2.80 → LSI ≈ 89.286% landing in Elevated Risk tier)
- [x] `npm run check` — TypeScript clean
- [x] Code review (pr-review-toolkit:code-reviewer) — clean ship-it verdict
- [x] Idempotency verified: Block E's `WHERE src.metric_code = 'AGILITY_505'` excludes the `_L`/`_R` rows it creates, preventing fan-out cascade on second apply
- [x] Schema/constraint alignment: every `ON CONFLICT (...)` matches the underlying unique constraint
- [x] Branch rebased to current `develop` (b22e883e), includes PR #399's `tier_group_id` uuid declaration
- [ ] **Pre-merge:** apply migration to local dev DB via `npm run db:migrate:manual` and confirm the `RAISE NOTICE` summary at the end reports the expected counts

## Diff scope

3 new files, 718 lines total:

| File | Lines | Purpose |
|---|---|---|
| `migrations/0128_add_bilateral_505_lsi_metrics.sql` | 287 | Up migration (Blocks A-F) |
| `migrations/0128_add_bilateral_505_lsi_metrics_down.sql` | 72 | Reversal in dependency-safe order |
| `tests/migrations/0128-bilateral-505-lsi.test.ts` | 359 | 24 tests across 3 layers |

## Deliberately out of scope

These are intentional scoping decisions per the plan, NOT missing work:

1. **Eval one-pager rendering (Part 4 of spec)** — the `/api/reports/eval-onepager/:athleteId` endpoint doesn't exist yet. The existing generic reporting feature should pick up the new derived metric automatically once seeded. Bilateral-specific UX (red-flag callouts, "athletes flagged for asymmetry" subsection) becomes a follow-up if needed.
2. **Per-leg seeding of D1/HS sets** — depends on AM-FEAT-007 landing first. Block E + F are deliberately INSERT…SELECT no-ops until those rows exist.
3. **No new `_LEFT`/`_RIGHT` codes** — the spec proposed them, but `_L` / `_R` already existed from migration 0107. Reusing them is cleaner and avoids duplicate metrics.
4. **BTA-side test-day protocol docs (Part 5)** — different repo.
5. **Backfilling historical data, 5-10-5 bilateral, position-specific norms, longitudinal LSI trends** — explicitly out of scope per spec.

## References

- Spec: `bta-company/specs/AM-FEAT-008_bilateral-505-lsi.md`
- Plan: `.claude/plans/zazzy-jumping-valiant.md`
- Research: `bta-company/docs/benchmarks/cod-research-context.md` §9 (Bishop / Hewett / Dos'Santos)
- Schema fix it depends on: PR #399 (tier_group_id as uuid) — merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)