### PR TITLE
fix(metrics): deactivate yyir1 'Elite/Pro' row until Pro level enum lands

### DIFF
--- a/migrations/0130_seed_yyir1_benchmarks.sql
+++ b/migrations/0130_seed_yyir1_benchmarks.sql
@@ -124,14 +124,17 @@ INSERT INTO site_benchmarks (
   ('d1-soc-yyir1-elite',
    'COND_YYIR1_DISTANCE', 'Soccer Elite/Pro Threshold',
    'Elite / pro female cohorts: > 1700 m, speed level 17.5+. Multi-source pro female aggregated data. Confidence: HIGH.',
-   'gte', 1700.000, 'Elite/Pro', 'green', 'Female', 'SOCCER', 'D1', true, true, 4)
+   'gte', 1700.000, 'Elite/Pro', 'green', 'Female', 'SOCCER', 'D1', true, false, 4)
 -- Conflict target is the explicit id PK so re-runs don't trip the PK before
 -- the arbiter index (see ON CONFLICT index inference: only conflicts on the
 -- inferred constraint are caught; PK conflicts on any other constraint raise).
--- TODO AM-FEAT-011: 'd1-soc-yyir1-elite' uses level='D1' because there is no
--- 'Pro' value in the level enum yet. Change to level='Pro' once the enum is
--- extended; level='D1' filters currently include this Elite/Pro row, which
--- inflates D1 ranges in level-filtered comparisons.
+-- 'd1-soc-yyir1-elite' is seeded with is_active=false + level='D1' because the
+-- level enum has no 'Pro' value yet. Leaving it active polluted level='D1'
+-- filters with the Elite/Pro row (≥1700 m) alongside D1 Average (≥1300 m) and
+-- D1 Top 25% (≥1650 m), inflating D1 ranges in level-filtered comparisons.
+-- Once a 'Pro' level enum value is added, change level to 'Pro' and flip
+-- is_active to true. is_active = EXCLUDED.is_active (not hardcoded true) so
+-- this row stays inactive on re-run.
 ON CONFLICT (id) DO UPDATE SET
   metric_code = EXCLUDED.metric_code,
   name = EXCLUDED.name,
@@ -144,7 +147,7 @@ ON CONFLICT (id) DO UPDATE SET
   gender = EXCLUDED.gender,
   sport = EXCLUDED.sport,
   level = EXCLUDED.level,
-  is_active = true,
+  is_active = EXCLUDED.is_active,
   updated_at = NOW();
 
 -- ============================================================================

--- a/migrations/0134_deactivate_yyir1_elite.sql
+++ b/migrations/0134_deactivate_yyir1_elite.sql
@@ -1,0 +1,36 @@
+-- Migration 0134: Deactivate 'd1-soc-yyir1-elite' until Pro enum lands
+--
+-- Follow-up to 0130 (AM-FEAT-009). The Elite/Pro YYIR1 threshold row was
+-- originally seeded active with level='D1' as a placeholder because the
+-- level enum has no 'Pro' value yet. Leaving it active polluted level='D1'
+-- filter results with the Elite/Pro tier (≥1700 m) alongside D1 Average
+-- (≥1300 m) and D1 Top 25% (≥1650 m), inflating D1 ranges in coach-facing
+-- benchmark comparisons.
+--
+-- This migration deactivates the row in already-deployed databases so its
+-- absence in level='D1' filters matches the source-file change to 0130.
+-- When a 'Pro' level enum value is added in a future feature, a new
+-- migration will both re-level this row to 'Pro' and reactivate it.
+--
+-- Idempotent: the UPDATE has no effect if the row is already inactive.
+
+UPDATE site_benchmarks
+   SET is_active = false,
+       updated_at = NOW()
+ WHERE id = 'd1-soc-yyir1-elite'
+   AND is_active = true;
+
+DO $$
+DECLARE
+  v_active INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_active
+    FROM site_benchmarks
+   WHERE id = 'd1-soc-yyir1-elite' AND is_active = true;
+
+  IF v_active = 0 THEN
+    RAISE NOTICE 'Migration 0134 complete: d1-soc-yyir1-elite is inactive (or not present).';
+  ELSE
+    RAISE WARNING 'Migration 0134: d1-soc-yyir1-elite is unexpectedly still active.';
+  END IF;
+END $$;

--- a/migrations/0134_deactivate_yyir1_elite_down.sql
+++ b/migrations/0134_deactivate_yyir1_elite_down.sql
@@ -1,0 +1,13 @@
+-- Down migration for 0134: re-activate 'd1-soc-yyir1-elite'
+--
+-- Reverses the deactivation. Note: this restores the row to is_active=true
+-- with level='D1', which reintroduces the level-filter pollution issue that
+-- 0134 deactivated the row to avoid. Operators rolling this back should
+-- understand that level='D1' filters will once again include the Elite/Pro
+-- row (≥1700 m) in D1 comparisons.
+
+UPDATE site_benchmarks
+   SET is_active = true,
+       updated_at = NOW()
+ WHERE id = 'd1-soc-yyir1-elite'
+   AND is_active = false;

--- a/tests/migrations/0130-yyir1-benchmarks.test.ts
+++ b/tests/migrations/0130-yyir1-benchmarks.test.ts
@@ -63,6 +63,13 @@ describe('Migration 0130: Yo-Yo IR1 Benchmark Seeding', () => {
       expect(upSql).toMatch(/'d1-soc-yyir1-elite'[\s\S]*?1700\.000/);
     });
 
+    it("'d1-soc-yyir1-elite' is seeded inactive (level='D1' workaround until Pro enum lands)", () => {
+      // Locks in the decision: elite row stays inactive while it carries
+      // level='D1', so it doesn't pollute level='D1' filters. Flip to true
+      // when the level enum gains a 'Pro' value and the row is updated.
+      expect(upSql).toMatch(/'d1-soc-yyir1-elite'[\s\S]*?'D1',\s*true,\s*false,\s*4/);
+    });
+
     it('inline-notes DII / DIII thresholds in D1 Avg description (Option A)', () => {
       expect(upSql).toMatch(/d1-soc-yyir1-d1-avg[\s\S]*?DII threshold[\s\S]*?DIII threshold/);
     });
@@ -226,10 +233,10 @@ describe('Migration 0130: Yo-Yo IR1 Benchmark Seeding', () => {
       }
     });
 
-    it('all 4 D1 soccer YYIR1 rows exist with correct values', async () => {
+    it('all 4 D1 soccer YYIR1 rows exist with correct values and active flags', async () => {
       try {
         const r = await db.execute(sql`
-          SELECT id, benchmark_value::numeric AS v
+          SELECT id, benchmark_value::numeric AS v, is_active
             FROM site_benchmarks
            WHERE id LIKE 'd1-soc-yyir1-%' ORDER BY id
         `);
@@ -239,11 +246,17 @@ describe('Migration 0130: Yo-Yo IR1 Benchmark Seeding', () => {
           return;
         }
         expect(rows).toHaveLength(4);
-        const byId = Object.fromEntries(rows.map(row => [row.id, Number(row.v)]));
-        expect(byId['d1-soc-yyir1-hs-avg']).toBe(950);
-        expect(byId['d1-soc-yyir1-d1-avg']).toBe(1300);
-        expect(byId['d1-soc-yyir1-d1-top25']).toBe(1650);
-        expect(byId['d1-soc-yyir1-elite']).toBe(1700);
+        const byId = Object.fromEntries(rows.map(row => [row.id, { v: Number(row.v), active: row.is_active }]));
+        expect(byId['d1-soc-yyir1-hs-avg'].v).toBe(950);
+        expect(byId['d1-soc-yyir1-d1-avg'].v).toBe(1300);
+        expect(byId['d1-soc-yyir1-d1-top25'].v).toBe(1650);
+        expect(byId['d1-soc-yyir1-elite'].v).toBe(1700);
+        // Active flags: only elite row is inactive (Pro enum workaround;
+        // 0134 also enforces this for already-deployed databases).
+        expect(byId['d1-soc-yyir1-hs-avg'].active).toBe(true);
+        expect(byId['d1-soc-yyir1-d1-avg'].active).toBe(true);
+        expect(byId['d1-soc-yyir1-d1-top25'].active).toBe(true);
+        expect(byId['d1-soc-yyir1-elite'].active).toBe(false);
       } catch (err) {
         // Narrow to 42P01 (relation does not exist) — re-throw real query
         // failures (column typo, permission error) so they don't silently pass.

--- a/tests/migrations/0134-deactivate-yyir1-elite.test.ts
+++ b/tests/migrations/0134-deactivate-yyir1-elite.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Test suite for Migration 0134: Deactivate 'd1-soc-yyir1-elite'
+ *
+ * Two layers:
+ *   1. Static SQL file analysis  — runs unconditionally, no DB needed
+ *   2. Live DB row inspection    — soft-skips if migration not applied
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { db } from '../../packages/api/db';
+import { sql } from 'drizzle-orm';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../..');
+
+const UP_SQL_PATH = path.join(projectRoot, 'migrations', '0134_deactivate_yyir1_elite.sql');
+const DOWN_SQL_PATH = path.join(projectRoot, 'migrations', '0134_deactivate_yyir1_elite_down.sql');
+
+describe('Migration 0134: Deactivate d1-soc-yyir1-elite', () => {
+  describe('Up-migration SQL file', () => {
+    let upSql: string;
+
+    beforeAll(() => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+    });
+
+    it('exists at expected path', () => {
+      expect(fs.existsSync(UP_SQL_PATH)).toBe(true);
+      expect(upSql.length).toBeGreaterThan(0);
+    });
+
+    it('targets only d1-soc-yyir1-elite', () => {
+      expect(upSql).toContain("WHERE id = 'd1-soc-yyir1-elite'");
+    });
+
+    it('sets is_active = false', () => {
+      expect(upSql).toMatch(/SET\s+is_active\s*=\s*false/);
+    });
+
+    it('is idempotent (no-op if already inactive)', () => {
+      // The AND clause prevents the UPDATE from re-touching an already-
+      // inactive row, keeping updated_at stable on re-apply.
+      expect(upSql).toMatch(/AND\s+is_active\s*=\s*true/);
+    });
+
+    it('emits a verification NOTICE', () => {
+      expect(upSql).toMatch(/RAISE NOTICE\s+'Migration 0134 complete/);
+    });
+  });
+
+  describe('Down-migration SQL file', () => {
+    it('exists at expected path', () => {
+      expect(fs.existsSync(DOWN_SQL_PATH)).toBe(true);
+    });
+
+    it('reactivates the row (is_active = true) gated on current inactive state', () => {
+      const downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
+      expect(downSql).toMatch(/SET\s+is_active\s*=\s*true/);
+      expect(downSql).toMatch(/AND\s+is_active\s*=\s*false/);
+      expect(downSql).toContain("WHERE id = 'd1-soc-yyir1-elite'");
+    });
+  });
+
+  describe.skipIf(!process.env.DATABASE_URL)('Database state (when migration is applied)', () => {
+    const rowsOf = (result: unknown): any[] => {
+      if (Array.isArray(result)) return result;
+      const r = result as { rows?: unknown };
+      return Array.isArray(r.rows) ? r.rows : [];
+    };
+
+    it("'d1-soc-yyir1-elite' is inactive in the live DB", async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT is_active FROM site_benchmarks WHERE id = 'd1-soc-yyir1-elite'
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0) {
+          console.warn('d1-soc-yyir1-elite not present - migration 0130 may not have been applied');
+          return;
+        }
+        expect(rows[0].is_active).toBe(false);
+      } catch (err) {
+        if ((err as { code?: string })?.code !== '42P01') throw err;
+        console.warn('Skipping live-DB check — site_benchmarks missing, migrations may not be applied');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #403 (AM-FEAT-009). Deactivates the \`d1-soc-yyir1-elite\` benchmark row until the level enum gains a \`Pro\` value.

The row was seeded active with \`level='D1'\` as a placeholder. Leaving it active polluted \`WHERE level='D1'\` filter results with the Elite/Pro tier (≥1700 m) alongside D1 Average (≥1300 m) and D1 Top 25% (≥1650 m), inflating D1 ranges in coach-facing benchmark comparisons.

## What changed

- **\`migrations/0130_seed_yyir1_benchmarks.sql\`** — elite row \`is_active\` flipped to \`false\`; Block C SET clause uses \`EXCLUDED.is_active\` so re-runs preserve the per-row value; TODO comment updated
- **\`migrations/0134_deactivate_yyir1_elite.sql\` (+ \`_down.sql\`)** — UPDATE for already-deployed databases. Idempotent (gated on current \`is_active=true\`)
- **Tests** — static check pins the elite row inactive; live-DB test now asserts active flags across all four D1 rows; new test file for migration 0134

## Why both files

Matches the team's established pattern of editing the original migration's source plus shipping a follow-up migration for the live DB delta (e.g., \`0130_restore_audit_actions_and_display_order_defaults.sql\`).

## Future fix

When a \`Pro\` level enum value is added, a new migration should re-level this row to \`'Pro'\` and re-activate it.

## Test plan

- [x] Static SQL tests pin the elite row's \`is_active=false\` in 0130
- [x] Live-DB test asserts \`is_active\` flags for all four D1 rows
- [x] New 0134 test file verifies UPDATE targeting + idempotency guard
- [ ] Migration applies cleanly to a fresh test DB
- [ ] Re-running 0134 produces no row updates (idempotent)
- [ ] Down migration reverses the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)