### PR TITLE
fix(measurements): add missing POST /api/measurements/bulk-delete handler

### DIFF
--- a/packages/api/routes/measurement-routes.ts
+++ b/packages/api/routes/measurement-routes.ts
@@ -808,6 +808,88 @@ export function registerMeasurementRoutes(app: Express) {
   });
 
   /**
+   * Bulk delete measurements (site admins, org admins, coaches)
+   *
+   * Athletes are blocked at this endpoint — they must use single-row delete which
+   * applies stricter ownership/verified checks. Org admins/coaches are scoped to
+   * their first organization membership; cross-org IDs land in errors[] (207).
+   */
+  app.post("/api/measurements/bulk-delete", measurementDeleteLimiter, requireAuth, async (req, res) => {
+    try {
+      const user = req.session.user;
+      if (!user?.id) {
+        return res.status(401).json({ message: "User not authenticated" });
+      }
+
+      if (user.role === 'athlete') {
+        return res.status(403).json({
+          message: "Athletes cannot bulk delete measurements. Delete measurements individually."
+        });
+      }
+
+      const bodySchema = z.object({
+        measurementIds: z.array(z.string().uuid()).min(1).max(100)
+      });
+
+      const { measurementIds } = bodySchema.parse(req.body);
+
+      let expectedOrganizationId: string | undefined = undefined;
+      if (!isSiteAdmin(user)) {
+        const userOrgs = await storage.getUserOrganizations(user.id);
+        expectedOrganizationId = userOrgs[0]?.organizationId;
+        if (!expectedOrganizationId) {
+          return res.status(403).json({
+            message: "No organization membership found"
+          });
+        }
+      }
+
+      const result = await measurementService.bulkDelete(
+        measurementIds,
+        expectedOrganizationId
+      );
+
+      if (result.deleted > 0 || result.failed > 0) {
+        await storage.createAuditLog({
+          userId: user.id,
+          action: 'measurements_bulk_delete',
+          resourceType: 'measurement',
+          resourceId: `bulk:${result.deleted}/${measurementIds.length}`,
+          details: JSON.stringify({
+            totalRequested: measurementIds.length,
+            deleted: result.deleted,
+            failed: result.failed,
+            errors: result.errors.length > 0 ? result.errors : undefined,
+            timestamp: new Date().toISOString()
+          }),
+          ipAddress: req.ip || null,
+          userAgent: req.get('user-agent') || null,
+        });
+      }
+
+      const statusCode = result.failed === 0 ? 200 : 207;
+
+      res.status(statusCode).json({
+        deleted: result.deleted,
+        failed: result.failed,
+        errors: result.errors,
+        message: result.failed === 0
+          ? `All ${result.deleted} measurement(s) deleted successfully`
+          : result.deleted === 0
+          ? `All measurements failed deletion`
+          : `${result.deleted} measurement(s) deleted, ${result.failed} failed`
+      });
+    } catch (error) {
+      console.error("Bulk delete measurements error:", error);
+      if (error instanceof ZodError) {
+        return res.status(400).json({ message: "Invalid request data", errors: error.errors });
+      }
+      const message = error instanceof Error ? error.message : "Failed to bulk delete measurements";
+      res.status(400).json({ message });
+    }
+  });
+
+  /**
    * Get calculation preview for derived metrics
    */
   app.get("/api/measurements/calculate-preview", measurementLimiter, requireAuth, async (req, res) => {

--- a/packages/api/routes/measurement-routes.ts
+++ b/packages/api/routes/measurement-routes.ts
@@ -810,20 +810,22 @@ export function registerMeasurementRoutes(app: Express) {
   /**
    * Bulk delete measurements (site admins, org admins, coaches)
    *
-   * Athletes are blocked at this endpoint — they must use single-row delete which
-   * applies stricter ownership/verified checks. Org admins/coaches are scoped to
-   * their first organization membership; cross-org IDs land in errors[] (207).
+   * Athletes and guests are blocked at this endpoint — they must use single-row
+   * delete which applies stricter ownership/verified checks. Org admins/coaches
+   * are scoped to their first organization membership; cross-org IDs land in
+   * errors[] (207).
    */
-  app.post("/api/measurements/bulk-delete", measurementDeleteLimiter, requireAuth, async (req, res) => {
+  app.post("/api/measurements/bulk-delete", measurementBatchLimiter, requireAuth, async (req, res) => {
     try {
       const user = req.session.user;
       if (!user?.id) {
         return res.status(401).json({ message: "User not authenticated" });
       }
 
-      if (user.role === 'athlete') {
+      const permission = canUseBatchEndpoint(user);
+      if (!permission.allowed) {
         return res.status(403).json({
-          message: "Athletes cannot bulk delete measurements. Delete measurements individually."
+          message: permission.reason ?? "Insufficient permissions to bulk delete measurements"
         });
       }
 

--- a/packages/api/routes/measurement-routes.ts
+++ b/packages/api/routes/measurement-routes.ts
@@ -852,6 +852,20 @@ export function registerMeasurementRoutes(app: Express) {
         expectedOrganizationId
       );
 
+      // Rewrite cross-org rejections so multi-org admins/coaches understand
+      // why a row they expected to be in scope ended up in errors[]. The
+      // service emits a generic message that is shared with single-row delete
+      // and bulkVerify; we enrich it here without touching the shared layer.
+      if (expectedOrganizationId) {
+        for (const err of result.errors) {
+          if (err.message === 'Access denied - measurement belongs to different organization') {
+            err.message =
+              'Measurement belongs to a different organization than your bulk-delete scope. ' +
+              'Bulk delete is scoped to your primary organization; switch organizations to delete the others.';
+          }
+        }
+      }
+
       // Audit-log writes must not propagate to the client: a failure here
       // would otherwise turn a successful delete into a 5xx that prompts
       // clients to retry, which would then 404 on the already-deleted rows.
@@ -894,6 +908,9 @@ export function registerMeasurementRoutes(app: Express) {
           : `${result.deleted} measurement(s) deleted, ${result.failed} failed`
       });
     } catch (error) {
+      // Log the full error server-side, but never echo it back to the client:
+      // raw error.message can leak DB constraint names, table names, and
+      // other internal structure.
       console.error("Bulk delete measurements error:", error);
       if (error instanceof ZodError) {
         return res.status(400).json({ message: "Invalid request data", errors: error.errors });
@@ -901,8 +918,7 @@ export function registerMeasurementRoutes(app: Express) {
       // Non-Zod errors here are server-side (unexpected service throws,
       // unhandled DB errors, etc.); 500 is the correct semantics rather
       // than 400, which would tell the client the request was malformed.
-      const message = error instanceof Error ? error.message : "Failed to bulk delete measurements";
-      res.status(500).json({ message });
+      res.status(500).json({ message: "Failed to bulk delete measurements" });
     }
   });
 

--- a/packages/api/routes/measurement-routes.ts
+++ b/packages/api/routes/measurement-routes.ts
@@ -841,7 +841,8 @@ export function registerMeasurementRoutes(app: Express) {
         expectedOrganizationId = userOrgs[0]?.organizationId;
         if (!expectedOrganizationId) {
           return res.status(403).json({
-            message: "No organization membership found"
+            message: "Bulk delete requires an organization membership. " +
+              "Your account is not a member of any organization — ask a site admin to add you to one.",
           });
         }
       }
@@ -851,7 +852,10 @@ export function registerMeasurementRoutes(app: Express) {
         expectedOrganizationId
       );
 
-      if (result.deleted > 0 || result.failed > 0) {
+      // Audit-log writes must not propagate to the client: a failure here
+      // would otherwise turn a successful delete into a 5xx that prompts
+      // clients to retry, which would then 404 on the already-deleted rows.
+      try {
         await storage.createAuditLog({
           userId: user.id,
           action: 'measurements_bulk_delete',
@@ -862,10 +866,18 @@ export function registerMeasurementRoutes(app: Express) {
             deleted: result.deleted,
             failed: result.failed,
             errors: result.errors.length > 0 ? result.errors : undefined,
+            scopedOrganizationId: expectedOrganizationId,
             timestamp: new Date().toISOString()
           }),
           ipAddress: req.ip || null,
           userAgent: req.get('user-agent') || null,
+        });
+      } catch (auditErr) {
+        console.error('Audit log failed after bulk delete', {
+          userId: user.id,
+          deleted: result.deleted,
+          failed: result.failed,
+          error: auditErr instanceof Error ? auditErr.message : String(auditErr),
         });
       }
 
@@ -886,8 +898,11 @@ export function registerMeasurementRoutes(app: Express) {
       if (error instanceof ZodError) {
         return res.status(400).json({ message: "Invalid request data", errors: error.errors });
       }
+      // Non-Zod errors here are server-side (unexpected service throws,
+      // unhandled DB errors, etc.); 500 is the correct semantics rather
+      // than 400, which would tell the client the request was malformed.
       const message = error instanceof Error ? error.message : "Failed to bulk delete measurements";
-      res.status(400).json({ message });
+      res.status(500).json({ message });
     }
   });
 

--- a/packages/api/services/measurement-service.ts
+++ b/packages/api/services/measurement-service.ts
@@ -1073,6 +1073,114 @@ export class MeasurementService {
   }
 
   /**
+   * Bulk delete measurements
+   *
+   * Per-row best-effort: rows missing or belonging to another organization are
+   * collected into errors[] and the rest are deleted. Mirrors bulkVerify semantics.
+   *
+   * After deletion, derived metrics for each affected (athlete, metric, date) are
+   * recalculated post-transaction so dependent calculated values stay consistent.
+   *
+   * @param measurementIds IDs to delete
+   * @param expectedOrganizationId IDOR scope (undefined = site admin, no org restriction)
+   * @returns Per-row result with successes, failures, and error details
+   */
+  async bulkDelete(
+    measurementIds: string[],
+    expectedOrganizationId?: string
+  ): Promise<{ deleted: number; failed: number; errors: Array<{ id: string; message: string }> }> {
+    const errors: Array<{ id: string; message: string }> = [];
+    let recalcKeys: Array<{ userId: string; metric: string; date: string }> = [];
+    let actualDeleted = 0;
+
+    try {
+      await db.transaction(async (tx) => {
+        const existingMeasurements = await tx
+          .select()
+          .from(measurements)
+          .where(inArray(measurements.id, measurementIds))
+          .for('update');
+
+        const foundMap = new Map(existingMeasurements.map(m => [m.id, m]));
+
+        const validIds: string[] = [];
+        for (const id of measurementIds) {
+          const measurement = foundMap.get(id);
+
+          if (!measurement) {
+            errors.push({ id, message: 'Measurement not found' });
+            continue;
+          }
+
+          if (expectedOrganizationId && measurement.organizationId !== expectedOrganizationId) {
+            errors.push({ id, message: 'Access denied - measurement belongs to different organization' });
+            continue;
+          }
+
+          validIds.push(id);
+          recalcKeys.push({
+            userId: measurement.userId,
+            metric: measurement.metric,
+            date: measurement.date,
+          });
+        }
+
+        if (validIds.length > 0) {
+          const result = await tx
+            .delete(measurements)
+            .where(inArray(measurements.id, validIds))
+            .returning({ id: measurements.id });
+
+          actualDeleted = result.length;
+
+          if (actualDeleted !== validIds.length) {
+            const missingIds = validIds.filter(id => !result.some(r => r.id === id));
+            missingIds.forEach(id => {
+              errors.push({ id, message: 'Measurement was deleted or modified during operation' });
+            });
+          }
+        }
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        deleted: 0,
+        failed: measurementIds.length,
+        errors: measurementIds.map(id => ({ id, message })),
+      };
+    }
+
+    if (recalcKeys.length > 0) {
+      const calculator = new DerivedMetricCalculator(db);
+      const seen = new Set<string>();
+      for (const key of recalcKeys) {
+        const dedupeKey = `${key.userId}|${key.metric}|${key.date}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        try {
+          await calculator.recalculateForAthlete(key.userId, key.metric, key.date, {
+            triggerContext: { event: 'measurement_delete' },
+          });
+        } catch (e) {
+          // Recalc failures must not roll back successful deletions; log and continue
+          console.error('Derived metric recalc failed after bulk delete', {
+            userId: key.userId,
+            metric: key.metric,
+            date: key.date,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+    }
+
+    return {
+      deleted: actualDeleted,
+      failed: errors.length,
+      errors,
+    };
+  }
+
+  /**
    * Get measurements with filters and pagination
    * @param filters Measurement filters including pagination options
    * @param allowCrossOrganization Whether to allow queries without organizationId (site admin only)

--- a/packages/api/services/measurement-service.ts
+++ b/packages/api/services/measurement-service.ts
@@ -1089,12 +1089,20 @@ export class MeasurementService {
     measurementIds: string[],
     expectedOrganizationId?: string
   ): Promise<{ deleted: number; failed: number; errors: Array<{ id: string; message: string }> }> {
-    const errors: Array<{ id: string; message: string }> = [];
-    let recalcKeys: Array<{ userId: string; metric: string; date: string }> = [];
-    let actualDeleted = 0;
+    type RecalcKey = { userId: string; metric: string; date: string };
+    type TxResult = {
+      deleted: number;
+      errors: Array<{ id: string; message: string }>;
+      recalcKeys: RecalcKey[];
+    };
 
+    let txResult: TxResult;
     try {
-      await db.transaction(async (tx) => {
+      // All mutable state lives inside the closure so a transaction retry
+      // (e.g. on serialization failure) starts from a clean slate.
+      txResult = await db.transaction(async (tx): Promise<TxResult> => {
+        const errors: Array<{ id: string; message: string }> = [];
+
         const existingMeasurements = await tx
           .select()
           .from(measurements)
@@ -1118,28 +1126,35 @@ export class MeasurementService {
           }
 
           validIds.push(id);
-          recalcKeys.push({
-            userId: measurement.userId,
-            metric: measurement.metric,
-            date: measurement.date,
+        }
+
+        if (validIds.length === 0) {
+          return { deleted: 0, errors, recalcKeys: [] };
+        }
+
+        const deletedRows = await tx
+          .delete(measurements)
+          .where(inArray(measurements.id, validIds))
+          .returning({
+            id: measurements.id,
+            userId: measurements.userId,
+            metric: measurements.metric,
+            date: measurements.date,
           });
-        }
 
-        if (validIds.length > 0) {
-          const result = await tx
-            .delete(measurements)
-            .where(inArray(measurements.id, validIds))
-            .returning({ id: measurements.id });
+        const deletedIdSet = new Set(deletedRows.map(r => r.id));
+        const missingIds = validIds.filter(id => !deletedIdSet.has(id));
+        missingIds.forEach(id => {
+          errors.push({ id, message: 'Measurement was deleted or modified during operation' });
+        });
 
-          actualDeleted = result.length;
+        const recalcKeys: RecalcKey[] = deletedRows.map(r => ({
+          userId: r.userId,
+          metric: r.metric,
+          date: r.date,
+        }));
 
-          if (actualDeleted !== validIds.length) {
-            const missingIds = validIds.filter(id => !result.some(r => r.id === id));
-            missingIds.forEach(id => {
-              errors.push({ id, message: 'Measurement was deleted or modified during operation' });
-            });
-          }
-        }
+        return { deleted: deletedRows.length, errors, recalcKeys };
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -1150,10 +1165,10 @@ export class MeasurementService {
       };
     }
 
-    if (recalcKeys.length > 0) {
+    if (txResult.recalcKeys.length > 0) {
       const calculator = new DerivedMetricCalculator(db);
       const seen = new Set<string>();
-      for (const key of recalcKeys) {
+      for (const key of txResult.recalcKeys) {
         const dedupeKey = `${key.userId}|${key.metric}|${key.date}`;
         if (seen.has(dedupeKey)) continue;
         seen.add(dedupeKey);
@@ -1174,9 +1189,9 @@ export class MeasurementService {
     }
 
     return {
-      deleted: actualDeleted,
-      failed: errors.length,
-      errors,
+      deleted: txResult.deleted,
+      failed: txResult.errors.length,
+      errors: txResult.errors,
     };
   }
 

--- a/tests/integration/measurement-bulk-delete.test.ts
+++ b/tests/integration/measurement-bulk-delete.test.ts
@@ -116,6 +116,9 @@ beforeEach(async () => {
     role: 'athlete',
   });
 
+  // NOTE: users table has no 'role' column — role is per-organization
+  // via userOrganizations.role. Site admin is the only role expressed
+  // directly on users via isSiteAdmin: true.
   [orgAdmin] = await db.insert(users).values({
     username: `bd_orgadmin_${ts}`,
     emails: [`bd_orgadmin_${ts}@test.com`],
@@ -123,7 +126,6 @@ beforeEach(async () => {
     firstName: 'Org',
     lastName: 'Admin',
     fullName: 'Org Admin',
-    role: 'org_admin',
   }).returning();
   await db.insert(userOrganizations).values({
     userId: orgAdmin.id,
@@ -138,7 +140,6 @@ beforeEach(async () => {
     firstName: 'Site',
     lastName: 'Admin',
     fullName: 'Site Admin',
-    role: 'site_admin',
     isSiteAdmin: true,
   }).returning();
 
@@ -149,7 +150,6 @@ beforeEach(async () => {
     firstName: 'Coach',
     lastName: 'User',
     fullName: 'Coach User',
-    role: 'coach',
   }).returning();
   await db.insert(userOrganizations).values({
     userId: coachUser.id,
@@ -164,7 +164,6 @@ beforeEach(async () => {
     firstName: 'Guest',
     lastName: 'User',
     fullName: 'Guest User',
-    role: 'guest',
   }).returning();
   await db.insert(userOrganizations).values({
     userId: guestUser.id,
@@ -179,7 +178,6 @@ beforeEach(async () => {
     firstName: 'Lone',
     lastName: 'Athlete',
     fullName: 'Lone Athlete',
-    role: 'athlete',
   }).returning();
   await db.insert(userOrganizations).values({
     userId: athleteUser.id,
@@ -192,7 +190,9 @@ beforeEach(async () => {
     userId: athleteA.id,
     organizationId: orgA.id,
     metric: 'VERTICAL_JUMP',
-    value: 28,
+    value: '28',
+    units: 'in',
+    age: 18,
     date: '2025-03-01',
     submittedBy: orgAdmin.id,
   }).returning();
@@ -201,7 +201,9 @@ beforeEach(async () => {
     userId: athleteB.id,
     organizationId: orgB.id,
     metric: 'VERTICAL_JUMP',
-    value: 30,
+    value: '30',
+    units: 'in',
+    age: 19,
     date: '2025-03-01',
     submittedBy: siteAdmin.id,
   }).returning();
@@ -210,7 +212,9 @@ beforeEach(async () => {
     userId: athleteUser.id,
     organizationId: orgA.id,
     metric: 'VERTICAL_JUMP',
-    value: 22,
+    value: '22',
+    units: 'in',
+    age: 17,
     date: '2025-03-01',
     submittedBy: athleteUser.id,
   }).returning();
@@ -331,6 +335,19 @@ describe('POST /api/measurements/bulk-delete', () => {
       .post('/api/measurements/bulk-delete')
       .set('Cookie', orgAdminCookie)
       .send({ measurementIds: ['not-a-uuid'] });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when measurementIds exceeds the 100-id cap', async () => {
+    // Generate 101 valid UUIDs to exercise the Zod max(100) constraint
+    const overSized = Array.from({ length: 101 }, (_, i) => {
+      const hex = i.toString(16).padStart(12, '0');
+      return `00000000-0000-0000-0000-${hex}`;
+    });
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', orgAdminCookie)
+      .send({ measurementIds: overSized });
     expect(res.status).toBe(400);
   });
 

--- a/tests/integration/measurement-bulk-delete.test.ts
+++ b/tests/integration/measurement-bulk-delete.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Integration tests for POST /api/measurements/bulk-delete
+ *
+ * Covers:
+ *   - Org admin bulk-deletes measurements in their own org (200)
+ *   - Partial failure: cross-org measurement is rejected, in-org succeeds (207)
+ *   - Site admin bulk-deletes across organizations (200)
+ *   - Athlete is rejected (403) — bulk delete is admin-only
+ *   - Unauthenticated (401)
+ *   - Body validation: empty array, oversized, non-uuid (400)
+ *   - Idempotency: missing IDs reported in errors[], not crash
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET = 'test-secret-key-for-integration-tests-only-at-least-32-characters-long';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+process.env.BYPASS_GENERAL_RATE_LIMIT = 'true';
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { type Express } from 'express';
+import bcrypt from 'bcrypt';
+import { eq, inArray, and } from 'drizzle-orm';
+import { db } from '../../packages/api/db';
+import {
+  organizations,
+  users,
+  userOrganizations,
+  measurements,
+} from '@shared/schema';
+import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+let app: Express;
+
+let orgA: any;
+let orgB: any;
+let athleteA: any;
+let athleteB: any;
+let orgAdmin: any;
+let siteAdmin: any;
+let athleteUser: any;
+let measurementInOrgA: any;
+let measurementInOrgB: any;
+let athleteOwnMeasurement: any;
+
+let orgAdminCookie: string;
+let siteAdminCookie: string;
+let athleteCookie: string;
+
+async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, BCRYPT_SALT_ROUNDS);
+}
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  await registerRoutes(app);
+});
+
+beforeEach(async () => {
+  const ts = Date.now();
+
+  [orgA] = await db.insert(organizations).values({
+    name: `Bulk Delete Org A ${ts}`,
+    description: 'orgA',
+    isActive: true,
+  }).returning();
+
+  [orgB] = await db.insert(organizations).values({
+    name: `Bulk Delete Org B ${ts}`,
+    description: 'orgB',
+    isActive: true,
+  }).returning();
+
+  const hashed = await hashPassword('TestPass123!');
+
+  [athleteA] = await db.insert(users).values({
+    username: `bd_athleteA_${ts}`,
+    emails: [`bd_athleteA_${ts}@test.com`],
+    password: hashed,
+    firstName: 'Athlete',
+    lastName: 'A',
+    fullName: 'Athlete A',
+  }).returning();
+  await db.insert(userOrganizations).values({
+    userId: athleteA.id,
+    organizationId: orgA.id,
+    role: 'athlete',
+  });
+
+  [athleteB] = await db.insert(users).values({
+    username: `bd_athleteB_${ts}`,
+    emails: [`bd_athleteB_${ts}@test.com`],
+    password: hashed,
+    firstName: 'Athlete',
+    lastName: 'B',
+    fullName: 'Athlete B',
+  }).returning();
+  await db.insert(userOrganizations).values({
+    userId: athleteB.id,
+    organizationId: orgB.id,
+    role: 'athlete',
+  });
+
+  [orgAdmin] = await db.insert(users).values({
+    username: `bd_orgadmin_${ts}`,
+    emails: [`bd_orgadmin_${ts}@test.com`],
+    password: hashed,
+    firstName: 'Org',
+    lastName: 'Admin',
+    fullName: 'Org Admin',
+    role: 'org_admin',
+  }).returning();
+  await db.insert(userOrganizations).values({
+    userId: orgAdmin.id,
+    organizationId: orgA.id,
+    role: 'org_admin',
+  });
+
+  [siteAdmin] = await db.insert(users).values({
+    username: `bd_siteadmin_${ts}`,
+    emails: [`bd_siteadmin_${ts}@test.com`],
+    password: hashed,
+    firstName: 'Site',
+    lastName: 'Admin',
+    fullName: 'Site Admin',
+    role: 'site_admin',
+    isSiteAdmin: true,
+  }).returning();
+
+  [athleteUser] = await db.insert(users).values({
+    username: `bd_loneathlete_${ts}`,
+    emails: [`bd_loneathlete_${ts}@test.com`],
+    password: hashed,
+    firstName: 'Lone',
+    lastName: 'Athlete',
+    fullName: 'Lone Athlete',
+    role: 'athlete',
+  }).returning();
+  await db.insert(userOrganizations).values({
+    userId: athleteUser.id,
+    organizationId: orgA.id,
+    role: 'athlete',
+  });
+
+  // Seed one measurement in each org plus one owned by lone athlete
+  [measurementInOrgA] = await db.insert(measurements).values({
+    userId: athleteA.id,
+    organizationId: orgA.id,
+    metric: 'VERTICAL_JUMP',
+    value: 28,
+    date: '2025-03-01',
+    submittedBy: orgAdmin.id,
+  }).returning();
+
+  [measurementInOrgB] = await db.insert(measurements).values({
+    userId: athleteB.id,
+    organizationId: orgB.id,
+    metric: 'VERTICAL_JUMP',
+    value: 30,
+    date: '2025-03-01',
+    submittedBy: siteAdmin.id,
+  }).returning();
+
+  [athleteOwnMeasurement] = await db.insert(measurements).values({
+    userId: athleteUser.id,
+    organizationId: orgA.id,
+    metric: 'VERTICAL_JUMP',
+    value: 22,
+    date: '2025-03-01',
+    submittedBy: athleteUser.id,
+  }).returning();
+
+  orgAdminCookie = (await request(app).post('/api/auth/login')
+    .send({ username: orgAdmin.username, password: 'TestPass123!' })).headers['set-cookie'][0];
+  siteAdminCookie = (await request(app).post('/api/auth/login')
+    .send({ username: siteAdmin.username, password: 'TestPass123!' })).headers['set-cookie'][0];
+  athleteCookie = (await request(app).post('/api/auth/login')
+    .send({ username: athleteUser.username, password: 'TestPass123!' })).headers['set-cookie'][0];
+});
+
+afterEach(async () => {
+  const seededIds = [measurementInOrgA?.id, measurementInOrgB?.id, athleteOwnMeasurement?.id].filter(Boolean);
+  if (seededIds.length) {
+    await db.delete(measurements).where(inArray(measurements.id, seededIds));
+  }
+  // Clean up any other measurements created during tests
+  await db.delete(measurements).where(inArray(measurements.userId,
+    [athleteA?.id, athleteB?.id, athleteUser?.id].filter(Boolean) as string[]));
+
+  await db.delete(userOrganizations).where(inArray(userOrganizations.userId,
+    [athleteA?.id, athleteB?.id, orgAdmin?.id, athleteUser?.id].filter(Boolean) as string[]));
+  await db.delete(users).where(inArray(users.id,
+    [athleteA?.id, athleteB?.id, orgAdmin?.id, siteAdmin?.id, athleteUser?.id].filter(Boolean) as string[]));
+  await db.delete(organizations).where(inArray(organizations.id,
+    [orgA?.id, orgB?.id].filter(Boolean) as string[]));
+});
+
+describe('POST /api/measurements/bulk-delete', () => {
+  it('401 when unauthenticated', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .send({ measurementIds: [measurementInOrgA.id] });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when athlete attempts bulk delete (admin-only endpoint)', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', athleteCookie)
+      .send({ measurementIds: [athleteOwnMeasurement.id] });
+    expect(res.status).toBe(403);
+  });
+
+  it('400 when measurementIds is empty', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', orgAdminCookie)
+      .send({ measurementIds: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when measurementIds contains non-uuid', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', orgAdminCookie)
+      .send({ measurementIds: ['not-a-uuid'] });
+    expect(res.status).toBe(400);
+  });
+
+  it('200 when org admin deletes measurements within own org', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', orgAdminCookie)
+      .send({ measurementIds: [measurementInOrgA.id] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(1);
+    expect(res.body.failed).toBe(0);
+    expect(res.body.errors).toEqual([]);
+
+    const remaining = await db.select().from(measurements)
+      .where(eq(measurements.id, measurementInOrgA.id));
+    expect(remaining.length).toBe(0);
+  });
+
+  it('207 partial success when some measurements belong to different org', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', orgAdminCookie)
+      .send({ measurementIds: [measurementInOrgA.id, measurementInOrgB.id] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.deleted).toBe(1);
+    expect(res.body.failed).toBe(1);
+    expect(res.body.errors.length).toBe(1);
+    expect(res.body.errors[0].id).toBe(measurementInOrgB.id);
+
+    // OrgA measurement should be gone, OrgB measurement should remain
+    const orgARemaining = await db.select().from(measurements)
+      .where(eq(measurements.id, measurementInOrgA.id));
+    const orgBRemaining = await db.select().from(measurements)
+      .where(eq(measurements.id, measurementInOrgB.id));
+    expect(orgARemaining.length).toBe(0);
+    expect(orgBRemaining.length).toBe(1);
+  });
+
+  it('200 when site admin deletes measurements across organizations', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', siteAdminCookie)
+      .send({ measurementIds: [measurementInOrgA.id, measurementInOrgB.id] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(2);
+    expect(res.body.failed).toBe(0);
+
+    const remaining = await db.select().from(measurements)
+      .where(inArray(measurements.id, [measurementInOrgA.id, measurementInOrgB.id]));
+    expect(remaining.length).toBe(0);
+  });
+
+  it('reports missing IDs in errors[] without crashing', async () => {
+    const fakeId = '00000000-0000-0000-0000-000000000000';
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', siteAdminCookie)
+      .send({ measurementIds: [measurementInOrgA.id, fakeId] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.deleted).toBe(1);
+    expect(res.body.failed).toBe(1);
+    expect(res.body.errors[0].id).toBe(fakeId);
+    expect(res.body.errors[0].message).toMatch(/not found/i);
+  });
+});

--- a/tests/integration/measurement-bulk-delete.test.ts
+++ b/tests/integration/measurement-bulk-delete.test.ts
@@ -47,6 +47,8 @@ let athleteA: any;
 let athleteB: any;
 let orgAdmin: any;
 let siteAdmin: any;
+let coachUser: any;
+let guestUser: any;
 let athleteUser: any;
 let measurementInOrgA: any;
 let measurementInOrgB: any;
@@ -54,6 +56,8 @@ let athleteOwnMeasurement: any;
 
 let orgAdminCookie: string;
 let siteAdminCookie: string;
+let coachCookie: string;
+let guestCookie: string;
 let athleteCookie: string;
 
 async function hashPassword(password: string): Promise<string> {
@@ -138,6 +142,36 @@ beforeEach(async () => {
     isSiteAdmin: true,
   }).returning();
 
+  [coachUser] = await db.insert(users).values({
+    username: `bd_coach_${ts}`,
+    emails: [`bd_coach_${ts}@test.com`],
+    password: hashed,
+    firstName: 'Coach',
+    lastName: 'User',
+    fullName: 'Coach User',
+    role: 'coach',
+  }).returning();
+  await db.insert(userOrganizations).values({
+    userId: coachUser.id,
+    organizationId: orgA.id,
+    role: 'coach',
+  });
+
+  [guestUser] = await db.insert(users).values({
+    username: `bd_guest_${ts}`,
+    emails: [`bd_guest_${ts}@test.com`],
+    password: hashed,
+    firstName: 'Guest',
+    lastName: 'User',
+    fullName: 'Guest User',
+    role: 'guest',
+  }).returning();
+  await db.insert(userOrganizations).values({
+    userId: guestUser.id,
+    organizationId: orgA.id,
+    role: 'guest',
+  });
+
   [athleteUser] = await db.insert(users).values({
     username: `bd_loneathlete_${ts}`,
     emails: [`bd_loneathlete_${ts}@test.com`],
@@ -185,6 +219,10 @@ beforeEach(async () => {
     .send({ username: orgAdmin.username, password: 'TestPass123!' })).headers['set-cookie'][0];
   siteAdminCookie = (await request(app).post('/api/auth/login')
     .send({ username: siteAdmin.username, password: 'TestPass123!' })).headers['set-cookie'][0];
+  coachCookie = (await request(app).post('/api/auth/login')
+    .send({ username: coachUser.username, password: 'TestPass123!' })).headers['set-cookie'][0];
+  guestCookie = (await request(app).post('/api/auth/login')
+    .send({ username: guestUser.username, password: 'TestPass123!' })).headers['set-cookie'][0];
   athleteCookie = (await request(app).post('/api/auth/login')
     .send({ username: athleteUser.username, password: 'TestPass123!' })).headers['set-cookie'][0];
 });
@@ -199,9 +237,9 @@ afterEach(async () => {
     [athleteA?.id, athleteB?.id, athleteUser?.id].filter(Boolean) as string[]));
 
   await db.delete(userOrganizations).where(inArray(userOrganizations.userId,
-    [athleteA?.id, athleteB?.id, orgAdmin?.id, athleteUser?.id].filter(Boolean) as string[]));
+    [athleteA?.id, athleteB?.id, orgAdmin?.id, coachUser?.id, guestUser?.id, athleteUser?.id].filter(Boolean) as string[]));
   await db.delete(users).where(inArray(users.id,
-    [athleteA?.id, athleteB?.id, orgAdmin?.id, siteAdmin?.id, athleteUser?.id].filter(Boolean) as string[]));
+    [athleteA?.id, athleteB?.id, orgAdmin?.id, siteAdmin?.id, coachUser?.id, guestUser?.id, athleteUser?.id].filter(Boolean) as string[]));
   await db.delete(organizations).where(inArray(organizations.id,
     [orgA?.id, orgB?.id].filter(Boolean) as string[]));
 });
@@ -220,6 +258,64 @@ describe('POST /api/measurements/bulk-delete', () => {
       .set('Cookie', athleteCookie)
       .send({ measurementIds: [athleteOwnMeasurement.id] });
     expect(res.status).toBe(403);
+  });
+
+  it('403 when guest with org membership attempts bulk delete', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', guestCookie)
+      .send({ measurementIds: [measurementInOrgA.id] });
+    expect(res.status).toBe(403);
+
+    // Defense-in-depth: measurement must still exist
+    const remaining = await db.select().from(measurements)
+      .where(eq(measurements.id, measurementInOrgA.id));
+    expect(remaining.length).toBe(1);
+  });
+
+  it('200 when coach deletes measurements within own org', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', coachCookie)
+      .send({ measurementIds: [measurementInOrgA.id] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(1);
+    expect(res.body.failed).toBe(0);
+
+    const remaining = await db.select().from(measurements)
+      .where(eq(measurements.id, measurementInOrgA.id));
+    expect(remaining.length).toBe(0);
+  });
+
+  it('207 when coach attempts cross-org delete (other-org rejected)', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', coachCookie)
+      .send({ measurementIds: [measurementInOrgB.id] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.deleted).toBe(0);
+    expect(res.body.failed).toBe(1);
+    expect(res.body.errors[0].id).toBe(measurementInOrgB.id);
+    expect(res.body.errors[0].message).toMatch(/different organization/i);
+
+    // Cross-org measurement still exists
+    const remaining = await db.select().from(measurements)
+      .where(eq(measurements.id, measurementInOrgB.id));
+    expect(remaining.length).toBe(1);
+  });
+
+  it('207 with deleted=0 when org admin posts only cross-org IDs', async () => {
+    const res = await request(app)
+      .post('/api/measurements/bulk-delete')
+      .set('Cookie', orgAdminCookie)
+      .send({ measurementIds: [measurementInOrgB.id] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.deleted).toBe(0);
+    expect(res.body.failed).toBe(1);
+    expect(res.body.message).toMatch(/all measurements failed/i);
   });
 
   it('400 when measurementIds is empty', async () => {

--- a/tests/integration/measurement-bulk-delete.test.ts
+++ b/tests/integration/measurement-bulk-delete.test.ts
@@ -66,10 +66,22 @@ async function hashPassword(password: string): Promise<string> {
 
 beforeAll(async () => {
   app = express();
+  // Trust X-Forwarded-For so each test can claim a unique source IP and
+  // avoid sharing the per-route rate-limit bucket (BATCH limit is 10/15min,
+  // we run more than 10 cases against this endpoint in this file).
+  app.set('trust proxy', 1);
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   await registerRoutes(app);
 });
+
+// Unique source IP per test to keep each one in its own rate-limit bucket.
+let nextTestIp = 1;
+function uniqueIp() {
+  // 10.0.0.x range is private and won't collide with anything real
+  const octet = nextTestIp++;
+  return `10.0.0.${octet}`;
+}
 
 beforeEach(async () => {
   const ts = Date.now();
@@ -252,6 +264,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('401 when unauthenticated', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .send({ measurementIds: [measurementInOrgA.id] });
     expect(res.status).toBe(401);
   });
@@ -259,6 +272,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('403 when athlete attempts bulk delete (admin-only endpoint)', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', athleteCookie)
       .send({ measurementIds: [athleteOwnMeasurement.id] });
     expect(res.status).toBe(403);
@@ -267,6 +281,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('403 when guest with org membership attempts bulk delete', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', guestCookie)
       .send({ measurementIds: [measurementInOrgA.id] });
     expect(res.status).toBe(403);
@@ -280,6 +295,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('200 when coach deletes measurements within own org', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', coachCookie)
       .send({ measurementIds: [measurementInOrgA.id] });
 
@@ -295,6 +311,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('207 when coach attempts cross-org delete (other-org rejected)', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', coachCookie)
       .send({ measurementIds: [measurementInOrgB.id] });
 
@@ -313,6 +330,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('207 with deleted=0 when org admin posts only cross-org IDs', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', orgAdminCookie)
       .send({ measurementIds: [measurementInOrgB.id] });
 
@@ -325,6 +343,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('400 when measurementIds is empty', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', orgAdminCookie)
       .send({ measurementIds: [] });
     expect(res.status).toBe(400);
@@ -333,6 +352,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('400 when measurementIds contains non-uuid', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', orgAdminCookie)
       .send({ measurementIds: ['not-a-uuid'] });
     expect(res.status).toBe(400);
@@ -346,6 +366,7 @@ describe('POST /api/measurements/bulk-delete', () => {
     });
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', orgAdminCookie)
       .send({ measurementIds: overSized });
     expect(res.status).toBe(400);
@@ -354,6 +375,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('200 when org admin deletes measurements within own org', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', orgAdminCookie)
       .send({ measurementIds: [measurementInOrgA.id] });
 
@@ -370,6 +392,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('207 partial success when some measurements belong to different org', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', orgAdminCookie)
       .send({ measurementIds: [measurementInOrgA.id, measurementInOrgB.id] });
 
@@ -391,6 +414,7 @@ describe('POST /api/measurements/bulk-delete', () => {
   it('200 when site admin deletes measurements across organizations', async () => {
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', siteAdminCookie)
       .send({ measurementIds: [measurementInOrgA.id, measurementInOrgB.id] });
 
@@ -403,10 +427,63 @@ describe('POST /api/measurements/bulk-delete', () => {
     expect(remaining.length).toBe(0);
   });
 
+  it('403 when authenticated user has no organization membership', async () => {
+    const ts = Date.now();
+    const hashed = await hashPassword('TestPass123!');
+    const [orphanUser] = await db.insert(users).values({
+      username: `bd_orphan_${ts}`,
+      emails: [`bd_orphan_${ts}@test.com`],
+      password: hashed,
+      firstName: 'Orphan',
+      lastName: 'User',
+      fullName: 'Orphan User',
+    }).returning();
+
+    try {
+      // No userOrganizations row inserted — user has no membership.
+      // Login still works because session.user.role falls back to 'athlete',
+      // but we want to specifically exercise the empty-orgs branch.
+      // Promote to coach via a temporary org to log in, then delete the membership.
+      const [tempOrg] = await db.insert(organizations).values({
+        name: `Bulk Delete Orphan Bridge ${ts}`,
+        description: 'temporary',
+        isActive: true,
+      }).returning();
+      await db.insert(userOrganizations).values({
+        userId: orphanUser.id,
+        organizationId: tempOrg.id,
+        role: 'coach',
+      });
+      const orphanCookie = (await request(app).post('/api/auth/login')
+        .send({ username: orphanUser.username, password: 'TestPass123!' })).headers['set-cookie'][0];
+      // Drop the membership AFTER login so the session role is 'coach' but the
+      // route's storage.getUserOrganizations returns an empty array.
+      await db.delete(userOrganizations).where(eq(userOrganizations.userId, orphanUser.id));
+      await db.delete(organizations).where(eq(organizations.id, tempOrg.id));
+
+      const res = await request(app)
+        .post('/api/measurements/bulk-delete')
+        .set('X-Forwarded-For', uniqueIp())
+        .set('Cookie', orphanCookie)
+        .send({ measurementIds: [measurementInOrgA.id] });
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toMatch(/organization membership/i);
+
+      // Defense-in-depth: targeted measurement still exists
+      const remaining = await db.select().from(measurements)
+        .where(eq(measurements.id, measurementInOrgA.id));
+      expect(remaining.length).toBe(1);
+    } finally {
+      await db.delete(users).where(eq(users.id, orphanUser.id));
+    }
+  });
+
   it('reports missing IDs in errors[] without crashing', async () => {
     const fakeId = '00000000-0000-0000-0000-000000000000';
     const res = await request(app)
       .post('/api/measurements/bulk-delete')
+      .set('X-Forwarded-For', uniqueIp())
       .set('Cookie', siteAdminCookie)
       .send({ measurementIds: [measurementInOrgA.id, fakeId] });
 

--- a/tests/integration/measurement-bulk-delete.test.ts
+++ b/tests/integration/measurement-bulk-delete.test.ts
@@ -320,6 +320,8 @@ describe('POST /api/measurements/bulk-delete', () => {
     expect(res.body.failed).toBe(1);
     expect(res.body.errors[0].id).toBe(measurementInOrgB.id);
     expect(res.body.errors[0].message).toMatch(/different organization/i);
+    // Enriched message hints at the bulk-delete scoping limitation
+    expect(res.body.errors[0].message).toMatch(/scoped to your primary organization/i);
 
     // Cross-org measurement still exists
     const remaining = await db.select().from(measurements)


### PR DESCRIPTION
## Summary

Fixes \`Unexpected token DOCTYPE is not valid JSON\` when an org admin tries to bulk-delete measurements on the \`/publish\` page.

**Root cause:** The frontend (\`packages/web/src/pages/publish.tsx:138\`) POSTs to \`/api/measurements/bulk-delete\`, but no server-side route is registered. Express finds no match, the request falls through to the SPA static catch-all (\`packages/api/vite.ts:84\`), which serves \`index.html\` with status 200. The frontend's \`response.json()\` then tries to parse HTML and throws.

**Fix:** Add the missing route + service method, modeled on the existing \`bulk-verify\` / \`bulk-unverify\` pattern.

## Behavior

- **Per-row best-effort** with \`errors[]\` (matches sibling bulk endpoints)
- **207 Multi-Status** on partial failure, **200** when everything succeeded
- **Single transaction** with \`FOR UPDATE\` locking on all rows
- **Audit log** row covering both successes and failures
- **Derived-metric recalculation** runs *after* the transaction commits, deduped by \`(userId, metric, date)\` so each affected combo is recomputed once. Recalc errors log-and-continue rather than rolling back deletions.
- **Athletes blocked at endpoint** (403) — they must use single-row delete which applies stricter ownership/verified checks.
- **Org admins / coaches scoped** to their first org membership; cross-org IDs land in \`errors[]\`.
- **Site admins** bypass the org scope.
- **Body validation** via Zod: \`measurementIds: uuid[1..100]\`.

## Test plan
- [x] Integration test added: \`tests/integration/measurement-bulk-delete.test.ts\` — covers 401, 403 (athlete), 400 (validation), 200 (org admin in own org), 207 (cross-org partial), 200 (site admin cross-org), missing-ID handling
- [x] \`npm run check\` clean (pre-existing \`exceljs\` typing error in \`dashr-export.ts\` is unrelated)
- [ ] Local integration run currently blocked by two pre-existing infra issues — \`ERR_ERL_KEY_GEN_IPV6\` in \`parent-link-request-routes.ts:73\` and a schema-drift on the dev DB (\`has_completed_onboarding\` column missing). CI environment will exercise the test.
- [ ] Manual: org admin selects measurements on \`/publish\` and clicks delete — expect successful deletion and toast, no \`DOCTYPE\` error.

## Related observations (not addressed in this PR)

While tracing this bug I noticed two pre-existing issues worth surfacing:

1. **CSRF and global \`/api\` rate limiter are inert.** \`packages/api/routes.ts:680\` calls \`registerAllRoutes(app)\` *before* \`app.use('/api', csrfProtection)\` (line 784) and \`app.use('/api', apiLimiter)\` (line 930). Express runs handlers in registration order; route handlers send their response and the later \`app.use\` middleware never executes. State-changing API endpoints rely solely on per-route limiters and middleware that's wired in directly.
2. **Missing \`/api/*\` 404 fallback.** Any unregistered \`/api/*\` path silently returns the SPA shell with status 200, which is the failure mode this PR fixes. A small middleware before \`serveStatic\` that 404s unmatched \`/api/*\` requests would have surfaced this immediately.

Happy to file follow-up issues / PRs for either if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)