### PR TITLE
feat(metrics): EUR protocol fix + broad jump + diagnostic tiers + bilateral RSI

### DIFF
--- a/migrations/0135_add_cmj_hoh_repoint_eur.sql
+++ b/migrations/0135_add_cmj_hoh_repoint_eur.sql
@@ -1,0 +1,72 @@
+-- Migration 0135: Add JUMP_CMJ_HOH and repoint POWER_EUR formula
+--
+-- Background: Migration 0131 seeded POWER_EUR with formula
+-- VERTICAL_JUMP / JUMP_SJ_HEIGHT, but VERTICAL_JUMP in this codebase is a
+-- hands-free CMJ (with arm swing). EUR's published interpretation thresholds
+-- (1.05 / 1.15 / 1.25 — see vertical-jump-research-context.md §2) are
+-- calibrated for hands-on-hips (HOH), no-arm-swing CMJ. The protocol mismatch
+-- was flagged in 0131 and worked around by raising EUR's validation_max to
+-- 2.5; this migration retires that workaround by introducing a dedicated
+-- HOH-CMJ base metric and repointing EUR to it.
+--
+-- Block layout:
+--   A — JUMP_CMJ_HOH base metric
+--   B — UPDATE POWER_EUR formula, dependent_metrics, validation_max, description
+--   C — RAISE NOTICE summary
+
+-- ============================================================================
+-- Block A — JUMP_CMJ_HOH base metric
+-- ============================================================================
+INSERT INTO site_metrics (
+  code, label, category, unit, metric_type, is_system_default, is_active,
+  display_order, description, decimal_precision, color, icon,
+  validation_min, validation_max
+) VALUES (
+  'JUMP_CMJ_HOH',
+  'Counter-Movement Jump (HOH)',
+  'Power',
+  'in',
+  'higher_is_better',
+  true, true,
+  61,
+  'Counter-Movement Jump with hands-on-hips (HOH) protocol: athlete keeps hands fixed on hips throughout, performs a full counter-movement (~90° knee dip) into an explosive vertical jump with no arm swing. Differs from VERTICAL_JUMP in this codebase, which permits arm swing and is therefore not protocol-compatible with the published EUR thresholds. Pair with JUMP_SJ_HEIGHT (Squat Jump) on the same date to compute POWER_EUR (CMJ ÷ SJ).',
+  1, 'red', 'ArrowUp',
+  1, 50
+)
+ON CONFLICT (code) DO UPDATE SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  metric_type = EXCLUDED.metric_type,
+  unit = EXCLUDED.unit,
+  validation_min = EXCLUDED.validation_min,
+  validation_max = EXCLUDED.validation_max,
+  is_active = true;
+
+-- ============================================================================
+-- Block B — Repoint POWER_EUR formula to JUMP_CMJ_HOH / JUMP_SJ_HEIGHT
+--
+-- Tightens validation_max from 2.5 → 1.5 (back to spec's calibrated range).
+-- Drops the PROTOCOL NOTE caveat from 0131 — no longer applicable.
+-- ============================================================================
+UPDATE site_metrics SET
+  formula = 'JUMP_CMJ_HOH / JUMP_SJ_HEIGHT',
+  dependent_metrics = ARRAY['JUMP_CMJ_HOH', 'JUMP_SJ_HEIGHT'],
+  validation_max = 1.5,
+  description = 'Eccentric Utilization Ratio: JUMP_CMJ_HOH ÷ JUMP_SJ_HEIGHT. Indicates stretch-shortening cycle (SSC) efficiency. Higher EUR = better elastic-energy use during counter-movement. Concentric-dominant athletes (low EUR) need plyometric prescription; reactive-trained athletes (high EUR) need raised SJ floor (concentric strength). Spec interpretation thresholds (calibrated for HOH-CMJ protocol): <1.05 Concentric-dominant; 1.05–1.15 Functional SSC use; 1.15–1.25 Trained reactive; >1.25 Elite reactive. Source: AM-FEAT-012 §5; vertical-jump-research-context.md §2.',
+  is_active = true
+WHERE code = 'POWER_EUR';
+
+-- ============================================================================
+-- Block C — Summary
+-- ============================================================================
+DO $$
+DECLARE
+  v_eur_formula TEXT;
+  v_eur_max     NUMERIC;
+BEGIN
+  SELECT formula, validation_max INTO v_eur_formula, v_eur_max
+    FROM site_metrics WHERE code = 'POWER_EUR';
+
+  RAISE NOTICE 'Migration 0135 complete: JUMP_CMJ_HOH added; POWER_EUR formula = %, validation_max = %',
+    v_eur_formula, v_eur_max;
+END $$;

--- a/migrations/0135_add_cmj_hoh_repoint_eur_down.sql
+++ b/migrations/0135_add_cmj_hoh_repoint_eur_down.sql
@@ -1,0 +1,26 @@
+-- Down Migration 0135: Reverse JUMP_CMJ_HOH addition + EUR repoint
+--
+-- Reverses 0135 in dependency-safe order:
+--   Step 1 — Restore POWER_EUR to its 0131-original formula, dependents,
+--            validation_max, and description (verbatim).
+--   Step 2 — Remove JUMP_CMJ_HOH base metric (CONDITIONAL — only if no
+--            measurements reference it; parallel to 0131-down's protection
+--            of JUMP_SJ_HEIGHT).
+
+-- Step 1 — Restore POWER_EUR to its 0131-original definition.
+UPDATE site_metrics SET
+  formula = 'VERTICAL_JUMP / JUMP_SJ_HEIGHT',
+  dependent_metrics = ARRAY['VERTICAL_JUMP', 'JUMP_SJ_HEIGHT'],
+  validation_max = 2.5,
+  description = 'Eccentric Utilization Ratio: VERTICAL_JUMP ÷ JUMP_SJ_HEIGHT. Indicates stretch-shortening cycle (SSC) efficiency. Higher EUR = better elastic-energy use during counter-movement. Concentric-dominant athletes (low EUR) need plyometric prescription; reactive-trained athletes (high EUR) need raised SJ floor (concentric strength). PROTOCOL NOTE: codebase VERTICAL_JUMP is hands-free CMJ (with arm swing) — EUR will read higher than HOH-CMJ-protocol thresholds (spec''s 1.05/1.15/1.25). Recalibrate after BTA internal data accumulates. Validation cap raised to 2.5 to accommodate seeded arm-swing-CMJ ratios (Soccer MS implied EUR ≈ 2.06 from VERTICAL_JUMP 13.0 / SJ 6.3).'
+WHERE code = 'POWER_EUR';
+
+-- Step 2 — Remove JUMP_CMJ_HOH (only if unused).
+DELETE FROM site_metrics
+ WHERE code = 'JUMP_CMJ_HOH'
+   AND NOT EXISTS (SELECT 1 FROM measurements WHERE metric_code = 'JUMP_CMJ_HOH');
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 0135 (down): POWER_EUR restored to VERTICAL_JUMP / JUMP_SJ_HEIGHT. JUMP_CMJ_HOH preserved if measurements reference it.';
+END $$;

--- a/migrations/0136_add_jump_broad.sql
+++ b/migrations/0136_add_jump_broad.sql
@@ -1,0 +1,133 @@
+-- Migration 0136: Add JUMP_BROAD base metric + D1/HS Female Soccer benchmarks
+--
+-- Adds the standing long jump (a.k.a. broad jump) as a first-class base metric
+-- and seeds D1 + HS age-grouped tier values for female soccer per
+-- bta-business/docs/benchmarks/d1-soccer-benchmarks.md §3 ("Broad Jump /
+-- Standing Long Jump"). MODERATE confidence at D1; LOW / LOW-MODERATE at HS
+-- (extrapolated from spec's Elite HS / Average HS anchors using the same
+-- pattern as 0131's age-grouped HS rows).
+--
+-- VB / basketball / football benchmarks are deferred — those sports are not
+-- tabulated in the BTA spec at this time.
+--
+-- Storage convention: inches (matches VERTICAL_JUMP, JUMP_SJ_HEIGHT,
+-- APPROACH_JUMP, BLOCK_JUMP). Spec source values are in cm; conversion shown
+-- in the description on each benchmark row.
+--
+-- Block layout:
+--   A — JUMP_BROAD base metric
+--   B — Soccer benchmark rows (D1 + HS age-grouped, female)
+--   C — benchmark_set_items linkages
+--   D — RAISE NOTICE summary
+
+-- ============================================================================
+-- Block A — JUMP_BROAD base metric
+-- ============================================================================
+INSERT INTO site_metrics (
+  code, label, category, unit, metric_type, is_system_default, is_active,
+  display_order, description, decimal_precision, color, icon,
+  validation_min, validation_max
+) VALUES (
+  'JUMP_BROAD',
+  'Broad Jump',
+  'Power',
+  'in',
+  'higher_is_better',
+  true, true,
+  64,
+  'Standing long jump (broad jump): athlete stands behind a marked line, performs a two-foot take-off with a counter-movement, and jumps horizontally for maximum distance. Distance is measured from the take-off line to the nearest heel landing. Tests horizontal explosive power; complements VERTICAL_JUMP (vertical) and JUMP_SJ_HEIGHT (concentric-only) in a power profile. Position-neutral for soccer (Lockie & Moreno 2016 — no significant positional differences).',
+  1, 'red', 'ArrowRight',
+  12, 170
+)
+ON CONFLICT (code) DO UPDATE SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  metric_type = EXCLUDED.metric_type,
+  unit = EXCLUDED.unit,
+  validation_min = EXCLUDED.validation_min,
+  validation_max = EXCLUDED.validation_max,
+  is_active = true;
+
+-- ============================================================================
+-- Block B — Soccer Broad Jump benchmark rows
+--
+-- Source values from d1-soccer-benchmarks.md §3 (cm); inches conversion shown
+-- in parentheticals. `gte` operator with lower bound of spec range (matches
+-- 0131's seeding choice). HS age-grouped rows are extrapolated from spec's
+-- 'Elite HS' (165 cm = 65 in) and 'Average HS' (150 cm = 59.1 in) anchors.
+-- ============================================================================
+INSERT INTO site_benchmarks (
+  id, metric_code, name, description,
+  comparison_operator, benchmark_value,
+  tier_name, tier_color,
+  gender, sport, level, age_min, age_max,
+  is_system_default, is_active, display_order
+) VALUES
+  -- D1 women's soccer
+  ('d1-soc-broad-d1-avg',
+   'JUMP_BROAD', 'Soccer D1 Average',
+   '178 cm = 70.1 in (lower bound of spec D1 Average range 178–197 cm). Source: Hilton 2021. Confidence: MODERATE.',
+   'gte', 70.100, 'D1 Average', 'blue', 'Female', 'SOCCER', 'D1', NULL, NULL, true, true, 4),
+
+  ('d1-soc-broad-d1-elite',
+   'JUMP_BROAD', 'Soccer D1 Top 25%',
+   '197 cm = 77.6 in (lower bound of spec D1 Elite range 197–210 cm). Source: Lockie & Moreno 2016 (D1 starters). Confidence: MODERATE.',
+   'gte', 77.600, 'D1 Top 25%', 'green', 'Female', 'SOCCER', 'D1', NULL, NULL, true, true, 5),
+
+  -- HS age-grouped soccer
+  ('hs-ms-soc-broad',
+   'JUMP_BROAD', 'HS MS Female Soccer (Ages 11-13) Average',
+   '~130 cm = 51.2 in. Confidence: LOW — extrapolated below spec''s ''Average HS'' floor (150 cm), pending BTA internal data. Limited published MS-age female broad jump norms.',
+   'gte', 51.200, 'MS Average', 'gray', 'Female', 'SOCCER', 'HS', 11, 13, true, true, 4),
+
+  ('hs-jv-soc-broad',
+   'JUMP_BROAD', 'HS JV Female Soccer (Ages 14-15) Average',
+   '~145 cm = 57.1 in. Confidence: LOW — extrapolated between MS and Varsity Average anchors, pending BTA internal data.',
+   'gte', 57.100, 'JV Average', 'gray', 'Female', 'SOCCER', 'HS', 14, 15, true, true, 4),
+
+  ('hs-var-soc-broad-avg',
+   'JUMP_BROAD', 'HS Varsity Female Soccer (Ages 16-18) Average',
+   '150 cm = 59.1 in (spec ''Average HS'' lower bound). Confidence: LOW-MODERATE — extrapolated from HS-tier anchor in d1-soccer-benchmarks.md §3.',
+   'gte', 59.100, 'Varsity Average', 'gray', 'Female', 'SOCCER', 'HS', 16, 18, true, true, 4),
+
+  ('hs-var-soc-broad-top25',
+   'JUMP_BROAD', 'HS Varsity Female Soccer (Ages 16-18) Top 25%',
+   '165 cm = 65.0 in (spec ''Elite HS'' lower bound, approaches D1 Average — high-tier HS achievable). Confidence: LOW-MODERATE.',
+   'gte', 65.000, 'Varsity Top 25%', 'green', 'Female', 'SOCCER', 'HS', 16, 18, true, true, 5)
+ON CONFLICT (metric_code, name) DO UPDATE SET
+  description = EXCLUDED.description,
+  comparison_operator = EXCLUDED.comparison_operator,
+  benchmark_value = EXCLUDED.benchmark_value,
+  tier_name = EXCLUDED.tier_name,
+  tier_color = EXCLUDED.tier_color,
+  is_active = true,
+  updated_at = NOW();
+
+-- ============================================================================
+-- Block C — benchmark_set_items linkages
+-- ============================================================================
+INSERT INTO benchmark_set_items (id, set_id, benchmark_id, benchmark_type, display_order)
+VALUES
+  ('bsi-d1-soc-broad-d1-avg',     'd1-womens-soccer',         'd1-soc-broad-d1-avg',     'site', 70),
+  ('bsi-d1-soc-broad-d1-elite',   'd1-womens-soccer',         'd1-soc-broad-d1-elite',   'site', 71),
+  ('bsi-hs-ms-soc-broad',         'hs-ms-female-soccer',      'hs-ms-soc-broad',         'site', 70),
+  ('bsi-hs-jv-soc-broad',         'hs-jv-female-soccer',      'hs-jv-soc-broad',         'site', 70),
+  ('bsi-hs-var-soc-broad-avg',    'hs-varsity-female-soccer', 'hs-var-soc-broad-avg',    'site', 70),
+  ('bsi-hs-var-soc-broad-top25',  'hs-varsity-female-soccer', 'hs-var-soc-broad-top25',  'site', 71)
+ON CONFLICT (set_id, benchmark_id, benchmark_type) DO UPDATE SET
+  display_order = EXCLUDED.display_order;
+
+-- ============================================================================
+-- Block D — Summary
+-- ============================================================================
+DO $$
+DECLARE
+  v_broad_rows  INTEGER;
+  v_set_items   INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_broad_rows FROM site_benchmarks WHERE metric_code = 'JUMP_BROAD';
+  SELECT COUNT(*) INTO v_set_items FROM benchmark_set_items WHERE benchmark_id LIKE '%-broad-%' OR benchmark_id LIKE '%-broad';
+
+  RAISE NOTICE 'Migration 0136 complete: JUMP_BROAD metric, % soccer benchmark rows, % set_items.',
+    v_broad_rows, v_set_items;
+END $$;

--- a/migrations/0136_add_jump_broad_down.sql
+++ b/migrations/0136_add_jump_broad_down.sql
@@ -1,0 +1,30 @@
+-- Down Migration 0136: Reverse JUMP_BROAD addition
+--
+-- Reverses 0136 in dependency-safe order:
+--   Step 1 — benchmark_set_items
+--   Step 2 — site_benchmarks rows for JUMP_BROAD
+--   Step 3 — JUMP_BROAD base metric (CONDITIONAL — only if no measurements
+--            reference it; parallel to 0131-down's protection of JUMP_SJ_HEIGHT)
+
+DELETE FROM benchmark_set_items
+ WHERE benchmark_id IN (
+   'd1-soc-broad-d1-avg', 'd1-soc-broad-d1-elite',
+   'hs-ms-soc-broad', 'hs-jv-soc-broad',
+   'hs-var-soc-broad-avg', 'hs-var-soc-broad-top25'
+ );
+
+DELETE FROM site_benchmarks
+ WHERE id IN (
+   'd1-soc-broad-d1-avg', 'd1-soc-broad-d1-elite',
+   'hs-ms-soc-broad', 'hs-jv-soc-broad',
+   'hs-var-soc-broad-avg', 'hs-var-soc-broad-top25'
+ );
+
+DELETE FROM site_metrics
+ WHERE code = 'JUMP_BROAD'
+   AND NOT EXISTS (SELECT 1 FROM measurements WHERE metric_code = 'JUMP_BROAD');
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 0136 (down): Removed JUMP_BROAD benchmarks. JUMP_BROAD metric preserved if measurements reference it.';
+END $$;

--- a/migrations/0137_add_coaching_note_seed_eur_rsi_tiers.sql
+++ b/migrations/0137_add_coaching_note_seed_eur_rsi_tiers.sql
@@ -1,0 +1,459 @@
+-- Migration 0137: Add coaching_note column + seed EUR diagnostic tiers + bilateral RSI metrics + RSI tiers
+--
+-- Three connected pieces:
+--
+--   1. ADD column site_benchmarks.coaching_note (TEXT NULL) — tier-specific
+--      coaching prose surfaced by the report renderer alongside tier labels.
+--      Distinct from the existing `description` column (which carries source
+--      citations and benchmark-management metadata).
+--
+--   2. SEED POWER_EUR's 4-tier diagnostic interpretation from AM-FEAT-012 §5
+--      (Concentric-dominant <1.05 / Functional SSC use 1.05–1.15 / Trained
+--      reactive 1.15–1.25 / Elite reactive >1.25). Coaching prose per
+--      AM-FEAT-012 §6. Migrating EUR from "render-time table" (aspirational,
+--      never built) to "DB-driven tier benchmarks" — plugs into the existing
+--      evaluateTierBenchmark() in report-service.ts with zero per-metric code.
+--
+--   3. ADD bilateral RSI single-leg metrics (RSI_L, RSI_R) + RSI_ASYM derived
+--      metric (asymmetry %, lower_is_better, per BTA assessment-system.md).
+--      Seed RSI_L and RSI_R normative tiers (Elite/Trained/General/Floor —
+--      universal-athletic, single-leg-specific) and RSI_ASYM screening tiers
+--      (Symmetrical/Borderline/Significant Deficit/Clinical Red Flag — per
+--      user-provided research synthesizing JOSPT Open 2025 + Bishop et al.).
+--
+-- Block layout:
+--   A — ALTER TABLE add coaching_note column
+--   B — POWER_EUR 4-tier rows (shared tier_group_id; coaching_note populated)
+--   C — EUR screening benchmark set
+--   D — Wire EUR tiers into the screening set
+--   E — RSI_L base metric
+--   F — RSI_R base metric
+--   G — RSI_ASYM derived metric (asymmetry %, lower_is_better)
+--   H — RSI screening sets (normative + asymmetry)
+--   I — RSI_L and RSI_R normative tier rows (4 tiers each)
+--   J — RSI_ASYM screening tier rows (4 tiers)
+--   K — Wire RSI tiers into screening sets
+--   L — RAISE NOTICE summary
+
+-- ============================================================================
+-- Block A — Add coaching_note column to site_benchmarks
+-- ============================================================================
+ALTER TABLE site_benchmarks
+  ADD COLUMN IF NOT EXISTS coaching_note TEXT;
+
+-- ============================================================================
+-- Block B — POWER_EUR 4-tier diagnostic interpretation
+--
+-- All four rows share tier_group_id 'e0eeeeee-0137-4eee-9eee-eeeeeeeeeeee'.
+-- POWER_EUR is higher_is_better, so tier_order 1 = best (Elite reactive).
+-- gender/sport/level/age all NULL (sport-agnostic; applies to any jumping athlete).
+-- ============================================================================
+INSERT INTO site_benchmarks (
+  id, metric_code, name, description, coaching_note,
+  comparison_operator, min_value, max_value,
+  tier_group_id, tier_order, tier_name, tier_color,
+  is_system_default, is_active, display_order
+) VALUES
+  ('bench-eur-elite-reactive',
+   'POWER_EUR',
+   'EUR Elite Reactive (>1.25)',
+   'EUR > 1.25. Top-end SSC efficiency; rare in HS-age athletes. Source: AM-FEAT-012 §5; vertical-jump-research-context.md §2 (CMJ vs SJ — EUR Framework).',
+   'Top-end SSC efficiency. Verify protocol consistency on next test; if confirmed, focus on sport-specific application.',
+   'range', 1.25, 1.5,
+   'e0eeeeee-0137-4eee-9eee-eeeeeeeeeeee'::uuid, 1, 'Elite reactive', 'green',
+   true, true, 1),
+
+  ('bench-eur-trained-reactive',
+   'POWER_EUR',
+   'EUR Trained Reactive (1.15-1.25)',
+   'EUR 1.15–1.25. Plyometrics-trained profile; D1-level SSC efficiency. Source: AM-FEAT-012 §5.',
+   'Strong SSC use. Focus on raising the SJ floor (concentric strength) to lift the whole curve.',
+   'range', 1.15, 1.249,
+   'e0eeeeee-0137-4eee-9eee-eeeeeeeeeeee'::uuid, 2, 'Trained reactive', 'blue',
+   true, true, 2),
+
+  ('bench-eur-functional-ssc',
+   'POWER_EUR',
+   'EUR Functional SSC Use (1.05-1.15)',
+   'EUR 1.05–1.15. Within trained-female athlete range. Source: AM-FEAT-012 §5.',
+   'Balanced jump profile. Continue current programming.',
+   'range', 1.05, 1.149,
+   'e0eeeeee-0137-4eee-9eee-eeeeeeeeeeee'::uuid, 3, 'Functional SSC use', 'gray',
+   true, true, 3),
+
+  ('bench-eur-concentric-dominant',
+   'POWER_EUR',
+   'EUR Concentric-Dominant (<1.05)',
+   'EUR < 1.05. Athlete relies on raw concentric strength; SSC use is minimal. Source: AM-FEAT-012 §5.',
+   'Concentric power is the lever. Plyometric block (depth jumps, bounding) before further strength gains.',
+   'range', 0, 1.049,
+   'e0eeeeee-0137-4eee-9eee-eeeeeeeeeeee'::uuid, 4, 'Concentric-dominant', 'yellow',
+   true, true, 4)
+ON CONFLICT (metric_code, name) DO UPDATE SET
+  description = EXCLUDED.description,
+  coaching_note = EXCLUDED.coaching_note,
+  min_value = EXCLUDED.min_value,
+  max_value = EXCLUDED.max_value,
+  comparison_operator = EXCLUDED.comparison_operator,
+  tier_group_id = EXCLUDED.tier_group_id,
+  tier_order = EXCLUDED.tier_order,
+  tier_name = EXCLUDED.tier_name,
+  tier_color = EXCLUDED.tier_color,
+  is_active = true;
+
+-- ============================================================================
+-- Block C — EUR screening benchmark set
+-- ============================================================================
+INSERT INTO benchmark_sets (
+  id, organization_id, name, description, sport, level, gender,
+  is_template, is_active
+) VALUES (
+  'set-screening-eur-diagnostic',
+  NULL,
+  'EUR Diagnostic Tiers',
+  'Eccentric Utilization Ratio interpretation tiers — SSC efficiency zones (not competitive levels). Tier label drives plyometric vs. concentric prescription. Source: AM-FEAT-012 §5; vertical-jump-research-context.md §2.',
+  NULL,
+  NULL,
+  NULL,
+  true, true
+)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  is_template = EXCLUDED.is_template,
+  is_active = true,
+  updated_at = NOW();
+
+-- ============================================================================
+-- Block D — Wire EUR tiers into the screening set
+-- ============================================================================
+INSERT INTO benchmark_set_items (id, set_id, benchmark_id, benchmark_type, display_order)
+VALUES
+  ('bsi-eur-elite-reactive',       'set-screening-eur-diagnostic', 'bench-eur-elite-reactive',       'site', 1),
+  ('bsi-eur-trained-reactive',     'set-screening-eur-diagnostic', 'bench-eur-trained-reactive',     'site', 2),
+  ('bsi-eur-functional-ssc',       'set-screening-eur-diagnostic', 'bench-eur-functional-ssc',       'site', 3),
+  ('bsi-eur-concentric-dominant',  'set-screening-eur-diagnostic', 'bench-eur-concentric-dominant',  'site', 4)
+ON CONFLICT (set_id, benchmark_id, benchmark_type) DO UPDATE SET
+  display_order = EXCLUDED.display_order;
+
+-- ============================================================================
+-- Block E — RSI_L base metric (single-leg, 10/5 Repeat Hop, left)
+-- ============================================================================
+INSERT INTO site_metrics (
+  code, label, category, unit, metric_type, is_system_default, is_active,
+  display_order, description, decimal_precision, color, icon,
+  validation_min, validation_max
+) VALUES (
+  'RSI_L',
+  'RSI Left Leg (10/5 Repeat Hop)',
+  'Power',
+  'ratio',
+  'higher_is_better',
+  true, true,
+  72,
+  'Single-leg Reactive Strength Index, left leg, via 10/5 Repeat Hop protocol: 10 maximal single-leg hops; first hop discarded; mean RSI of best 5 of remaining 9. RSI = flight time ÷ ground contact time. Higher RSI = better elastic energy use and reactive control. Pair with RSI_R to compute RSI_ASYM (asymmetry %). Source: BTA assessment-system.md §1; tiered-assessment-system.md §3.',
+  2, 'red', 'Activity',
+  0, 5
+)
+ON CONFLICT (code) DO UPDATE SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  metric_type = EXCLUDED.metric_type,
+  unit = EXCLUDED.unit,
+  validation_min = EXCLUDED.validation_min,
+  validation_max = EXCLUDED.validation_max,
+  is_active = true;
+
+-- ============================================================================
+-- Block F — RSI_R base metric (single-leg, 10/5 Repeat Hop, right)
+-- ============================================================================
+INSERT INTO site_metrics (
+  code, label, category, unit, metric_type, is_system_default, is_active,
+  display_order, description, decimal_precision, color, icon,
+  validation_min, validation_max
+) VALUES (
+  'RSI_R',
+  'RSI Right Leg (10/5 Repeat Hop)',
+  'Power',
+  'ratio',
+  'higher_is_better',
+  true, true,
+  73,
+  'Single-leg Reactive Strength Index, right leg, via 10/5 Repeat Hop protocol: 10 maximal single-leg hops; first hop discarded; mean RSI of best 5 of remaining 9. RSI = flight time ÷ ground contact time. Higher RSI = better elastic energy use and reactive control. Pair with RSI_L to compute RSI_ASYM (asymmetry %). Source: BTA assessment-system.md §1; tiered-assessment-system.md §3.',
+  2, 'red', 'Activity',
+  0, 5
+)
+ON CONFLICT (code) DO UPDATE SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  metric_type = EXCLUDED.metric_type,
+  unit = EXCLUDED.unit,
+  validation_min = EXCLUDED.validation_min,
+  validation_max = EXCLUDED.validation_max,
+  is_active = true;
+
+-- ============================================================================
+-- Block G — RSI_ASYM derived metric (asymmetry %, lower_is_better)
+--
+-- Formula: ((max(RSI_L, RSI_R) - min(RSI_L, RSI_R)) / max(RSI_L, RSI_R)) * 100
+-- Output: 0% = perfect symmetry; 12.5% = 12.5% asymmetry.
+-- ============================================================================
+INSERT INTO site_metrics (
+  code, label, category, unit, metric_type, is_system_default, is_active,
+  display_order, description, decimal_precision, color, icon,
+  validation_min, validation_max,
+  is_derived, formula, dependent_metrics, calculation_config
+) VALUES (
+  'RSI_ASYM',
+  'RSI L/R Asymmetry',
+  'Power',
+  '%',
+  'lower_is_better',
+  true, true,
+  74,
+  'Asymmetry % between single-leg RSI values: ((max - min) / max) * 100. 0% = perfect symmetry. RSI asymmetry tolerates higher CV (~7–10%) than 5-0-5 LSI; thresholds calibrated accordingly. RSI asymmetry is "stickier" than other LSI metrics in return-to-play — an athlete passing 5-0-5 LSI but failing RSI symmetry is likely "muscling" through movement vs. using elastic energy. Source: AM-FEAT-008 family; user-provided research synthesizing JOSPT Open 2025 + Bishop et al.',
+  1, 'red', 'Activity',
+  0, 100,
+  true,
+  '((max(RSI_L, RSI_R) - min(RSI_L, RSI_R)) / max(RSI_L, RSI_R)) * 100',
+  ARRAY['RSI_L', 'RSI_R'],
+  '{"dateMatchStrategy":"same_date","missingSourceBehavior":"skip"}'::jsonb
+)
+ON CONFLICT (code) DO UPDATE SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  formula = EXCLUDED.formula,
+  dependent_metrics = EXCLUDED.dependent_metrics,
+  calculation_config = EXCLUDED.calculation_config,
+  is_derived = EXCLUDED.is_derived,
+  metric_type = EXCLUDED.metric_type,
+  unit = EXCLUDED.unit,
+  validation_min = EXCLUDED.validation_min,
+  validation_max = EXCLUDED.validation_max,
+  is_active = true;
+
+-- ============================================================================
+-- Block H — RSI screening benchmark sets
+-- ============================================================================
+INSERT INTO benchmark_sets (
+  id, organization_id, name, description, sport, level, gender,
+  is_template, is_active
+) VALUES
+  ('set-screening-female-rsi-normative',
+   NULL,
+   'Female Single-Leg RSI Normative Tiers',
+   'Per-leg single-leg RSI normative tiers (10/5 Repeat Hop): Elite >1.5 / Trained 1.1–1.5 / General 0.5–1.1 / Below Floor <0.5. Universal-athletic, single-leg-specific (bilateral RSI norms differ — not seeded here). Source: user-provided research; SimpliFaster RSI primers; field-validated across collegiate female athletes.',
+   NULL,
+   NULL,
+   'Female',
+   true, true),
+
+  ('set-screening-female-rsi-asymmetry',
+   NULL,
+   'Female RSI Bilateral Asymmetry Screening',
+   'Screening tiers for RSI_ASYM applying to female athletes. Tiers reflect clinical injury-risk thresholds, not competitive levels. <10% Symmetrical / 10–15% Borderline / 15–20% Significant Deficit / >20% Clinical Red Flag. Sources: User-provided research synthesizing JOSPT Open 2025 + Bishop et al. (LSI cutoffs); RSI tolerates higher CV than 5-0-5.',
+   NULL,
+   NULL,
+   'Female',
+   true, true)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  gender = EXCLUDED.gender,
+  is_template = EXCLUDED.is_template,
+  is_active = true,
+  updated_at = NOW();
+
+-- ============================================================================
+-- Block I — RSI_L and RSI_R normative tier rows
+--
+-- 4 tiers each, separate tier_group_id per leg (per 0128's per-leg pattern).
+-- Both RSI_L and RSI_R are higher_is_better → tier_order 1 = best (Elite).
+-- Coaching note is identical across legs (training prescription is the same).
+-- ============================================================================
+INSERT INTO site_benchmarks (
+  id, metric_code, name, description, coaching_note,
+  comparison_operator, min_value, max_value,
+  tier_group_id, tier_order, tier_name, tier_color,
+  gender, is_system_default, is_active, display_order
+) VALUES
+  -- RSI_L normative tiers
+  ('bench-rsi-l-elite',
+   'RSI_L', 'RSI_L Elite (≥1.5)',
+   'Single-leg RSI ≥ 1.5. Elite reactive capacity. Source: user-provided research.',
+   'Elite reactive capacity. Maintain via low-volume / high-intensity plyometric exposure.',
+   'range', 1.5, 5,
+   '15151515-0137-4151-9151-aaaaaaaaaaaa'::uuid, 1, 'Elite', 'green',
+   'Female', true, true, 1),
+
+  ('bench-rsi-l-trained',
+   'RSI_L', 'RSI_L Trained (1.1-1.5)',
+   'Single-leg RSI 1.1–1.5. Trained reactive profile.',
+   'Trained reactive profile; continue progressive plyometric loading.',
+   'range', 1.1, 1.499,
+   '15151515-0137-4151-9151-aaaaaaaaaaaa'::uuid, 2, 'Trained', 'blue',
+   'Female', true, true, 2),
+
+  ('bench-rsi-l-general',
+   'RSI_L', 'RSI_L General (0.5-1.1)',
+   'Single-leg RSI 0.5–1.1. General-athletic-population range.',
+   'General-population range; build reactive base before progressing intensity.',
+   'range', 0.5, 1.099,
+   '15151515-0137-4151-9151-aaaaaaaaaaaa'::uuid, 3, 'General', 'gray',
+   'Female', true, true, 3),
+
+  ('bench-rsi-l-floor',
+   'RSI_L', 'RSI_L Below Floor (<0.5)',
+   'Single-leg RSI < 0.5. Below the minimum floor for safe reactive athletic play.',
+   'Below safe-play floor. Prioritize tendon prep + low-amplitude pogos before reactive progression.',
+   'range', 0, 0.499,
+   '15151515-0137-4151-9151-aaaaaaaaaaaa'::uuid, 4, 'Below Floor', 'red',
+   'Female', true, true, 4),
+
+  -- RSI_R normative tiers (mirror of RSI_L; separate tier_group_id)
+  ('bench-rsi-r-elite',
+   'RSI_R', 'RSI_R Elite (≥1.5)',
+   'Single-leg RSI ≥ 1.5. Elite reactive capacity. Source: user-provided research.',
+   'Elite reactive capacity. Maintain via low-volume / high-intensity plyometric exposure.',
+   'range', 1.5, 5,
+   '26262626-0137-4262-a262-bbbbbbbbbbbb'::uuid, 1, 'Elite', 'green',
+   'Female', true, true, 1),
+
+  ('bench-rsi-r-trained',
+   'RSI_R', 'RSI_R Trained (1.1-1.5)',
+   'Single-leg RSI 1.1–1.5. Trained reactive profile.',
+   'Trained reactive profile; continue progressive plyometric loading.',
+   'range', 1.1, 1.499,
+   '26262626-0137-4262-a262-bbbbbbbbbbbb'::uuid, 2, 'Trained', 'blue',
+   'Female', true, true, 2),
+
+  ('bench-rsi-r-general',
+   'RSI_R', 'RSI_R General (0.5-1.1)',
+   'Single-leg RSI 0.5–1.1. General-athletic-population range.',
+   'General-population range; build reactive base before progressing intensity.',
+   'range', 0.5, 1.099,
+   '26262626-0137-4262-a262-bbbbbbbbbbbb'::uuid, 3, 'General', 'gray',
+   'Female', true, true, 3),
+
+  ('bench-rsi-r-floor',
+   'RSI_R', 'RSI_R Below Floor (<0.5)',
+   'Single-leg RSI < 0.5. Below the minimum floor for safe reactive athletic play.',
+   'Below safe-play floor. Prioritize tendon prep + low-amplitude pogos before reactive progression.',
+   'range', 0, 0.499,
+   '26262626-0137-4262-a262-bbbbbbbbbbbb'::uuid, 4, 'Below Floor', 'red',
+   'Female', true, true, 4)
+ON CONFLICT (metric_code, name) DO UPDATE SET
+  description = EXCLUDED.description,
+  coaching_note = EXCLUDED.coaching_note,
+  min_value = EXCLUDED.min_value,
+  max_value = EXCLUDED.max_value,
+  comparison_operator = EXCLUDED.comparison_operator,
+  tier_group_id = EXCLUDED.tier_group_id,
+  tier_order = EXCLUDED.tier_order,
+  tier_name = EXCLUDED.tier_name,
+  tier_color = EXCLUDED.tier_color,
+  is_active = true;
+
+-- ============================================================================
+-- Block J — RSI_ASYM screening tier rows
+--
+-- 4 tiers, shared tier_group_id. RSI_ASYM is lower_is_better →
+-- tier_order 1 = best (Symmetrical).
+-- ============================================================================
+INSERT INTO site_benchmarks (
+  id, metric_code, name, description, coaching_note,
+  comparison_operator, min_value, max_value,
+  tier_group_id, tier_order, tier_name, tier_color,
+  gender, is_system_default, is_active, display_order
+) VALUES
+  ('bench-rsi-asym-symmetric',
+   'RSI_ASYM',
+   'RSI Symmetrical (<10%)',
+   'RSI asymmetry < 10%. Acceptable variance for most athletes — within typical CV (~7–10%) for single-leg RSI. Source: user-provided research; Bishop et al.',
+   'Acceptable variance for most athletes. Continue programming.',
+   'range', 0, 9.999,
+   'c0c0c0c0-0137-4ccc-bccc-cccccccccccc'::uuid, 1, 'Symmetrical', 'green',
+   'Female', true, true, 1),
+
+  ('bench-rsi-asym-borderline',
+   'RSI_ASYM',
+   'RSI Borderline (10-15%)',
+   'RSI asymmetry 10–15%. Borderline; potentially normal during heavy-usage phase. Source: user-provided research.',
+   'Monitor; potentially normal during heavy-usage phase. Bias bilateral loading toward weak side.',
+   'range', 10, 14.999,
+   'c0c0c0c0-0137-4ccc-bccc-cccccccccccc'::uuid, 2, 'Borderline', 'yellow',
+   'Female', true, true, 2),
+
+  ('bench-rsi-asym-significant',
+   'RSI_ASYM',
+   'RSI Significant Deficit (15-20%)',
+   'RSI asymmetry 15–20%. Significant deficit indicating SSC breakdown / "energy leaking" on weak side. Source: user-provided research; JOSPT Open 2025.',
+   'High alert. SSC breakdown / energy leaking on weak side. Targeted unilateral plyometric work; reassess in 4 weeks.',
+   'range', 15, 19.999,
+   'c0c0c0c0-0137-4ccc-bccc-cccccccccccc'::uuid, 3, 'Significant Deficit', 'orange',
+   'Female', true, true, 3),
+
+  ('bench-rsi-asym-redflag',
+   'RSI_ASYM',
+   'RSI Clinical Red Flag (>20%)',
+   'RSI asymmetry > 20%. Strongly correlated with lingering ACL/joint deficits or significant eccentric weakness. Source: user-provided research; JOSPT Open 2025.',
+   'Strongly correlated with lingering ACL/joint deficits or significant eccentric weakness. Pause high-intensity reactive work; refer to clinical screening if recent injury history.',
+   'range', 20, 100,
+   'c0c0c0c0-0137-4ccc-bccc-cccccccccccc'::uuid, 4, 'Clinical Red Flag', 'red',
+   'Female', true, true, 4)
+ON CONFLICT (metric_code, name) DO UPDATE SET
+  description = EXCLUDED.description,
+  coaching_note = EXCLUDED.coaching_note,
+  min_value = EXCLUDED.min_value,
+  max_value = EXCLUDED.max_value,
+  comparison_operator = EXCLUDED.comparison_operator,
+  tier_group_id = EXCLUDED.tier_group_id,
+  tier_order = EXCLUDED.tier_order,
+  tier_name = EXCLUDED.tier_name,
+  tier_color = EXCLUDED.tier_color,
+  is_active = true;
+
+-- ============================================================================
+-- Block K — Wire RSI tier rows into screening sets
+-- ============================================================================
+INSERT INTO benchmark_set_items (id, set_id, benchmark_id, benchmark_type, display_order)
+VALUES
+  -- Normative set: both legs share the set
+  ('bsi-rsi-l-elite',     'set-screening-female-rsi-normative', 'bench-rsi-l-elite',    'site', 1),
+  ('bsi-rsi-l-trained',   'set-screening-female-rsi-normative', 'bench-rsi-l-trained',  'site', 2),
+  ('bsi-rsi-l-general',   'set-screening-female-rsi-normative', 'bench-rsi-l-general',  'site', 3),
+  ('bsi-rsi-l-floor',     'set-screening-female-rsi-normative', 'bench-rsi-l-floor',    'site', 4),
+  ('bsi-rsi-r-elite',     'set-screening-female-rsi-normative', 'bench-rsi-r-elite',    'site', 5),
+  ('bsi-rsi-r-trained',   'set-screening-female-rsi-normative', 'bench-rsi-r-trained',  'site', 6),
+  ('bsi-rsi-r-general',   'set-screening-female-rsi-normative', 'bench-rsi-r-general',  'site', 7),
+  ('bsi-rsi-r-floor',     'set-screening-female-rsi-normative', 'bench-rsi-r-floor',    'site', 8),
+  -- Asymmetry set
+  ('bsi-rsi-asym-symmetric',     'set-screening-female-rsi-asymmetry', 'bench-rsi-asym-symmetric',     'site', 1),
+  ('bsi-rsi-asym-borderline',    'set-screening-female-rsi-asymmetry', 'bench-rsi-asym-borderline',    'site', 2),
+  ('bsi-rsi-asym-significant',   'set-screening-female-rsi-asymmetry', 'bench-rsi-asym-significant',   'site', 3),
+  ('bsi-rsi-asym-redflag',       'set-screening-female-rsi-asymmetry', 'bench-rsi-asym-redflag',       'site', 4)
+ON CONFLICT (set_id, benchmark_id, benchmark_type) DO UPDATE SET
+  display_order = EXCLUDED.display_order;
+
+-- ============================================================================
+-- Block L — Summary
+-- ============================================================================
+DO $$
+DECLARE
+  v_eur_tiers     INTEGER;
+  v_rsi_norm      INTEGER;
+  v_rsi_asym      INTEGER;
+  v_coaching_col  INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_coaching_col FROM information_schema.columns
+    WHERE table_name = 'site_benchmarks' AND column_name = 'coaching_note';
+  SELECT COUNT(*) INTO v_eur_tiers FROM site_benchmarks
+    WHERE tier_group_id = 'e0eeeeee-0137-4eee-9eee-eeeeeeeeeeee'::uuid;
+  SELECT COUNT(*) INTO v_rsi_norm FROM site_benchmarks
+    WHERE metric_code IN ('RSI_L', 'RSI_R');
+  SELECT COUNT(*) INTO v_rsi_asym FROM site_benchmarks
+    WHERE metric_code = 'RSI_ASYM';
+
+  RAISE NOTICE 'Migration 0137 complete: coaching_note column present (%), POWER_EUR % tiers, RSI_L+RSI_R % normative tiers, RSI_ASYM % screening tiers.',
+    v_coaching_col, v_eur_tiers, v_rsi_norm, v_rsi_asym;
+END $$;

--- a/migrations/0137_add_coaching_note_seed_eur_rsi_tiers_down.sql
+++ b/migrations/0137_add_coaching_note_seed_eur_rsi_tiers_down.sql
@@ -1,0 +1,67 @@
+-- Down Migration 0137: Reverse coaching_note seed + EUR tiers + bilateral RSI
+--
+-- Reverses 0137 in dependency-safe order:
+--   Step 1 — benchmark_set_items (EUR + RSI normative + RSI asymmetry)
+--   Step 2 — site_benchmarks rows (EUR tiers + RSI tier rows)
+--   Step 3 — benchmark_sets (3 screening sets created in 0137)
+--   Step 4 — RSI_ASYM derived metric (safe — no measurements)
+--   Step 5 — RSI_L and RSI_R base metrics (CONDITIONAL — only if no
+--            measurements; parallel to 0131-down's protection of JUMP_SJ_HEIGHT)
+--
+-- IMPORTANT: site_benchmarks.coaching_note column is NOT dropped on rollback.
+-- Rationale: the column is purely additive (nullable, no default), and dropping
+-- a column is a destructive schema change that would lose any coaching_note
+-- data populated by future migrations or operator edits. It is safe to leave
+-- the column in place after a 0137 rollback — schema stays superset-compatible
+-- with 0137-up. If the column genuinely needs to be dropped (e.g., before a
+-- replay), do so manually with explicit confirmation that no data will be lost.
+
+-- Step 1 — benchmark_set_items
+DELETE FROM benchmark_set_items
+ WHERE benchmark_id IN (
+   -- EUR
+   'bench-eur-elite-reactive', 'bench-eur-trained-reactive',
+   'bench-eur-functional-ssc', 'bench-eur-concentric-dominant',
+   -- RSI normative L+R
+   'bench-rsi-l-elite', 'bench-rsi-l-trained', 'bench-rsi-l-general', 'bench-rsi-l-floor',
+   'bench-rsi-r-elite', 'bench-rsi-r-trained', 'bench-rsi-r-general', 'bench-rsi-r-floor',
+   -- RSI asymmetry
+   'bench-rsi-asym-symmetric', 'bench-rsi-asym-borderline',
+   'bench-rsi-asym-significant', 'bench-rsi-asym-redflag'
+ );
+
+-- Step 2 — site_benchmarks rows
+DELETE FROM site_benchmarks
+ WHERE id IN (
+   'bench-eur-elite-reactive', 'bench-eur-trained-reactive',
+   'bench-eur-functional-ssc', 'bench-eur-concentric-dominant',
+   'bench-rsi-l-elite', 'bench-rsi-l-trained', 'bench-rsi-l-general', 'bench-rsi-l-floor',
+   'bench-rsi-r-elite', 'bench-rsi-r-trained', 'bench-rsi-r-general', 'bench-rsi-r-floor',
+   'bench-rsi-asym-symmetric', 'bench-rsi-asym-borderline',
+   'bench-rsi-asym-significant', 'bench-rsi-asym-redflag'
+ );
+
+-- Step 3 — benchmark_sets created by 0137
+DELETE FROM benchmark_sets
+ WHERE id IN (
+   'set-screening-eur-diagnostic',
+   'set-screening-female-rsi-normative',
+   'set-screening-female-rsi-asymmetry'
+ );
+
+-- Step 4 — RSI_ASYM derived metric (safe — no direct measurements)
+DELETE FROM site_metrics WHERE code = 'RSI_ASYM';
+
+-- Step 5 — RSI_L / RSI_R base metrics (only if unused)
+DELETE FROM site_metrics
+ WHERE code IN ('RSI_L', 'RSI_R')
+   AND NOT EXISTS (
+     SELECT 1 FROM measurements WHERE metric_code IN ('RSI_L', 'RSI_R')
+   );
+
+-- Note: coaching_note column is NOT dropped — see header comment above.
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 0137 (down): Removed EUR tiers, RSI tier rows, screening sets, RSI_ASYM. RSI_L/RSI_R preserved if measurements reference them. coaching_note column intentionally retained.';
+END $$;

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -4032,11 +4032,17 @@ async function generatePDF(report: any, reportData: any, format: 'visual' | 'sim
               }
               // Prefix with rank indicator
               const rankPrefix = comp.tierOrder ? `#${comp.tierOrder} ` : '';
+              // Append per-tier coaching note when present (migration 0137).
+              // Newline-separated so autoTable wraps it as secondary text below
+              // the tier label.
+              const tierCellText = comp.coachingNote
+                ? `${rankPrefix}${tierLabel}\n${comp.coachingNote}`
+                : `${rankPrefix}${tierLabel}`;
               tierData.push({
                 cells: [
                   label,
                   comp.tierGroupName || comp.benchmarkName,
-                  `${rankPrefix}${tierLabel}`,
+                  tierCellText,
                   `${comp.athleteValue.toFixed(2)}${unit ? ` ${unit}` : ''}`,
                 ],
                 tierColor: comp.tierColor || 'gray',

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -118,6 +118,9 @@ interface BenchmarkComparison {
   distanceToNextTier?: number | null;
   nextTierName?: string | null;
   isBestTier?: boolean;
+  /** Tier-specific coaching prose (migration 0137). Surfaced under the tier
+   *  label in reports when present. Null for non-coaching tier rows. */
+  coachingNote?: string | null;
   // All tiers in this group (for rendering legends/references)
   allTiers?: Array<{
     tierName: string;
@@ -1320,6 +1323,7 @@ export class ReportService extends BaseService {
       tierColor?: string;
       tierGroupId?: string;
       tierOrder?: number;
+      coachingNote?: string | null;
     }>>,
     includeEventPercentiles?: boolean
   ): Promise<AthletePerformance[]> {
@@ -1711,6 +1715,7 @@ export class ReportService extends BaseService {
       distanceToNextTier,
       nextTierName,
       isBestTier,
+      coachingNote: matchedTier.coachingNote ?? null,
       allTiers: allTiers.map((t: any) => ({
         tierName: t.tierName || t.name,
         tierColor: t.tierColor || 'gray',
@@ -1735,6 +1740,7 @@ export class ReportService extends BaseService {
     tierColor?: string;
     tierGroupId?: string;
     tierOrder?: number;
+    coachingNote?: string | null;
   }>>> {
     const benchmarksByMetric: Record<string, Array<{
       name: string;
@@ -1746,6 +1752,7 @@ export class ReportService extends BaseService {
       tierColor?: string;
       tierGroupId?: string;
       tierOrder?: number;
+      coachingNote?: string | null;
     }>> = {};
 
     if (!benchmarkConfig) {
@@ -1805,6 +1812,7 @@ export class ReportService extends BaseService {
             tierColor: benchmark.tierColor ?? undefined,
             tierGroupId: benchmark.tierGroupId ?? undefined,
             tierOrder: benchmark.tierOrder ?? undefined,
+            coachingNote: benchmark.coachingNote ?? null,
           });
         }
         // Handle single-value benchmarks (may also be part of a tier group with lte/gte operator)
@@ -1817,6 +1825,7 @@ export class ReportService extends BaseService {
             tierColor: benchmark.tierColor ?? undefined,
             tierGroupId: benchmark.tierGroupId ?? undefined,
             tierOrder: benchmark.tierOrder ?? undefined,
+            coachingNote: benchmark.coachingNote ?? null,
           });
         }
         // Skip benchmarks with neither (invalid data)
@@ -1864,6 +1873,8 @@ export class ReportService extends BaseService {
             tierColor: benchmark.tierColor ?? undefined,
             tierGroupId: benchmark.tierGroupId ?? undefined,
             tierOrder: benchmark.tierOrder ?? undefined,
+            // customBenchmarks doesn't carry coaching_note (site-level only)
+            coachingNote: null,
           });
         }
         // Handle single-value benchmarks (may also be part of a tier group with lte/gte operator)
@@ -1876,6 +1887,7 @@ export class ReportService extends BaseService {
             tierColor: benchmark.tierColor ?? undefined,
             tierGroupId: benchmark.tierGroupId ?? undefined,
             tierOrder: benchmark.tierOrder ?? undefined,
+            coachingNote: null,
           });
         }
         // Skip benchmarks with neither (invalid data)

--- a/packages/shared/schema/tables/benchmarks.ts
+++ b/packages/shared/schema/tables/benchmarks.ts
@@ -26,6 +26,10 @@ export const siteBenchmarks = pgTable("site_benchmarks", {
   tierOrder: integer("tier_order"),
   tierName: varchar("tier_name", { length: 50 }),
   tierColor: varchar("tier_color", { length: 20 }),
+  // Tier-specific coaching prose surfaced in reports (migration 0137).
+  // Null for non-coaching benchmarks (e.g., source-citation tiers); populated
+  // for diagnostic/screening tiers that imply a training prescription.
+  coachingNote: text("coaching_note"),
   // Organization type filtering (NULL = applies to all org types)
   applicableOrgTypes: text("applicable_org_types").array().$type<(typeof organizationTypeEnum)[number][]>(),
   // Athlete attribute filters (NULL = applies to all)

--- a/packages/web/src/components/reports/IndividualReportView.tsx
+++ b/packages/web/src/components/reports/IndividualReportView.tsx
@@ -246,17 +246,24 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
                             {benchmarks.map((b: any, idx: number) => (
                               <div key={idx}>
                                 {b.tierName ? (
-                                  <div className="flex items-center gap-2">
-                                    <span className="text-sm font-medium">{b.tierGroupName || b.benchmarkName}:</span>
-                                    <TierBadge
-                                      tierName={b.tierName}
-                                      tierColor={b.tierColor || 'gray'}
-                                      tierOrder={b.tierOrder}
-                                      nextTierName={b.nextTierName}
-                                      distanceToNextTier={b.distanceToNextTier}
-                                      unit={unit}
-                                      showProgress={true}
-                                    />
+                                  <div>
+                                    <div className="flex items-center gap-2">
+                                      <span className="text-sm font-medium">{b.tierGroupName || b.benchmarkName}:</span>
+                                      <TierBadge
+                                        tierName={b.tierName}
+                                        tierColor={b.tierColor || 'gray'}
+                                        tierOrder={b.tierOrder}
+                                        nextTierName={b.nextTierName}
+                                        distanceToNextTier={b.distanceToNextTier}
+                                        unit={unit}
+                                        showProgress={true}
+                                      />
+                                    </div>
+                                    {b.coachingNote && (
+                                      <p className="mt-1 text-xs italic text-muted-foreground">
+                                        {b.coachingNote}
+                                      </p>
+                                    )}
                                   </div>
                                 ) : (
                                   <div className="text-sm">

--- a/packages/web/src/types/report-types.ts
+++ b/packages/web/src/types/report-types.ts
@@ -41,6 +41,9 @@ export interface BenchmarkComparison {
   distanceToNextTier?: number | null;
   nextTierName?: string | null;
   isBestTier?: boolean;
+  /** Tier-specific coaching prose (migration 0137). Surfaced under the tier
+   *  label in reports when present. Null for non-coaching tier rows. */
+  coachingNote?: string | null;
   allTiers?: Array<{
     tierName: string;
     tierColor: string;

--- a/tests/migrations/0131-squat-jump-eur.test.ts
+++ b/tests/migrations/0131-squat-jump-eur.test.ts
@@ -147,7 +147,11 @@ describe('Migration 0131: Squat Jump + EUR', () => {
         const eur = rows.find(row => row.code === 'POWER_EUR');
         expect(eur).toBeDefined();
         expect(eur.is_derived).toBe(true);
-        expect(eur.formula).toBe(EUR_FORMULA);
+        // Loosened to assert only what 0131 itself contributes — that
+        // POWER_EUR uses JUMP_SJ_HEIGHT as denominator. Migration 0135
+        // repoints the numerator from VERTICAL_JUMP to JUMP_CMJ_HOH;
+        // pinning the full formula here would fail on a fully-migrated DB.
+        expect(eur.formula).toContain('JUMP_SJ_HEIGHT');
       } catch (err) {
         console.warn('Skipping live-DB check (migration 0131 may not have been applied):', err);
       }

--- a/tests/migrations/0135-cmj-hoh-eur.test.ts
+++ b/tests/migrations/0135-cmj-hoh-eur.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Test suite for Migration 0135: JUMP_CMJ_HOH + POWER_EUR repoint
+ *
+ * Adds JUMP_CMJ_HOH base metric and repoints POWER_EUR's formula from
+ * VERTICAL_JUMP / JUMP_SJ_HEIGHT (set by 0131) to JUMP_CMJ_HOH / JUMP_SJ_HEIGHT
+ * so EUR's published interpretation thresholds (1.05/1.15/1.25) apply directly
+ * without the arm-swing-protocol caveat.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { db } from '../../packages/api/db';
+import { sql } from 'drizzle-orm';
+import { evaluateFormula, validateFormula } from '../../packages/api/services/formula-service';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../..');
+
+const UP_SQL_PATH = path.join(projectRoot, 'migrations', '0135_add_cmj_hoh_repoint_eur.sql');
+const DOWN_SQL_PATH = path.join(projectRoot, 'migrations', '0135_add_cmj_hoh_repoint_eur_down.sql');
+
+const NEW_EUR_FORMULA = 'JUMP_CMJ_HOH / JUMP_SJ_HEIGHT';
+const OLD_EUR_FORMULA = 'VERTICAL_JUMP / JUMP_SJ_HEIGHT';
+
+describe('Migration 0135: JUMP_CMJ_HOH + EUR repoint', () => {
+  describe('Up-migration SQL file', () => {
+    let upSql: string;
+
+    beforeAll(() => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+    });
+
+    it('exists and contains JUMP_CMJ_HOH metric definition', () => {
+      expect(fs.existsSync(UP_SQL_PATH)).toBe(true);
+      expect(upSql).toContain("'JUMP_CMJ_HOH'");
+      expect(upSql).toContain("'Counter-Movement Jump (HOH)'");
+    });
+
+    it('JUMP_CMJ_HOH uses inches (matches JUMP_SJ_HEIGHT convention)', () => {
+      expect(upSql).toMatch(/'JUMP_CMJ_HOH'[\s\S]*?'in'/);
+    });
+
+    it('JUMP_CMJ_HOH description emphasizes HOH protocol and distinguishes from VERTICAL_JUMP', () => {
+      expect(upSql).toMatch(/hands-on-hips|hands fixed on hips/);
+      expect(upSql).toMatch(/no arm swing/);
+      expect(upSql).toMatch(/VERTICAL_JUMP[\s\S]*?arm swing/);
+    });
+
+    it('repoints POWER_EUR formula to JUMP_CMJ_HOH / JUMP_SJ_HEIGHT', () => {
+      expect(upSql).toContain(NEW_EUR_FORMULA);
+      expect(upSql).toMatch(/UPDATE site_metrics[\s\S]*?formula\s*=\s*'JUMP_CMJ_HOH \/ JUMP_SJ_HEIGHT'/);
+    });
+
+    it('updates POWER_EUR dependent_metrics to include JUMP_CMJ_HOH', () => {
+      expect(upSql).toMatch(/dependent_metrics\s*=\s*ARRAY\['JUMP_CMJ_HOH',\s*'JUMP_SJ_HEIGHT'\]/);
+    });
+
+    it('tightens POWER_EUR validation_max from 2.5 to 1.5', () => {
+      expect(upSql).toMatch(/validation_max\s*=\s*1\.5/);
+    });
+
+    it('drops the PROTOCOL NOTE caveat from POWER_EUR description', () => {
+      // The new description should no longer mention "PROTOCOL NOTE" or "arm swing"
+      // in the EUR description (verified by checking the UPDATE block for POWER_EUR).
+      const updateBlock = upSql.match(/UPDATE site_metrics[\s\S]*?WHERE code = 'POWER_EUR'/);
+      expect(updateBlock).not.toBeNull();
+      expect(updateBlock![0]).not.toMatch(/PROTOCOL NOTE/);
+    });
+  });
+
+  describe('Down-migration SQL file', () => {
+    let downSql: string;
+
+    beforeAll(() => {
+      downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
+    });
+
+    it('exists and restores POWER_EUR to the 0131 formula', () => {
+      expect(fs.existsSync(DOWN_SQL_PATH)).toBe(true);
+      expect(downSql).toContain(OLD_EUR_FORMULA);
+    });
+
+    it('restores POWER_EUR validation_max to 2.5', () => {
+      expect(downSql).toMatch(/validation_max\s*=\s*2\.5/);
+    });
+
+    it('preserves JUMP_CMJ_HOH if measurements reference it', () => {
+      expect(downSql).toMatch(/code = 'JUMP_CMJ_HOH'[\s\S]*?NOT EXISTS[\s\S]*?measurements/);
+    });
+
+    it('restores PROTOCOL NOTE caveat in POWER_EUR description', () => {
+      expect(downSql).toMatch(/PROTOCOL NOTE/);
+    });
+  });
+
+  describe('Repointed EUR formula evaluation', () => {
+    it('parses against JUMP_CMJ_HOH and JUMP_SJ_HEIGHT', () => {
+      const r = validateFormula(NEW_EUR_FORMULA, ['JUMP_CMJ_HOH', 'JUMP_SJ_HEIGHT']);
+      expect(r.errors).toEqual([]);
+      expect(r.valid).toBe(true);
+    });
+
+    it('HOH-CMJ 28 in / SJ 24 in → EUR ≈ 1.17 (Trained reactive zone)', () => {
+      const v = evaluateFormula(NEW_EUR_FORMULA, { JUMP_CMJ_HOH: 28, JUMP_SJ_HEIGHT: 24 });
+      expect(v).toBeCloseTo(1.167, 2);
+    });
+
+    it('HOH-CMJ 25 in / SJ 24 in → EUR ≈ 1.04 (Concentric-dominant zone)', () => {
+      const v = evaluateFormula(NEW_EUR_FORMULA, { JUMP_CMJ_HOH: 25, JUMP_SJ_HEIGHT: 24 });
+      expect(v).toBeCloseTo(1.042, 2);
+    });
+
+    it('returns null when JUMP_SJ_HEIGHT is 0 (division-by-zero protection)', () => {
+      const v = evaluateFormula(NEW_EUR_FORMULA, { JUMP_CMJ_HOH: 28, JUMP_SJ_HEIGHT: 0 });
+      expect(v).toBeNull();
+    });
+  });
+
+  describe.skipIf(!process.env.DATABASE_URL)('Database state (when applied)', () => {
+    const rowsOf = (result: unknown): any[] => {
+      if (Array.isArray(result)) return result;
+      const r = result as { rows?: unknown };
+      return Array.isArray(r.rows) ? r.rows : [];
+    };
+
+    it('JUMP_CMJ_HOH exists with correct unit and metric_type', async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT code, unit, metric_type, validation_min, validation_max
+            FROM site_metrics WHERE code = 'JUMP_CMJ_HOH'
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0) {
+          console.warn('JUMP_CMJ_HOH not found — migration 0135 may not have been applied');
+          return;
+        }
+        expect(rows).toHaveLength(1);
+        expect(rows[0].unit).toBe('in');
+        expect(rows[0].metric_type).toBe('higher_is_better');
+      } catch (err) {
+        console.warn('Skipping live-DB check (migration 0135 may not have been applied):', err);
+      }
+    });
+
+    it('POWER_EUR formula is JUMP_CMJ_HOH / JUMP_SJ_HEIGHT and validation_max is 1.5', async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT formula, validation_max FROM site_metrics WHERE code = 'POWER_EUR'
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0) {
+          console.warn('POWER_EUR not found — migration 0131 may not have been applied');
+          return;
+        }
+        expect(rows[0].formula).toBe(NEW_EUR_FORMULA);
+        expect(parseFloat(rows[0].validation_max)).toBe(1.5);
+      } catch (err) {
+        console.warn('Skipping live-DB check (migration 0135 may not have been applied):', err);
+      }
+    });
+  });
+});

--- a/tests/migrations/0136-broad-jump.test.ts
+++ b/tests/migrations/0136-broad-jump.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Test suite for Migration 0136: JUMP_BROAD + Female Soccer benchmarks
+ *
+ * Adds the broad jump (standing long jump) base metric and seeds D1 + HS
+ * age-grouped female soccer tier values per
+ * bta-business/docs/benchmarks/d1-soccer-benchmarks.md §3.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { db } from '../../packages/api/db';
+import { sql } from 'drizzle-orm';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../..');
+
+const UP_SQL_PATH = path.join(projectRoot, 'migrations', '0136_add_jump_broad.sql');
+const DOWN_SQL_PATH = path.join(projectRoot, 'migrations', '0136_add_jump_broad_down.sql');
+
+describe('Migration 0136: JUMP_BROAD + Soccer benchmarks', () => {
+  describe('Up-migration SQL file', () => {
+    let upSql: string;
+
+    beforeAll(() => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+    });
+
+    it('exists and contains JUMP_BROAD metric definition', () => {
+      expect(fs.existsSync(UP_SQL_PATH)).toBe(true);
+      expect(upSql).toContain("'JUMP_BROAD'");
+      expect(upSql).toContain("'Broad Jump'");
+    });
+
+    it('JUMP_BROAD uses inches (codebase convention for jump metrics)', () => {
+      expect(upSql).toMatch(/'JUMP_BROAD'[\s\S]*?'in'/);
+    });
+
+    it('JUMP_BROAD is categorized as Power, higher_is_better', () => {
+      expect(upSql).toMatch(/'JUMP_BROAD'[\s\S]*?'Power'[\s\S]*?'higher_is_better'/);
+    });
+
+    it('seeds D1 soccer values per spec (Block B)', () => {
+      // D1 Avg = 70.1 in (= 178 cm)
+      expect(upSql).toMatch(/'d1-soc-broad-d1-avg'[\s\S]*?70\.100/);
+      // D1 Top 25% = 77.6 in (= 197 cm)
+      expect(upSql).toMatch(/'d1-soc-broad-d1-elite'[\s\S]*?77\.600/);
+    });
+
+    it('seeds HS varsity soccer values per spec', () => {
+      // Varsity Avg = 59.1 in (= 150 cm spec lower bound)
+      expect(upSql).toMatch(/'hs-var-soc-broad-avg'[\s\S]*?59\.100/);
+      // Varsity Top 25% = 65.0 in (= 165 cm spec lower bound)
+      expect(upSql).toMatch(/'hs-var-soc-broad-top25'[\s\S]*?65\.000/);
+    });
+
+    it('seeds HS MS / JV soccer values flagged LOW confidence', () => {
+      expect(upSql).toMatch(/'hs-ms-soc-broad'[\s\S]*?51\.200/);
+      expect(upSql).toMatch(/'hs-jv-soc-broad'[\s\S]*?57\.100/);
+      expect(upSql).toMatch(/'hs-ms-soc-broad'[\s\S]*?LOW/);
+    });
+
+    it('cites spec sources (Hilton 2021, Lockie 2016) on D1 rows', () => {
+      expect(upSql).toMatch(/'d1-soc-broad-d1-avg'[\s\S]*?Hilton/);
+      expect(upSql).toMatch(/'d1-soc-broad-d1-elite'[\s\S]*?Lockie/);
+    });
+
+    it('flags D1 rows MODERATE and HS Varsity rows LOW-MODERATE confidence', () => {
+      expect(upSql).toMatch(/'d1-soc-broad-d1-avg'[\s\S]*?MODERATE/);
+      expect(upSql).toMatch(/'hs-var-soc-broad-avg'[\s\S]*?LOW-MODERATE/);
+    });
+
+    it('ON CONFLICT pairing intact (each INSERT has matching DO clause)', () => {
+      const sqlOnly = upSql.split('\n').filter(l => !l.trim().startsWith('--')).join('\n');
+      const insertCount = (sqlOnly.match(/INSERT INTO/g) || []).length;
+      const conflictCount = (sqlOnly.match(/ON CONFLICT \([^)]+\)\s+DO\s+(UPDATE|NOTHING)/g) || []).length;
+      expect(insertCount).toBe(3);
+      expect(conflictCount).toBe(insertCount);
+    });
+
+    it('wires soccer broad jump benchmarks into existing 0131 sets', () => {
+      expect(upSql).toMatch(/'bsi-d1-soc-broad-d1-avg'[\s\S]*?'d1-womens-soccer'/);
+      expect(upSql).toMatch(/'bsi-hs-var-soc-broad-avg'[\s\S]*?'hs-varsity-female-soccer'/);
+    });
+  });
+
+  describe('Down-migration SQL file', () => {
+    it('exists and orders deletes safely', () => {
+      expect(fs.existsSync(DOWN_SQL_PATH)).toBe(true);
+      const downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
+      const setItemsIdx = downSql.indexOf('DELETE FROM benchmark_set_items');
+      const benchmarksIdx = downSql.indexOf('DELETE FROM site_benchmarks');
+      expect(setItemsIdx).toBeLessThan(benchmarksIdx);
+    });
+
+    it('preserves JUMP_BROAD if measurements reference it', () => {
+      const downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
+      expect(downSql).toMatch(/code = 'JUMP_BROAD'[\s\S]*?NOT EXISTS[\s\S]*?measurements/);
+    });
+  });
+
+  describe.skipIf(!process.env.DATABASE_URL)('Database state (when applied)', () => {
+    const rowsOf = (result: unknown): any[] => {
+      if (Array.isArray(result)) return result;
+      const r = result as { rows?: unknown };
+      return Array.isArray(r.rows) ? r.rows : [];
+    };
+
+    it('JUMP_BROAD metric exists with correct unit and category', async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT code, unit, category, metric_type
+            FROM site_metrics WHERE code = 'JUMP_BROAD'
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0) {
+          console.warn('JUMP_BROAD not found — migration 0136 may not have been applied');
+          return;
+        }
+        expect(rows).toHaveLength(1);
+        expect(rows[0].unit).toBe('in');
+        expect(rows[0].metric_type).toBe('higher_is_better');
+      } catch (err) {
+        console.warn('Skipping live-DB check (migration 0136 may not have been applied):', err);
+      }
+    });
+
+    it('Soccer broad jump benchmarks exist', async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT COUNT(*)::int AS n FROM site_benchmarks
+           WHERE metric_code = 'JUMP_BROAD' AND sport = 'SOCCER'
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0 || rows[0].n === 0) {
+          console.warn('Broad jump benchmarks not found — migration 0136 may not have been applied');
+          return;
+        }
+        expect(rows[0].n).toBe(6);
+      } catch (err) {
+        console.warn('Skipping live-DB check (migration 0136 may not have been applied):', err);
+      }
+    });
+  });
+});

--- a/tests/migrations/0137-eur-rsi-tiers.test.ts
+++ b/tests/migrations/0137-eur-rsi-tiers.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Test suite for Migration 0137:
+ *   - Add site_benchmarks.coaching_note column
+ *   - Seed POWER_EUR 4-tier diagnostic interpretation
+ *   - Add RSI_L / RSI_R base metrics + RSI_ASYM derived metric
+ *   - Seed RSI_L / RSI_R normative tiers + RSI_ASYM screening tiers
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { db } from '../../packages/api/db';
+import { sql } from 'drizzle-orm';
+import { evaluateFormula, validateFormula } from '../../packages/api/services/formula-service';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '../..');
+
+const UP_SQL_PATH = path.join(projectRoot, 'migrations', '0137_add_coaching_note_seed_eur_rsi_tiers.sql');
+const DOWN_SQL_PATH = path.join(projectRoot, 'migrations', '0137_add_coaching_note_seed_eur_rsi_tiers_down.sql');
+
+const RSI_ASYM_FORMULA = '((max(RSI_L, RSI_R) - min(RSI_L, RSI_R)) / max(RSI_L, RSI_R)) * 100';
+
+describe('Migration 0137: EUR tiers + bilateral RSI + coaching_note', () => {
+  describe('Up-migration SQL file', () => {
+    let upSql: string;
+
+    beforeAll(() => {
+      upSql = fs.readFileSync(UP_SQL_PATH, 'utf-8');
+    });
+
+    it('adds coaching_note column to site_benchmarks', () => {
+      expect(fs.existsSync(UP_SQL_PATH)).toBe(true);
+      expect(upSql).toMatch(/ALTER TABLE site_benchmarks[\s\S]*?ADD COLUMN IF NOT EXISTS coaching_note TEXT/);
+    });
+
+    describe('POWER_EUR 4-tier diagnostic', () => {
+      it('seeds Elite reactive tier with > 1.25 range', () => {
+        expect(upSql).toMatch(/'bench-eur-elite-reactive'[\s\S]*?'POWER_EUR'[\s\S]*?1\.25,\s*1\.5/);
+        expect(upSql).toMatch(/'bench-eur-elite-reactive'[\s\S]*?'Elite reactive'/);
+      });
+
+      it('seeds Trained reactive tier with 1.15–1.249 range', () => {
+        expect(upSql).toMatch(/'bench-eur-trained-reactive'[\s\S]*?1\.15,\s*1\.249/);
+      });
+
+      it('seeds Functional SSC use tier with 1.05–1.149 range', () => {
+        expect(upSql).toMatch(/'bench-eur-functional-ssc'[\s\S]*?1\.05,\s*1\.149/);
+      });
+
+      it('seeds Concentric-dominant tier with 0–1.049 range', () => {
+        expect(upSql).toMatch(/'bench-eur-concentric-dominant'[\s\S]*?0,\s*1\.049/);
+      });
+
+      it('all 4 EUR tiers share tier_group_id e0eeeeee', () => {
+        // Count tier_group_id casts followed by `, <int>,` (tier_order) — that
+        // pattern only appears inside INSERT VALUES tuples, not in comments
+        // or summary WHERE clauses.
+        const tgMatches = upSql.match(/'e0eeeeee-0137-4eee-9eee-eeeeeeeeeeee'::uuid,\s*\d+,/g) || [];
+        expect(tgMatches).toHaveLength(4);
+      });
+
+      it('Concentric-dominant coaching note prescribes plyometric block', () => {
+        expect(upSql).toMatch(/'bench-eur-concentric-dominant'[\s\S]*?Plyometric block/);
+      });
+
+      it('Trained reactive coaching note prescribes raising the SJ floor', () => {
+        expect(upSql).toMatch(/'bench-eur-trained-reactive'[\s\S]*?raising the SJ floor/);
+      });
+    });
+
+    describe('Bilateral RSI metrics', () => {
+      it('inserts RSI_L base metric with ratio unit and higher_is_better', () => {
+        expect(upSql).toMatch(/'RSI_L'[\s\S]*?'ratio'[\s\S]*?'higher_is_better'/);
+      });
+
+      it('inserts RSI_R base metric with ratio unit and higher_is_better', () => {
+        expect(upSql).toMatch(/'RSI_R'[\s\S]*?'ratio'[\s\S]*?'higher_is_better'/);
+      });
+
+      it('RSI_L description references 10/5 Repeat Hop protocol', () => {
+        expect(upSql).toMatch(/'RSI_L'[\s\S]*?10\/5 Repeat Hop/);
+      });
+
+      it('inserts RSI_ASYM derived metric with asymmetry % formula and lower_is_better', () => {
+        expect(upSql).toContain("'RSI_ASYM'");
+        expect(upSql).toMatch(/'RSI_ASYM'[\s\S]*?'%'[\s\S]*?'lower_is_better'/);
+        expect(upSql).toContain(RSI_ASYM_FORMULA);
+        expect(upSql).toMatch(/dependent_metrics[\s\S]*?ARRAY\['RSI_L',\s*'RSI_R'\]/);
+      });
+    });
+
+    describe('RSI_L and RSI_R normative tiers', () => {
+      it('seeds Elite tier (≥1.5) for both legs', () => {
+        expect(upSql).toMatch(/'bench-rsi-l-elite'[\s\S]*?1\.5,\s*5/);
+        expect(upSql).toMatch(/'bench-rsi-r-elite'[\s\S]*?1\.5,\s*5/);
+      });
+
+      it('seeds Trained tier (1.1–1.499) for both legs', () => {
+        expect(upSql).toMatch(/'bench-rsi-l-trained'[\s\S]*?1\.1,\s*1\.499/);
+        expect(upSql).toMatch(/'bench-rsi-r-trained'[\s\S]*?1\.1,\s*1\.499/);
+      });
+
+      it('seeds General tier (0.5–1.099) for both legs', () => {
+        expect(upSql).toMatch(/'bench-rsi-l-general'[\s\S]*?0\.5,\s*1\.099/);
+        expect(upSql).toMatch(/'bench-rsi-r-general'[\s\S]*?0\.5,\s*1\.099/);
+      });
+
+      it('seeds Below Floor tier (0–0.499) for both legs', () => {
+        expect(upSql).toMatch(/'bench-rsi-l-floor'[\s\S]*?0,\s*0\.499/);
+        expect(upSql).toMatch(/'bench-rsi-r-floor'[\s\S]*?0,\s*0\.499/);
+      });
+
+      it('RSI_L tiers share group 15151515 and RSI_R tiers share group 26262626', () => {
+        const lCasts = upSql.match(/'15151515-0137-4151-9151-aaaaaaaaaaaa'::uuid,\s*\d+,/g) || [];
+        const rCasts = upSql.match(/'26262626-0137-4262-a262-bbbbbbbbbbbb'::uuid,\s*\d+,/g) || [];
+        expect(lCasts).toHaveLength(4);
+        expect(rCasts).toHaveLength(4);
+      });
+    });
+
+    describe('RSI_ASYM screening tiers', () => {
+      it('seeds 4 tiers per spec ranges', () => {
+        expect(upSql).toMatch(/'bench-rsi-asym-symmetric'[\s\S]*?0,\s*9\.999/);
+        expect(upSql).toMatch(/'bench-rsi-asym-borderline'[\s\S]*?10,\s*14\.999/);
+        expect(upSql).toMatch(/'bench-rsi-asym-significant'[\s\S]*?15,\s*19\.999/);
+        expect(upSql).toMatch(/'bench-rsi-asym-redflag'[\s\S]*?20,\s*100/);
+      });
+
+      it('Significant Deficit tier carries SSC-breakdown coaching note', () => {
+        expect(upSql).toMatch(/'bench-rsi-asym-significant'[\s\S]*?SSC breakdown/);
+      });
+
+      it('Clinical Red Flag tier references ACL/joint deficit warning', () => {
+        expect(upSql).toMatch(/'bench-rsi-asym-redflag'[\s\S]*?ACL/);
+      });
+    });
+
+    describe('Benchmark sets and set items', () => {
+      it('creates EUR diagnostic screening set', () => {
+        expect(upSql).toMatch(/'set-screening-eur-diagnostic'[\s\S]*?'EUR Diagnostic Tiers'/);
+      });
+
+      it('creates RSI normative + asymmetry screening sets', () => {
+        expect(upSql).toContain("'set-screening-female-rsi-normative'");
+        expect(upSql).toContain("'set-screening-female-rsi-asymmetry'");
+      });
+
+      it('wires all 4 EUR tiers, 8 RSI normative tiers, 4 RSI asymmetry tiers into set_items', () => {
+        const setItemsBlock = upSql.match(/INSERT INTO benchmark_set_items[\s\S]*?ON CONFLICT/g) || [];
+        // Count benchmark_set_items inserts in the wiring block (Block D + Block K)
+        const totalBsiRows = (upSql.match(/^\s*\('bsi-(eur|rsi)-/gm) || []).length;
+        expect(totalBsiRows).toBe(16);
+      });
+    });
+  });
+
+  describe('Down-migration SQL file', () => {
+    let downSql: string;
+
+    beforeAll(() => {
+      downSql = fs.readFileSync(DOWN_SQL_PATH, 'utf-8');
+    });
+
+    it('exists and orders deletes safely (set_items → benchmarks → sets → metrics)', () => {
+      expect(fs.existsSync(DOWN_SQL_PATH)).toBe(true);
+      const setItemsIdx = downSql.indexOf('DELETE FROM benchmark_set_items');
+      const benchmarksIdx = downSql.indexOf('DELETE FROM site_benchmarks');
+      const setsIdx = downSql.indexOf('DELETE FROM benchmark_sets');
+      const metricsIdx = downSql.indexOf("WHERE code = 'RSI_ASYM'");
+      expect(setItemsIdx).toBeLessThan(benchmarksIdx);
+      expect(benchmarksIdx).toBeLessThan(setsIdx);
+      expect(setsIdx).toBeLessThan(metricsIdx);
+    });
+
+    it('preserves RSI_L and RSI_R if measurements reference them', () => {
+      expect(downSql).toMatch(/code IN \('RSI_L',\s*'RSI_R'\)[\s\S]*?NOT EXISTS[\s\S]*?measurements/);
+    });
+
+    it('intentionally does NOT drop the coaching_note column', () => {
+      expect(downSql).not.toMatch(/DROP COLUMN coaching_note/);
+      expect(downSql).toMatch(/coaching_note column[\s\S]*?NOT dropped/i);
+    });
+
+    it('removes the 3 screening benchmark_sets', () => {
+      expect(downSql).toContain("'set-screening-eur-diagnostic'");
+      expect(downSql).toContain("'set-screening-female-rsi-normative'");
+      expect(downSql).toContain("'set-screening-female-rsi-asymmetry'");
+    });
+  });
+
+  describe('RSI_ASYM formula evaluation', () => {
+    it('parses against [RSI_L, RSI_R]', () => {
+      const r = validateFormula(RSI_ASYM_FORMULA, ['RSI_L', 'RSI_R']);
+      expect(r.errors).toEqual([]);
+      expect(r.valid).toBe(true);
+    });
+
+    it('RSI_L 1.4, RSI_R 1.2 → asymmetry ≈ 14.286%', () => {
+      const v = evaluateFormula(RSI_ASYM_FORMULA, { RSI_L: 1.4, RSI_R: 1.2 });
+      expect(v).toBeCloseTo(14.286, 2);
+    });
+
+    it('RSI_L 1.0, RSI_R 1.0 → asymmetry = 0% (perfect symmetry)', () => {
+      const v = evaluateFormula(RSI_ASYM_FORMULA, { RSI_L: 1.0, RSI_R: 1.0 });
+      expect(v).toBe(0);
+    });
+
+    it('RSI_L 1.0, RSI_R 0.7 → asymmetry = 30% (Clinical Red Flag zone)', () => {
+      const v = evaluateFormula(RSI_ASYM_FORMULA, { RSI_L: 1.0, RSI_R: 0.7 });
+      expect(v).toBeCloseTo(30, 2);
+    });
+
+    it('returns null when both inputs are 0 (degenerate / div-by-zero)', () => {
+      const v = evaluateFormula(RSI_ASYM_FORMULA, { RSI_L: 0, RSI_R: 0 });
+      expect(v).toBeNull();
+    });
+
+    it('RSI_L 0, RSI_R 1.0 → 100% asymmetry (one-leg-zero edge case)', () => {
+      // Physiologically implausible but possible from data-entry error;
+      // formula should produce 100% rather than div-by-zero or NaN, since
+      // max(0, 1.0) = 1.0 keeps the denominator non-zero.
+      const v = evaluateFormula(RSI_ASYM_FORMULA, { RSI_L: 0, RSI_R: 1.0 });
+      expect(v).toBeCloseTo(100, 2);
+    });
+  });
+
+  describe.skipIf(!process.env.DATABASE_URL)('Database state (when applied)', () => {
+    const rowsOf = (result: unknown): any[] => {
+      if (Array.isArray(result)) return result;
+      const r = result as { rows?: unknown };
+      return Array.isArray(r.rows) ? r.rows : [];
+    };
+
+    it('coaching_note column exists on site_benchmarks', async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT column_name FROM information_schema.columns
+            WHERE table_name = 'site_benchmarks' AND column_name = 'coaching_note'
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0) {
+          console.warn('coaching_note column not found — migration 0137 may not have been applied');
+          return;
+        }
+        expect(rows).toHaveLength(1);
+      } catch (err) {
+        console.warn('Skipping live-DB check:', err);
+      }
+    });
+
+    it('POWER_EUR has 4 tier rows with coaching notes', async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT COUNT(*)::int AS n FROM site_benchmarks
+           WHERE metric_code = 'POWER_EUR' AND coaching_note IS NOT NULL
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0) return;
+        expect(rows[0].n).toBe(4);
+      } catch (err) {
+        console.warn('Skipping live-DB check:', err);
+      }
+    });
+
+    it('RSI_L, RSI_R, RSI_ASYM exist with correct types', async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT code, metric_type, is_derived FROM site_metrics
+           WHERE code IN ('RSI_L', 'RSI_R', 'RSI_ASYM') ORDER BY code
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0) return;
+        expect(rows).toHaveLength(3);
+        const asym = rows.find((row: any) => row.code === 'RSI_ASYM');
+        expect(asym.metric_type).toBe('lower_is_better');
+        expect(asym.is_derived).toBe(true);
+      } catch (err) {
+        console.warn('Skipping live-DB check:', err);
+      }
+    });
+
+    it('RSI_ASYM has 4 screening tiers; RSI_L+RSI_R have 8 normative tiers', async () => {
+      try {
+        const r = await db.execute(sql`
+          SELECT metric_code, COUNT(*)::int AS n FROM site_benchmarks
+           WHERE metric_code IN ('RSI_L', 'RSI_R', 'RSI_ASYM')
+             AND tier_group_id IS NOT NULL
+           GROUP BY metric_code ORDER BY metric_code
+        `);
+        const rows = rowsOf(r);
+        if (rows.length === 0) return;
+        const counts = Object.fromEntries(rows.map((row: any) => [row.metric_code, row.n]));
+        expect(counts.RSI_L).toBe(4);
+        expect(counts.RSI_R).toBe(4);
+        expect(counts.RSI_ASYM).toBe(4);
+      } catch (err) {
+        console.warn('Skipping live-DB check:', err);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three connected migrations + renderer touch-ups that close the EUR protocol-mismatch caveat, add the horizontal-power broad jump test, and ship interpretive screening tiers for EUR + bilateral RSI so reports surface training-prescription guidance instead of bare numbers.

- **Migration 0135** — add `JUMP_CMJ_HOH` (hands-on-hips CMJ) and repoint `POWER_EUR` formula to `JUMP_CMJ_HOH / JUMP_SJ_HEIGHT`; tighten `validation_max` 2.5→1.5 and drop the protocol caveat that 0131 carried.
- **Migration 0136** — add `JUMP_BROAD` (standing long jump) base metric + 6 D1/HS female soccer benchmarks per `bta-business/docs/benchmarks/d1-soccer-benchmarks.md` §3.
- **Migration 0137** — add nullable `coaching_note` column on `site_benchmarks`; seed `POWER_EUR` 4-tier diagnostic interpretation (Concentric-dominant / Functional SSC / Trained reactive / Elite reactive) per AM-FEAT-012 §5–§6; add `RSI_L`/`RSI_R` (10/5 Repeat Hop) + `RSI_ASYM` derived metric; seed RSI normative tiers (Elite/Trained/General/Below Floor) and RSI_ASYM screening tiers (Symmetrical/Borderline/Significant Deficit/Clinical Red Flag).
- App code propagates `coachingNote` through `evaluateTierBenchmark` → PDF + web reports; appears as italicized prose under the tier badge when present.

## Why this matters

- **EUR protocol fix**: AM-FEAT-012 published EUR thresholds (1.05 / 1.15 / 1.25) calibrated for hands-on-hips CMJ. AthleteMetrics' `VERTICAL_JUMP` is a hands-free CMJ (with arm swing), so 0131's EUR formula was off by ~15–25%. 0135 introduces a protocol-distinct metric (`JUMP_CMJ_HOH`) and repoints EUR to it.
- **Tier rendering, not aspirational tables**: AM-FEAT-012 §5 defined a "render-time interpretation table" for EUR — but no render-time logic exists in the codebase. All tier rendering is DB-driven via `evaluateTierBenchmark()` (`packages/api/services/report-service.ts:1570-1653`). 0137 closes the gap by seeding tiers as DB rows so they plug into the existing pipeline.
- **Bilateral RSI for return-to-play**: RSI asymmetry is "stickier" than 5-0-5 LSI in return-to-play — an athlete passing 5-0-5 LSI but failing RSI symmetry is likely "muscling" through movement vs. using elastic energy. Tiers from user-provided research synthesizing JOSPT Open 2025 + Bishop et al.

## Files changed

**Migrations (6 new SQL files):**
- `migrations/0135_add_cmj_hoh_repoint_eur.sql` + `_down.sql`
- `migrations/0136_add_jump_broad.sql` + `_down.sql`
- `migrations/0137_add_coaching_note_seed_eur_rsi_tiers.sql` + `_down.sql`

**Migration tests (3 new + 1 touch-up):**
- `tests/migrations/0135-cmj-hoh-eur.test.ts` (17 tests)
- `tests/migrations/0136-broad-jump.test.ts` (14 tests)
- `tests/migrations/0137-eur-rsi-tiers.test.ts` (37 tests)
- `tests/migrations/0131-squat-jump-eur.test.ts` — loosens one live-DB assertion that pinned the EUR formula (now changes by design in 0135)

**App code (5 files, additive):**
- `packages/shared/schema/tables/benchmarks.ts` — adds `coachingNote` column to `siteBenchmarks`
- `packages/api/services/report-service.ts` — `evaluateTierBenchmark` returns `coachingNote`; `getBenchmarksForReport` propagates it through 4 push sites
- `packages/api/routes/report-routes.ts` — PDF tier-cell text appends coaching note when present
- `packages/web/src/types/report-types.ts` — `BenchmarkComparison` adds `coachingNote`
- `packages/web/src/components/reports/IndividualReportView.tsx` — renders coaching note as italicized muted text under the TierBadge

## Schema-rollback design choice

`migrations/0137_..._down.sql` deliberately **does not drop** the `coaching_note` column. Rationale documented in the migration header: `ALTER TABLE … DROP COLUMN` is destructive, and the column is purely additive (nullable, no default). Leaving it in place keeps schema superset-compatible with 0137-up; manual drop is recommended only with explicit confirmation that no data will be lost.

## Test plan

- [ ] `npm run check` — TypeScript compiles cleanly (verified locally; passing)
- [ ] `npm run test -- 0131 0135 0136 0137` — all 83 migration tests pass (verified locally; passing)
- [ ] Apply migrations to a dev DB via `npm run db:migrate:manual` and verify:
  - `coaching_note` column exists on `site_benchmarks`
  - `POWER_EUR` formula = `JUMP_CMJ_HOH / JUMP_SJ_HEIGHT`, validation_max = 1.5
  - 4 EUR tier rows present with coaching notes populated
  - 8 RSI normative tiers (4 each for `RSI_L`, `RSI_R`)
  - 4 `RSI_ASYM` screening tiers
  - 6 `JUMP_BROAD` soccer benchmarks
- [ ] UI smoke test: enter paired CMJ-HOH + SJ measurements → eval one-pager renders EUR tier label + coaching note
- [ ] Regression: confirm `AGILITY_505_LSI` rendering unchanged (its tier rows have `coaching_note=NULL` so the renderer should silently omit the prose line)

## Out of scope (deferred)

- VB / basketball / football broad jump benchmarks (pending sport-specific spec tabulation)
- Bilateral `RSI` (non-leg-specific) normative tiers — user-provided research is single-leg-specific
- CV-aware RSI asymmetry flagging (requires per-trial RSI storage)
- Drop Jump (`POWER_RSI_DJ`) — separate spec
- Coaching notes for existing tiered metrics (e.g., 0128 LSI tiers) — can be backfilled in a future seed migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)