### PR TITLE
fix(metrics): display metric labels in UI instead of raw codes

### DIFF
--- a/packages/web/src/__tests__/components/athlete/MetricProgressCard.test.tsx
+++ b/packages/web/src/__tests__/components/athlete/MetricProgressCard.test.tsx
@@ -18,6 +18,19 @@ vi.mock('react-chartjs-2', () => ({
   ),
 }));
 
+const METRIC_LABEL_FIXTURE: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+};
+
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: METRIC_LABEL_FIXTURE,
+    getLabel: (code: string) => METRIC_LABEL_FIXTURE[code] ?? code,
+    isLoading: false,
+  }),
+}));
+
 describe('MetricProgressCard', () => {
   const mockMeasurements = [
     { value: 1.55, date: '2023-12-15' },

--- a/packages/web/src/__tests__/components/recent-athletes-widget.test.tsx
+++ b/packages/web/src/__tests__/components/recent-athletes-widget.test.tsx
@@ -177,10 +177,12 @@ describe("RecentAthletesWidget", () => {
         expect(screen.getByText("John Smith")).toBeInTheDocument();
       });
 
-      // Check measurement types are displayed (now as raw metric codes - fallback behavior)
-      expect(screen.getByText("FLY10_TIME")).toBeInTheDocument();
-      expect(screen.getByText("VERTICAL_JUMP")).toBeInTheDocument();
-      expect(screen.getByText("DASH_40YD")).toBeInTheDocument();
+      // Check measurement types are displayed. With no metricLabels fixture
+      // in scope (test doesn't seed the query cache), getLabel falls back to
+      // the underscore-split form — still prose, not the underscored code.
+      expect(screen.getByText("FLY10 TIME")).toBeInTheDocument();
+      expect(screen.getByText("VERTICAL JUMP")).toBeInTheDocument();
+      expect(screen.getByText("DASH 40YD")).toBeInTheDocument();
 
       // Check dates are formatted and displayed
       const dates = screen.getAllByText(/Nov \d{1,2}/i);

--- a/packages/web/src/__tests__/components/recent-athletes-widget.test.tsx
+++ b/packages/web/src/__tests__/components/recent-athletes-widget.test.tsx
@@ -19,6 +19,19 @@ import RecentAthletesWidget from "@/components/recent-athletes-widget";
 // Mock fetch API
 global.fetch = vi.fn();
 
+// Mock useMetricLabels with empty labels so the widget falls through to the
+// hook's underscore-split fallback (FLY10_TIME → "FLY10 TIME"). This is
+// what these tests assert below; making the mock explicit prevents a future
+// setupFiles change that seeds the React Query cache from silently
+// breaking the expectations.
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: {},
+    getLabel: (code: string) => code.replace(/_/g, ' '),
+    isLoading: false,
+  }),
+}));
+
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: {

--- a/packages/web/src/components/analytics/StatisticsSummaryCard.tsx
+++ b/packages/web/src/components/analytics/StatisticsSummaryCard.tsx
@@ -6,7 +6,8 @@
 import React, { useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { calculateStatistics } from '@shared/analytics-utils';
-import { getMetricDisplayName, getMetricUnits, getMetricType } from '@/lib/metrics';
+import { getMetricUnits, getMetricType } from '@/lib/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import type { MetricType } from '@shared/analytics-types';
 
 /**
@@ -35,13 +36,6 @@ function formatNumber(value: number, decimals: number = 2): string {
   return value.toFixed(decimals);
 }
 
-/**
- * Generate default title from metric name using shared utility
- */
-function getDefaultTitle(metric: string): string {
-  return `${getMetricDisplayName(metric)} Statistics`;
-}
-
 export function StatisticsSummaryCard({
   measurements,
   metric,
@@ -49,6 +43,7 @@ export function StatisticsSummaryCard({
   distributionMode = 'quartiles',
   metricType: metricTypeOverride,
 }: StatisticsSummaryCardProps) {
+  const { getLabel } = useMetricLabels();
   // Resolve metric direction: DB override > fallback chain
   const metricDirection = metricTypeOverride || getMetricType(metric);
   // Extract numeric values from measurements (already filtered by caller)
@@ -60,7 +55,7 @@ export function StatisticsSummaryCard({
 
   // Get units for this metric
   const units = getMetricUnits(metric);
-  const displayTitle = title || getDefaultTitle(metric);
+  const displayTitle = title || `${getLabel(metric)} Statistics`;
 
   // Handle empty state
   if (stats.count === 0) {

--- a/packages/web/src/components/analytics/__tests__/StatisticsSummaryCard.test.tsx
+++ b/packages/web/src/components/analytics/__tests__/StatisticsSummaryCard.test.tsx
@@ -4,11 +4,25 @@
  */
 
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { StatisticsSummaryCard } from '../StatisticsSummaryCard';
 import type { Measurement } from '@shared/schema';
+
+const METRIC_LABEL_FIXTURE: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+  DASH_40YD: '40-Yard Dash',
+};
+
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: METRIC_LABEL_FIXTURE,
+    getLabel: (code: string) => METRIC_LABEL_FIXTURE[code] ?? code,
+    isLoading: false,
+  }),
+}));
 
 // Helper to create minimal test measurement
 function createTestMeasurement(overrides: Partial<Measurement>): Measurement {

--- a/packages/web/src/components/athlete/DeleteMeasurementDialog.tsx
+++ b/packages/web/src/components/athlete/DeleteMeasurementDialog.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Loader2 } from 'lucide-react';
 import type { Measurement } from '@shared/schema';
-import { getMetricDisplayName } from '@/constants/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 
 export interface DeleteMeasurementDialogProps {
   open: boolean;
@@ -35,12 +35,14 @@ export function DeleteMeasurementDialog({
   onCancel,
   isDeleting = false,
 }: DeleteMeasurementDialogProps) {
+  const { getLabel } = useMetricLabels();
+
   // Don't render if no measurement
   if (!measurement) {
     return null;
   }
 
-  const metricDisplayName = getMetricDisplayName(measurement.metric);
+  const metricDisplayName = getLabel(measurement.metric);
 
   const handleConfirm = () => {
     onConfirm(measurement.id);

--- a/packages/web/src/components/athlete/EditMeasurementModal.tsx
+++ b/packages/web/src/components/athlete/EditMeasurementModal.tsx
@@ -30,7 +30,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Loader2 } from 'lucide-react';
 import type { Measurement } from '@shared/schema';
-import { getMetricDisplayName, getMetricUnit } from '@/constants/metrics';
+import { getMetricUnit } from '@/constants/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 
 // Form validation schema
 const editMeasurementSchema = z.object({
@@ -85,6 +86,8 @@ export function EditMeasurementModal({
     },
   });
 
+  const { getLabel } = useMetricLabels();
+
   // Reset form when measurement changes
   React.useEffect(() => {
     if (measurement && open) {
@@ -101,7 +104,7 @@ export function EditMeasurementModal({
     return null;
   }
 
-  const metricDisplayName = getMetricDisplayName(measurement.metric);
+  const metricDisplayName = getLabel(measurement.metric);
   const metricUnits = getMetricUnit(measurement.metric, measurement.units);
 
   const handleSubmit = (data: EditMeasurementFormData) => {

--- a/packages/web/src/components/athlete/MeasurementHistoryTable.tsx
+++ b/packages/web/src/components/athlete/MeasurementHistoryTable.tsx
@@ -23,7 +23,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ChevronDown, ChevronUp, Download, Pencil, Trash2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getMetricDisplayName } from '@/constants/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import { AthleteOrgContext } from '@/lib/athlete-org-context';
 import { Link } from 'wouter';
 
@@ -63,6 +63,7 @@ export function MeasurementHistoryTable({
   showSourceColumn = false,
 }: MeasurementHistoryTableProps) {
   const showActions = Boolean(onEdit || onDelete);
+  const { getLabel } = useMetricLabels();
 
   // Try to get filter mode from context to determine if we should show org column
   const athleteOrgContext = useContext(AthleteOrgContext);
@@ -83,9 +84,7 @@ export function MeasurementHistoryTable({
           comparison = new Date(a.date).getTime() - new Date(b.date).getTime();
           break;
         case 'metric':
-          comparison = getMetricDisplayName(a.metric).localeCompare(
-            getMetricDisplayName(b.metric)
-          );
+          comparison = getLabel(a.metric).localeCompare(getLabel(b.metric));
           break;
         case 'value':
           comparison = parseFloat(a.value) - parseFloat(b.value);
@@ -96,7 +95,7 @@ export function MeasurementHistoryTable({
     });
 
     return sorted;
-  }, [measurements, sortField, sortDirection]);
+  }, [measurements, sortField, sortDirection, getLabel]);
 
   const handleSort = useCallback((field: SortField) => {
     if (sortField === field) {
@@ -266,10 +265,10 @@ export function MeasurementHistoryTable({
                   }}
                   tabIndex={0}
                   aria-expanded={isExpanded}
-                  aria-label={`${getMetricDisplayName(measurement.metric)}: ${measurement.value} ${measurement.units}. Press Enter to ${isExpanded ? 'collapse' : 'expand'} notes.`}
+                  aria-label={`${getLabel(measurement.metric)}: ${measurement.value} ${measurement.units}. Press Enter to ${isExpanded ? 'collapse' : 'expand'} notes.`}
                 >
                   <TableCell>{formatDate(measurement.date)}</TableCell>
-                  <TableCell>{getMetricDisplayName(measurement.metric)}</TableCell>
+                  <TableCell>{getLabel(measurement.metric)}</TableCell>
                   <TableCell>
                     {measurement.value} {measurement.units}
                   </TableCell>
@@ -315,7 +314,7 @@ export function MeasurementHistoryTable({
                                 e.stopPropagation();
                                 onEdit(measurement);
                               }}
-                              aria-label={`Edit ${getMetricDisplayName(measurement.metric)} measurement`}
+                              aria-label={`Edit ${getLabel(measurement.metric)} measurement`}
                             >
                               <Pencil className="h-4 w-4" />
                             </Button>
@@ -329,7 +328,7 @@ export function MeasurementHistoryTable({
                                 e.stopPropagation();
                                 onDelete(measurement);
                               }}
-                              aria-label={`Delete ${getMetricDisplayName(measurement.metric)} measurement`}
+                              aria-label={`Delete ${getLabel(measurement.metric)} measurement`}
                             >
                               <Trash2 className="h-4 w-4" />
                             </Button>

--- a/packages/web/src/components/athlete/MeasurementProgressChart.tsx
+++ b/packages/web/src/components/athlete/MeasurementProgressChart.tsx
@@ -15,7 +15,8 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { AlertCircle, TrendingUp } from 'lucide-react';
 import type { Measurement } from '@shared/schema';
-import { getMetricDisplayName, getMetricUnit, isLowerBetter } from '@/constants/metrics';
+import { getMetricUnit, isLowerBetter } from '@/constants/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 
 // Import chart setup to register Chart.js components
 import '@/lib/chart-setup';
@@ -106,6 +107,7 @@ export function MeasurementProgressChart({
   const [internalShowTrendLine, setInternalShowTrendLine] = useState(true);
   const showTrendLine = controlledShowTrendLine ?? internalShowTrendLine;
   const handleTrendLineChange = onShowTrendLineChange ?? setInternalShowTrendLine;
+  const { getLabel } = useMetricLabels();
 
   // Check if measurements have mixed metrics
   const uniqueMetrics = useMemo(() => {
@@ -189,7 +191,7 @@ export function MeasurementProgressChart({
     // Build datasets array with proper typing
     const datasets: ChartDataset<'line', number[]>[] = [
       {
-        label: `${getMetricDisplayName(metric)} (${getMetricUnit(metric, units)})`,
+        label: `${getLabel(metric)} (${getMetricUnit(metric, units)})`,
         data,
         borderColor: 'rgb(59, 130, 246)',
         backgroundColor: 'rgba(59, 130, 246, 0.5)',
@@ -224,7 +226,7 @@ export function MeasurementProgressChart({
       labels,
       datasets,
     };
-  }, [processedData, showTrendLine, trendData]);
+  }, [processedData, showTrendLine, trendData, getLabel]);
 
   const chartOptions: ChartOptions<'line'> = useMemo(
     () => ({
@@ -359,7 +361,7 @@ export function MeasurementProgressChart({
       <div
         className="h-80"
         role="img"
-        aria-label={`Line chart showing ${getMetricDisplayName(measurements[0]?.metric || '')} progress over time${showTrendLine ? ' with trend line' : ''}`}
+        aria-label={`Line chart showing ${getLabel(measurements[0]?.metric || '')} progress over time${showTrendLine ? ' with trend line' : ''}`}
       >
         <Line data={chartData} options={chartOptions} />
       </div>

--- a/packages/web/src/components/athlete/MeasurementTimeline.tsx
+++ b/packages/web/src/components/athlete/MeasurementTimeline.tsx
@@ -32,7 +32,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { VerificationBadge } from './VerificationBadge';
 import type { Measurement } from '@shared/schema';
-import { getMetricDisplayName } from '@/constants/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 
 export interface MeasurementTimelineProps {
   measurements: Measurement[];
@@ -133,6 +133,8 @@ export function MeasurementTimeline({
   measurements,
   isLoading = false,
 }: MeasurementTimelineProps) {
+  const { getLabel } = useMetricLabels();
+
   // Show loading skeleton
   if (isLoading) {
     return <TimelineLoadingSkeleton />;
@@ -159,7 +161,7 @@ export function MeasurementTimeline({
           <div className="space-y-4 pl-4 border-l-2 border-muted">
             {monthMeasurements.map((measurement) => {
               const date = parseLocalDate(measurement.date);
-              const displayName = getMetricDisplayName(measurement.metric);
+              const displayName = getLabel(measurement.metric);
               const truncatedNote = truncateNote(measurement.notes);
 
               return (

--- a/packages/web/src/components/athlete/MetricProgressCard.tsx
+++ b/packages/web/src/components/athlete/MetricProgressCard.tsx
@@ -25,7 +25,7 @@ import {
 import { MetricContextTooltip } from './MetricContextTooltip';
 import { AthleteMetricExplanation } from './AthleteMetricExplanation';
 import { isLowerBetter } from '@/constants/metrics';
-import { getMetricDisplayName } from '@/lib/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import type { MetricExplanation } from '@shared/metric-explanations';
 
 // Chart.js is already registered globally in App.tsx via chart-setup.ts
@@ -100,6 +100,7 @@ export function MetricProgressCard({
   explanation,
 }: MetricProgressCardProps) {
   const confettiTriggered = useRef(false);
+  const { getLabel: getMetricLabel } = useMetricLabels();
 
   // Trigger confetti for recent PRs
   useEffect(() => {
@@ -332,7 +333,7 @@ export function MetricProgressCard({
       </CardContent>
       {isDerived && dependentMetrics.length > 0 && (
         <CardFooter className="pt-2 pb-3 text-xs text-muted-foreground border-t">
-          Calculated from: {dependentMetrics.map(m => dependentMetricLabels?.[m] ?? getMetricDisplayName(m)).join(', ')}
+          Calculated from: {dependentMetrics.map(m => dependentMetricLabels?.[m] ?? getMetricLabel(m)).join(', ')}
         </CardFooter>
       )}
     </Card>

--- a/packages/web/src/components/athlete/PeerComparisonCard.tsx
+++ b/packages/web/src/components/athlete/PeerComparisonCard.tsx
@@ -85,10 +85,7 @@ function PercentileIndicator({ percentile }: { percentile: number }) {
 /**
  * Single metric row display
  */
-function MetricPercentileRow({ result }: { result: PercentileResult }) {
-  const { getLabel } = useMetricLabels();
-  const displayName = getLabel(result.metric);
-
+function MetricPercentileRow({ result, displayName }: { result: PercentileResult; displayName: string }) {
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between text-sm">
@@ -168,6 +165,9 @@ export function PeerComparisonCard({
   availableMetrics,
   compact = false,
 }: PeerComparisonCardProps) {
+  // Resolve metric labels once for the whole card (single subscription, not per row)
+  const { getLabel } = useMetricLabels();
+
   // Check opt-in status
   const { data: peerStatus, isLoading: statusLoading } = usePeerComparisonStatus(userId);
 
@@ -268,7 +268,7 @@ export function PeerComparisonCard({
         {/* Metrics list */}
         <div className="space-y-3">
           {sortedPercentiles.slice(0, compact ? 3 : 5).map((result) => (
-            <MetricPercentileRow key={result.metric} result={result} />
+            <MetricPercentileRow key={result.metric} result={result} displayName={getLabel(result.metric)} />
           ))}
         </div>
 

--- a/packages/web/src/components/athlete/PeerComparisonCard.tsx
+++ b/packages/web/src/components/athlete/PeerComparisonCard.tsx
@@ -36,7 +36,7 @@ import {
   getPercentileLabel,
   type PercentileResult,
 } from '@/hooks/usePeerComparison';
-import { getMetricDisplayName } from '@/lib/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 
 interface PeerComparisonCardProps {
   userId: string;
@@ -86,7 +86,8 @@ function PercentileIndicator({ percentile }: { percentile: number }) {
  * Single metric row display
  */
 function MetricPercentileRow({ result }: { result: PercentileResult }) {
-  const displayName = getMetricDisplayName(result.metric);
+  const { getLabel } = useMetricLabels();
+  const displayName = getLabel(result.metric);
 
   return (
     <div className="space-y-1.5">

--- a/packages/web/src/components/athlete/__tests__/DeleteMeasurementDialog.test.tsx
+++ b/packages/web/src/components/athlete/__tests__/DeleteMeasurementDialog.test.tsx
@@ -12,6 +12,19 @@ import '@testing-library/jest-dom';
 import { DeleteMeasurementDialog } from '../DeleteMeasurementDialog';
 import type { Measurement } from '@shared/schema';
 
+const METRIC_LABELS: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+};
+
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: METRIC_LABELS,
+    getLabel: (code: string) => METRIC_LABELS[code] ?? code,
+    isLoading: false,
+  }),
+}));
+
 // Mock measurement data
 const mockMeasurement: Measurement = {
   id: 'measurement-1',
@@ -108,8 +121,6 @@ describe('DeleteMeasurementDialog', () => {
     });
 
     it('should display metric name in message', () => {
-      // NOTE: getMetricDisplayName now returns metric codes as fallback.
-      // In production, labels come from database via useMetricConfig hook.
       render(
         <DeleteMeasurementDialog
           open={true}
@@ -119,8 +130,8 @@ describe('DeleteMeasurementDialog', () => {
         />
       );
 
-      // Now displays metric code (fallback behavior)
-      expect(screen.getByText(/FLY10_TIME/i)).toBeInTheDocument();
+      // Displays user-facing label resolved via useMetricLabels
+      expect(screen.getByText(/10-Yard Fly Time/i)).toBeInTheDocument();
     });
   });
 

--- a/packages/web/src/components/athlete/__tests__/EditMeasurementModal.test.tsx
+++ b/packages/web/src/components/athlete/__tests__/EditMeasurementModal.test.tsx
@@ -12,6 +12,19 @@ import '@testing-library/jest-dom';
 import { EditMeasurementModal } from '../EditMeasurementModal';
 import type { Measurement } from '@shared/schema';
 
+const METRIC_LABELS: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+};
+
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: METRIC_LABELS,
+    getLabel: (code: string) => METRIC_LABELS[code] ?? code,
+    isLoading: false,
+  }),
+}));
+
 // Mock measurement data
 const mockMeasurement: Measurement = {
   id: 'measurement-1',
@@ -95,8 +108,6 @@ describe('EditMeasurementModal', () => {
     });
 
     it('should display metric name in title or description', () => {
-      // NOTE: getMetricDisplayName now returns metric codes as fallback.
-      // In production, labels come from database via useMetricConfig hook.
       render(
         <EditMeasurementModal
           open={true}
@@ -106,8 +117,8 @@ describe('EditMeasurementModal', () => {
         />
       );
 
-      // Now displays metric code (fallback behavior)
-      expect(screen.getByText(/FLY10_TIME/i)).toBeInTheDocument();
+      // Displays user-facing label resolved via useMetricLabels
+      expect(screen.getByText(/10-Yard Fly Time/i)).toBeInTheDocument();
     });
   });
 

--- a/packages/web/src/components/athlete/__tests__/MeasurementHistoryTable.test.tsx
+++ b/packages/web/src/components/athlete/__tests__/MeasurementHistoryTable.test.tsx
@@ -10,6 +10,22 @@ import userEvent from '@testing-library/user-event';
 import { MeasurementHistoryTable } from '../MeasurementHistoryTable';
 import type { Measurement } from '@shared/schema';
 
+const METRIC_LABELS: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+  AGILITY_505: '5-0-5 Agility',
+  DASH_40YD: '40-Yard Dash',
+  T_TEST: 'T-Test',
+};
+
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: METRIC_LABELS,
+    getLabel: (code: string) => METRIC_LABELS[code] ?? code,
+    isLoading: false,
+  }),
+}));
+
 // Mock measurements data
 const mockMeasurements: Measurement[] = [
   {
@@ -133,13 +149,11 @@ describe('MeasurementHistoryTable', () => {
     });
 
     it('should display metric display name instead of raw key', () => {
-      // NOTE: getMetricDisplayName now returns metric codes as fallback.
-      // In production, labels come from database via useMetricConfig hook.
       render(<MeasurementHistoryTable measurements={mockMeasurements} />);
 
-      // Now displays metric codes (fallback behavior - labels from DB in production)
-      expect(screen.getByText('FLY10_TIME')).toBeInTheDocument();
-      expect(screen.getByText('VERTICAL_JUMP')).toBeInTheDocument();
+      // Now displays user-facing labels resolved via useMetricLabels
+      expect(screen.getByText('10-Yard Fly Time')).toBeInTheDocument();
+      expect(screen.getByText('Vertical Jump')).toBeInTheDocument();
     });
 
     it('should display value with units', () => {
@@ -194,8 +208,8 @@ describe('MeasurementHistoryTable', () => {
     it('should not show actual data when loading', () => {
       render(<MeasurementHistoryTable measurements={mockMeasurements} isLoading={true} />);
 
-      // Data should not be visible during loading (metric codes instead of display names)
-      expect(screen.queryByText('FLY10_TIME')).not.toBeInTheDocument();
+      // Data should not be visible during loading
+      expect(screen.queryByText('10-Yard Fly Time')).not.toBeInTheDocument();
     });
   });
 
@@ -239,8 +253,10 @@ describe('MeasurementHistoryTable', () => {
       const rows = screen.getAllByRole('row').slice(1);
       const firstRow = rows[0];
 
-      // Should be sorted alphabetically by metric code (fallback behavior)
-      expect(within(firstRow).getByText(/FLY10_TIME|AGILITY_505|VERTICAL_JUMP/i)).toBeInTheDocument();
+      // Should be sorted alphabetically by metric label
+      // Labels: "10-Yard Fly Time", "5-0-5 Agility", "Vertical Jump"
+      // Ascending alphabetical order starts with "10-Yard Fly Time"
+      expect(within(firstRow).getByText('10-Yard Fly Time')).toBeInTheDocument();
     });
 
     it('should sort by value when clicking value column header', async () => {

--- a/packages/web/src/components/athlete/__tests__/MeasurementProgressChart.test.tsx
+++ b/packages/web/src/components/athlete/__tests__/MeasurementProgressChart.test.tsx
@@ -21,6 +21,19 @@ vi.mock('react-chartjs-2', () => ({
   ))
 }));
 
+const METRIC_LABELS: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+};
+
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: METRIC_LABELS,
+    getLabel: (code: string) => METRIC_LABELS[code] ?? code,
+    isLoading: false,
+  }),
+}));
+
 // Import after mocks
 import { MeasurementProgressChart } from '../MeasurementProgressChart';
 
@@ -105,8 +118,8 @@ describe('MeasurementProgressChart', () => {
     it('should render chart with metric name as label', () => {
       render(<MeasurementProgressChart measurements={mockMeasurements} />);
 
-      // Now uses raw metric code as fallback since METRIC_DISPLAY_NAMES is empty
-      expect(screen.getByTestId('chart-dataset-label')).toHaveTextContent(/FLY10_TIME/i);
+      // Uses user-facing label resolved via useMetricLabels
+      expect(screen.getByTestId('chart-dataset-label')).toHaveTextContent(/10-Yard Fly Time/i);
     });
   });
 

--- a/packages/web/src/components/athlete/__tests__/MeasurementTimeline.test.tsx
+++ b/packages/web/src/components/athlete/__tests__/MeasurementTimeline.test.tsx
@@ -4,10 +4,25 @@
  * TDD Test Suite for athlete measurement timeline view
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import { MeasurementTimeline } from '../MeasurementTimeline';
 import type { Measurement } from '@shared/schema';
+
+const METRIC_LABELS: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+  DASH_40YD: '40-Yard Dash',
+  T_TEST: 'T-Test',
+};
+
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: METRIC_LABELS,
+    getLabel: (code: string) => METRIC_LABELS[code] ?? code,
+    isLoading: false,
+  }),
+}));
 
 // Mock measurements data
 const mockMeasurements: Measurement[] = [
@@ -148,13 +163,13 @@ describe('MeasurementTimeline', () => {
 
       const measurementCards = screen.getAllByTestId(/^measurement-card-/);
 
-      // First card should be the most recent (Dec 15) - now shows raw metric codes
-      expect(within(measurementCards[0]).getByText('FLY10_TIME')).toBeInTheDocument();
+      // First card should be the most recent (Dec 15) - shows labels via useMetricLabels
+      expect(within(measurementCards[0]).getByText('10-Yard Fly Time')).toBeInTheDocument();
       // Value and unit are separate text nodes in the component
       expect(within(measurementCards[0]).getByText('1.52', { exact: false })).toBeInTheDocument();
 
       // Second card should be Dec 10
-      expect(within(measurementCards[1]).getByText('VERTICAL_JUMP')).toBeInTheDocument();
+      expect(within(measurementCards[1]).getByText('Vertical Jump')).toBeInTheDocument();
       expect(within(measurementCards[1]).getByText('28.5', { exact: false })).toBeInTheDocument();
     });
 
@@ -172,15 +187,13 @@ describe('MeasurementTimeline', () => {
 
   describe('Measurement card content', () => {
     it('should display metric name in human-readable format', () => {
-      // NOTE: getMetricDisplayName now returns metric codes as fallback.
-      // In production, labels come from database via useMetricConfig hook.
       render(<MeasurementTimeline measurements={mockMeasurements} />);
 
-      // Now displays metric codes (fallback behavior)
-      expect(screen.getByText('FLY10_TIME')).toBeInTheDocument();
-      expect(screen.getByText('VERTICAL_JUMP')).toBeInTheDocument();
-      expect(screen.getByText('DASH_40YD')).toBeInTheDocument();
-      expect(screen.getByText('T_TEST')).toBeInTheDocument();
+      // Now displays user-facing labels resolved via useMetricLabels
+      expect(screen.getByText('10-Yard Fly Time')).toBeInTheDocument();
+      expect(screen.getByText('Vertical Jump')).toBeInTheDocument();
+      expect(screen.getByText('40-Yard Dash')).toBeInTheDocument();
+      expect(screen.getByText('T-Test')).toBeInTheDocument();
     });
 
     it('should display value with units', () => {

--- a/packages/web/src/components/benchmarks/AthleteBenchmarkStatus.tsx
+++ b/packages/web/src/components/benchmarks/AthleteBenchmarkStatus.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { getMetricDisplayName } from "@/constants/metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 
 interface AthleteBenchmarkStatusProps {
   organizationId: string;
@@ -31,6 +31,7 @@ export function AthleteBenchmarkStatus({
 }: AthleteBenchmarkStatusProps) {
   const [filterStatus, setFilterStatus] = useState<"all" | "met" | "unmet">("all");
   const [filterSetId, setFilterSetId] = useState<string>("all");
+  const { getLabel } = useMetricLabels();
 
   const { data: benchmarks, isLoading, error } = useAthleteBenchmarkStatus(
     organizationId,
@@ -193,7 +194,7 @@ export function AthleteBenchmarkStatus({
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-1">
                         <h4 className="font-semibold">{benchmark.benchmarkName}</h4>
-                        <Badge variant="outline">{getMetricDisplayName(benchmark.metricCode)}</Badge>
+                        <Badge variant="outline">{getLabel(benchmark.metricCode)}</Badge>
                       </div>
                     </div>
                     <BenchmarkBadge isMet={benchmark.isMet} progress={benchmark.progress} />

--- a/packages/web/src/components/benchmarks/BenchmarkCard.tsx
+++ b/packages/web/src/components/benchmarks/BenchmarkCard.tsx
@@ -10,7 +10,7 @@ import { useMetricConfig } from "@/hooks/use-metric-config";
 import { Edit, Trash2, Target, Layers } from "lucide-react";
 import { BenchmarkDeleteDialog } from "./BenchmarkDeleteDialog";
 import { TierBadgeCompact } from "./TierBadge";
-import { getMetricDisplayName } from "@/constants/metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 import type { SiteBenchmark } from "@shared/schema";
 
 interface BenchmarkCardProps {
@@ -23,6 +23,7 @@ export function BenchmarkCard({ benchmark, onEdit }: BenchmarkCardProps) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const { getMetricConfig } = useMetricConfig();
+  const { getLabel } = useMetricLabels();
 
   const toggleStatusMutation = useToggleSiteBenchmarkStatus();
   const deleteMutation = useDeleteSiteBenchmark();
@@ -108,7 +109,7 @@ export function BenchmarkCard({ benchmark, onEdit }: BenchmarkCardProps) {
                 {benchmark.name}
               </CardTitle>
               <div className="flex flex-wrap gap-2 mt-2">
-                <Badge variant="outline">{getMetricDisplayName(benchmark.metricCode)}</Badge>
+                <Badge variant="outline">{getLabel(benchmark.metricCode)}</Badge>
                 <Badge variant={benchmark.isActive ? "default" : "secondary"}>
                   {benchmark.isActive ? "Active" : "Inactive"}
                 </Badge>

--- a/packages/web/src/components/benchmarks/BenchmarkCatalog.tsx
+++ b/packages/web/src/components/benchmarks/BenchmarkCatalog.tsx
@@ -16,7 +16,7 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Search, Target, Layers } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BenchmarkEnablementToggle } from "./BenchmarkEnablementToggle";
-import { getMetricDisplayName } from "@/constants/metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 
 interface BenchmarkCatalogProps {
   open: boolean;
@@ -27,6 +27,7 @@ interface BenchmarkCatalogProps {
 export function BenchmarkCatalog({ open, onClose, organizationId }: BenchmarkCatalogProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const { getMetricConfig } = useMetricConfig();
+  const { getLabel } = useMetricLabels();
 
   // Fetch site benchmarks available for this organization (filtered by org type)
   const { data: siteBenchmarks, isLoading: loadingSite } = useSiteBenchmarksForOrg(organizationId, false);
@@ -132,7 +133,7 @@ export function BenchmarkCatalog({ open, onClose, organizationId }: BenchmarkCat
                           <div className="flex items-center gap-2 mb-2">
                             <Target className="h-4 w-4" />
                             <h4 className="font-semibold">{benchmark.name}</h4>
-                            <Badge variant="outline">{getMetricDisplayName(benchmark.metricCode)}</Badge>
+                            <Badge variant="outline">{getLabel(benchmark.metricCode)}</Badge>
                           </div>
                           {benchmark.description && (
                             <p className="text-sm text-muted-foreground mb-2">
@@ -204,7 +205,7 @@ export function BenchmarkCatalog({ open, onClose, organizationId }: BenchmarkCat
                           <div className="flex items-center gap-2 mb-2">
                             <Target className="h-4 w-4" />
                             <h4 className="font-semibold">{benchmark.name}</h4>
-                            <Badge variant="outline">{getMetricDisplayName(benchmark.metricCode)}</Badge>
+                            <Badge variant="outline">{getLabel(benchmark.metricCode)}</Badge>
                             <Badge variant="secondary">Custom</Badge>
                           </div>
                           {benchmark.description && (

--- a/packages/web/src/components/benchmarks/CustomBenchmarkCard.tsx
+++ b/packages/web/src/components/benchmarks/CustomBenchmarkCard.tsx
@@ -8,7 +8,7 @@ import { useMetricConfig } from "@/hooks/use-metric-config";
 import { Edit, Trash2, Target, Layers } from "lucide-react";
 import { CustomBenchmarkDeleteDialog } from "./CustomBenchmarkDeleteDialog";
 import { TierBadgeCompact } from "./TierBadge";
-import { getMetricDisplayName } from "@/constants/metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 import type { CustomBenchmark } from "@shared/schema";
 
 interface CustomBenchmarkCardProps {
@@ -25,6 +25,7 @@ export function CustomBenchmarkCard({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const { toast } = useToast();
   const { getMetricConfig } = useMetricConfig();
+  const { getLabel } = useMetricLabels();
 
   const deleteMutation = useDeleteCustomBenchmark();
 
@@ -93,7 +94,7 @@ export function CustomBenchmarkCard({
                 {benchmark.name}
               </CardTitle>
               <div className="flex flex-wrap gap-2 mt-2">
-                <Badge variant="outline">{getMetricDisplayName(benchmark.metricCode)}</Badge>
+                <Badge variant="outline">{getLabel(benchmark.metricCode)}</Badge>
                 <Badge variant="secondary">Custom</Badge>
                 <Badge variant={benchmark.isActive ? "default" : "secondary"}>
                   {benchmark.isActive ? "Active" : "Inactive"}

--- a/packages/web/src/components/benchmarks/OrganizationBenchmarksList.tsx
+++ b/packages/web/src/components/benchmarks/OrganizationBenchmarksList.tsx
@@ -11,7 +11,7 @@ import { BenchmarkCatalog } from "./BenchmarkCatalog";
 import { BenchmarkEnablementToggle } from "./BenchmarkEnablementToggle";
 import { BenchmarkFilters } from "./BenchmarkFilters";
 import { Link } from "wouter";
-import { getMetricDisplayName } from "@/constants/metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 import type { OrganizationBenchmarkWithDetails } from "@shared/schema";
 
 interface OrganizationBenchmarksListProps {
@@ -22,6 +22,7 @@ export function OrganizationBenchmarksList({ organizationId }: OrganizationBench
   const [showCatalog, setShowCatalog] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const { getMetricConfig } = useMetricConfig();
+  const { getLabel } = useMetricLabels();
   const [filters, setFilters] = useState<{
     metricCode?: string;
     gender?: string;
@@ -185,7 +186,7 @@ export function OrganizationBenchmarksList({ organizationId }: OrganizationBench
                     <div className="flex flex-wrap gap-3 text-sm">
                       <div>
                         <span className="font-medium">Metric:</span>{" "}
-                        <span className="text-muted-foreground">{getMetricDisplayName(benchmark.metricCode)}</span>
+                        <span className="text-muted-foreground">{getLabel(benchmark.metricCode)}</span>
                       </div>
                       <div>
                         <span className="font-medium">Target:</span>{" "}

--- a/packages/web/src/components/charts/LineChart.tsx
+++ b/packages/web/src/components/charts/LineChart.tsx
@@ -9,6 +9,7 @@ import type {
   BenchmarkLine
 } from '@shared/analytics-types';
 import { useMetricConfig } from '@/hooks/use-metric-config';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import { isFly10Metric, formatFly10Dual } from '@/utils/fly10-conversion';
 import { parseColorToRgba } from '@/lib/color-utils';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -42,6 +43,7 @@ export function LineChart({
   showBenchmarks = true
 }: LineChartProps) {
   const { getMetricConfig } = useMetricConfig();
+  const { getLabel } = useMetricLabels();
 
   // State for athlete visibility toggles
   const [athleteToggles, setAthleteToggles] = useState<Record<string, boolean>>({});
@@ -633,12 +635,12 @@ export function LineChart({
 
       <div
         role="img"
-        aria-label={`Line chart showing ${lineData.metric} performance over time${benchmarks && benchmarks.length > 0 ? ` with ${benchmarks.length} benchmark reference ${benchmarks.length === 1 ? 'line' : 'lines'}` : ''}`}
+        aria-label={`Line chart showing ${getLabel(lineData.metric)} performance over time${benchmarks && benchmarks.length > 0 ? ` with ${benchmarks.length} benchmark reference ${benchmarks.length === 1 ? 'line' : 'lines'}` : ''}`}
         aria-describedby="linechart-description"
         className="flex-1 min-h-[300px]"
       >
         <span id="linechart-description" className="sr-only">
-          {`Performance trend chart for ${lineData.metric}. ${visibleAthleteCount} ${visibleAthleteCount === 1 ? 'athlete' : 'athletes'} displayed.${benchmarks && benchmarks.length > 0 ? ` Benchmark lines: ${benchmarks.map(b => b.name).join(', ')}.` : ''}`}
+          {`Performance trend chart for ${getLabel(lineData.metric)}. ${visibleAthleteCount} ${visibleAthleteCount === 1 ? 'athlete' : 'athletes'} displayed.${benchmarks && benchmarks.length > 0 ? ` Benchmark lines: ${benchmarks.map(b => b.name).join(', ')}.` : ''}`}
         </span>
         <Line data={lineData} options={options} />
       </div>

--- a/packages/web/src/components/command-palette/command-palette.tsx
+++ b/packages/web/src/components/command-palette/command-palette.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@/lib/auth';
 import { hasPermission, type Permission } from '@shared/role-types';
 import { getCommandActions, filterActionsByQuery, filterActionsByPermissions } from '@/lib/command-palette-actions';
 import { getRecentItems, addRecentItem, type RecentItem } from '@/lib/recent-items';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import { User, Users, Activity, Clock } from 'lucide-react';
 
 export function CommandPalette() {
@@ -19,6 +20,7 @@ export function CommandPalette() {
   const [query, setQuery] = useState('');
   const [, setLocation] = useLocation();
   const { user } = useAuth();
+  const { getLabel } = useMetricLabels();
 
   // Navigation function compatible with wouter
   const navigate = (path: string) => setLocation(path);
@@ -206,7 +208,7 @@ export function CommandPalette() {
                 <div className="flex flex-col">
                   <span>{measurement.athleteName}</span>
                   <span className="text-xs text-muted-foreground">
-                    {measurement.metric} • {measurement.value} • {measurement.date}
+                    {getLabel(measurement.metric)} • {measurement.value} • {measurement.date}
                   </span>
                 </div>
               </CommandItem>

--- a/packages/web/src/components/device-import/DeviceImportDialog.tsx
+++ b/packages/web/src/components/device-import/DeviceImportDialog.tsx
@@ -44,6 +44,7 @@ import {
   type PreviewAthlete,
   type ParsedSession,
 } from '@/hooks/useDeviceImport';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import { ChevronDown, ChevronRight, AlertTriangle, Upload, Loader2 } from 'lucide-react';
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -127,6 +128,7 @@ function AthleteReviewRow({
   onIncluded,
 }: AthleteReviewRowProps) {
   const [open, setOpen] = useState(false);
+  const { getLabel } = useMetricLabels();
   const effectiveMatchId = overrideMatchedId ?? athlete.matchedAthleteId;
   const effectiveMatchType =
     overrideMatchedId && overrideMatchedId !== athlete.matchedAthleteId
@@ -206,7 +208,7 @@ function AthleteReviewRow({
             <div className="space-y-1 text-xs">
               {athlete.drills.map((drill, i) => (
                 <div key={i} className="flex items-center gap-2">
-                  <span className="font-mono text-muted-foreground w-28">{drill.metric}</span>
+                  <span className="text-muted-foreground w-28">{getLabel(drill.metric)}</span>
                   <span className="font-semibold">
                     {drill.value} {drill.units}
                   </span>
@@ -222,7 +224,7 @@ function AthleteReviewRow({
                   )}
                   {drill.splits && drill.splits.length > 0 && (
                     <span className="text-muted-foreground">
-                      ({drill.splits.map((s) => `${s.metric}: ${s.value}${s.units}`).join(', ')})
+                      ({drill.splits.map((s) => `${getLabel(s.metric)}: ${s.value}${s.units}`).join(', ')})
                     </span>
                   )}
                 </div>

--- a/packages/web/src/components/device-import/DeviceImportDialog.tsx
+++ b/packages/web/src/components/device-import/DeviceImportDialog.tsx
@@ -117,6 +117,9 @@ interface AthleteReviewRowProps {
   included: boolean;
   onOverride: (csvName: string, athleteId: string | undefined) => void;
   onIncluded: (csvName: string, included: boolean) => void;
+  /** Metric-code → label resolver; hoisted from the parent so we don't
+   *  re-call useMetricLabels() once per row. */
+  getLabel: (code: string) => string;
 }
 
 function AthleteReviewRow({
@@ -126,9 +129,9 @@ function AthleteReviewRow({
   included,
   onOverride,
   onIncluded,
+  getLabel,
 }: AthleteReviewRowProps) {
   const [open, setOpen] = useState(false);
-  const { getLabel } = useMetricLabels();
   const effectiveMatchId = overrideMatchedId ?? athlete.matchedAthleteId;
   const effectiveMatchType =
     overrideMatchedId && overrideMatchedId !== athlete.matchedAthleteId
@@ -250,6 +253,11 @@ export function DeviceImportDialog({
   const [source] = useState<string>('dashr');
   const [duplicateStrategy, setDuplicateStrategy] = useState<'skip' | 'replace'>('skip');
   const [addMissingEventMetrics, setAddMissingEventMetrics] = useState(false);
+
+  // Resolve metric labels once for the whole dialog so each AthleteReviewRow
+  // doesn't re-subscribe to useAvailableMetrics; getLabel is referentially
+  // stable across renders thanks to useCallback inside useMetricLabels.
+  const { getLabel } = useMetricLabels();
 
   const {
     step,
@@ -577,6 +585,7 @@ export function DeviceImportDialog({
                     included={override?.included ?? athlete.included}
                     onOverride={setAthleteOverride}
                     onIncluded={setAthleteIncluded}
+                    getLabel={getLabel}
                   />
                 );
               })}

--- a/packages/web/src/components/measurements-timeline.tsx
+++ b/packages/web/src/components/measurements-timeline.tsx
@@ -28,21 +28,18 @@ interface MeasurementsTimelineProps {
 }
 
 /**
- * Three-tier label resolution for a timeline entry:
+ * Two-tier label resolution for a timeline entry:
  *   1. Server-supplied metricName (preferred — built against the payload)
- *   2. Org-aware live label from useMetricLabels (covers custom org metrics
- *      and per-org label overrides)
- *   3. Underscore-split fallback (e.g. FLY10_TIME → "FLY10 TIME") so legacy
- *      codes no longer in availableMetrics still read as prose
+ *   2. Org-aware live label from useMetricLabels — handles custom org
+ *      metrics, per-org label overrides, AND the unknown-code fallback
+ *      (underscore-split prose) internally, so no third tier is needed
+ *      here.
  */
 function resolveTimelineLabel(
   measurement: Measurement,
   getLabel: (code: string) => string,
 ): string {
-  if (measurement.metricName) return measurement.metricName;
-  const resolved = getLabel(measurement.metricType);
-  if (resolved !== measurement.metricType) return resolved;
-  return measurement.metricType.replace(/_/g, ' ');
+  return measurement.metricName ?? getLabel(measurement.metricType);
 }
 
 export function MeasurementsTimeline({ measurements }: MeasurementsTimelineProps) {

--- a/packages/web/src/components/measurements-timeline.tsx
+++ b/packages/web/src/components/measurements-timeline.tsx
@@ -138,7 +138,18 @@ export function MeasurementsTimeline({ measurements }: MeasurementsTimelineProps
                   variant="secondary"
                 >
                   <Icon className="h-3 w-3 mr-1" />
-                  {measurement.metricName || getLabel(measurement.metricType)}
+                  {(() => {
+                    // Three-tier resolution:
+                    //   1. Server-supplied metricName (preferred — built against the report payload)
+                    //   2. Live org-aware label from useMetricLabels (handles custom org metrics + label overrides)
+                    //   3. Underscore-split fallback (e.g. FLY10_TIME → "FLY10 TIME") so archived/deleted
+                    //      metrics that no longer appear in availableMetrics still read as prose,
+                    //      preserving the pre-migration UX for legacy data.
+                    if (measurement.metricName) return measurement.metricName;
+                    const resolved = getLabel(measurement.metricType);
+                    if (resolved !== measurement.metricType) return resolved;
+                    return measurement.metricType.replace(/_/g, ' ');
+                  })()}
                 </Badge>
               </div>
             </CardHeader>

--- a/packages/web/src/components/measurements-timeline.tsx
+++ b/packages/web/src/components/measurements-timeline.tsx
@@ -27,6 +27,24 @@ interface MeasurementsTimelineProps {
   measurements: Measurement[];
 }
 
+/**
+ * Three-tier label resolution for a timeline entry:
+ *   1. Server-supplied metricName (preferred — built against the payload)
+ *   2. Org-aware live label from useMetricLabels (covers custom org metrics
+ *      and per-org label overrides)
+ *   3. Underscore-split fallback (e.g. FLY10_TIME → "FLY10 TIME") so legacy
+ *      codes no longer in availableMetrics still read as prose
+ */
+function resolveTimelineLabel(
+  measurement: Measurement,
+  getLabel: (code: string) => string,
+): string {
+  if (measurement.metricName) return measurement.metricName;
+  const resolved = getLabel(measurement.metricType);
+  if (resolved !== measurement.metricType) return resolved;
+  return measurement.metricType.replace(/_/g, ' ');
+}
+
 export function MeasurementsTimeline({ measurements }: MeasurementsTimelineProps) {
   const { getLabel } = useMetricLabels();
   const formatDate = (dateStr: string) => {
@@ -138,18 +156,7 @@ export function MeasurementsTimeline({ measurements }: MeasurementsTimelineProps
                   variant="secondary"
                 >
                   <Icon className="h-3 w-3 mr-1" />
-                  {(() => {
-                    // Three-tier resolution:
-                    //   1. Server-supplied metricName (preferred — built against the report payload)
-                    //   2. Live org-aware label from useMetricLabels (handles custom org metrics + label overrides)
-                    //   3. Underscore-split fallback (e.g. FLY10_TIME → "FLY10 TIME") so archived/deleted
-                    //      metrics that no longer appear in availableMetrics still read as prose,
-                    //      preserving the pre-migration UX for legacy data.
-                    if (measurement.metricName) return measurement.metricName;
-                    const resolved = getLabel(measurement.metricType);
-                    if (resolved !== measurement.metricType) return resolved;
-                    return measurement.metricType.replace(/_/g, ' ');
-                  })()}
+                  {resolveTimelineLabel(measurement, getLabel)}
                 </Badge>
               </div>
             </CardHeader>

--- a/packages/web/src/components/measurements-timeline.tsx
+++ b/packages/web/src/components/measurements-timeline.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 
 interface Measurement {
   id: string;
@@ -27,6 +28,7 @@ interface MeasurementsTimelineProps {
 }
 
 export function MeasurementsTimeline({ measurements }: MeasurementsTimelineProps) {
+  const { getLabel } = useMetricLabels();
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
     const now = new Date();
@@ -136,7 +138,7 @@ export function MeasurementsTimeline({ measurements }: MeasurementsTimelineProps
                   variant="secondary"
                 >
                   <Icon className="h-3 w-3 mr-1" />
-                  {measurement.metricName || measurement.metricType.replace(/_/g, ' ')}
+                  {measurement.metricName || getLabel(measurement.metricType)}
                 </Badge>
               </div>
             </CardHeader>

--- a/packages/web/src/components/photo-upload/ocr-results.tsx
+++ b/packages/web/src/components/photo-upload/ocr-results.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { AlertCircle, CheckCircle, Eye } from "lucide-react";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { useState } from "react";
-import { getMetricDisplayName } from "@/constants/metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 
 interface OCRResult {
   success: boolean;
@@ -37,6 +37,7 @@ interface OCRResultsProps {
 
 export function OCRResults({ result }: OCRResultsProps) {
   const [showExtractedText, setShowExtractedText] = useState(false);
+  const { getLabel } = useMetricLabels();
 
   const getConfidenceColor = (confidence: number) => {
     if (confidence >= 80) return 'text-green-600';
@@ -135,7 +136,7 @@ export function OCRResults({ result }: OCRResultsProps) {
                   <div className="flex-1">
                     <div className="font-medium">{item.athlete}</div>
                     <div className="text-sm text-gray-600">
-                      {getMetricDisplayName(item.measurement.metric)}: {item.measurement.value}
+                      {getLabel(item.measurement.metric)}: {item.measurement.value}
                       {item.measurement.date && ` | Date: ${item.measurement.date}`}
                     </div>
                     {item.rawText && (

--- a/packages/web/src/components/recent-athletes-widget.tsx
+++ b/packages/web/src/components/recent-athletes-widget.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Users, Plus, AlertCircle, RefreshCw } from "lucide-react";
-import { getMetricDisplayName } from "@/lib/metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 import { format } from "date-fns";
 
 interface RecentAthlete {
@@ -24,6 +24,7 @@ export default function RecentAthletesWidget({
   organizationId,
   onAddMeasurement,
 }: RecentAthletesWidgetProps) {
+  const { getLabel: getMetricLabel } = useMetricLabels();
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["/api/athletes/recent", organizationId],
     queryFn: async () => {
@@ -160,7 +161,7 @@ export default function RecentAthletesWidget({
                     {athlete.firstName} {athlete.lastName}
                   </p>
                   <div className="flex items-center space-x-2 text-xs text-gray-500">
-                    <span>{getMetricDisplayName(athlete.lastMeasurementType)}</span>
+                    <span>{getMetricLabel(athlete.lastMeasurementType)}</span>
                     <span>•</span>
                     <span>
                       {format(new Date(athlete.lastMeasurementDate), "MMM d")}

--- a/packages/web/src/components/reports/AthleteReportView.tsx
+++ b/packages/web/src/components/reports/AthleteReportView.tsx
@@ -18,6 +18,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useGenerateReport } from "@/hooks/use-reports";
 import { useReportPdf } from "@/hooks/use-report-pdf";
 import { useToast } from "@/hooks/use-toast";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ReportLoadingState } from "./ReportLoadingState";
@@ -136,6 +137,10 @@ function AthleteIndividualReportView({ report }: { report: Report }) {
   }
 
   const { athlete, metricLabels, metricUnits } = reportData;
+  // Backstop label resolution with the org's currently-active metric labels —
+  // see the matching block in AthleteTeamReportView below for rationale.
+  const { getLabel } = useMetricLabels();
+  const resolveLabel = (code: string) => metricLabels?.[code] ?? getLabel(code);
 
   return (
     <div className="space-y-6">
@@ -217,7 +222,7 @@ function AthleteIndividualReportView({ report }: { report: Report }) {
                   const percentile = athlete.percentiles[metricCode];
                   const teamAverage = athlete.teamAverages?.[metricCode];
                   const benchmarks = athlete.benchmarkComparisons[metricCode] || [];
-                  const metricLabel = metricLabels?.[metricCode] || metricCode;
+                  const metricLabel = resolveLabel(metricCode);
                   const unit = metricUnits?.[metricCode] || "";
 
                   return (
@@ -338,6 +343,11 @@ function AthleteTeamReportView({ report }: { report: Report }) {
   }
 
   const { teamStatistics, athleteRankings, generatedAt, metricLabels, metricUnits } = reportData;
+  // Backstop label resolution with the org's currently-active metric labels in
+  // case the report payload omits a code (e.g. custom org metric added after
+  // the report ran but before it rendered).
+  const { getLabel } = useMetricLabels();
+  const resolveLabel = (code: string) => metricLabels?.[code] ?? getLabel(code);
 
   // Collect all unique benchmark names
   const allBenchmarkNames = new Set<string>();
@@ -491,7 +501,7 @@ function AthleteTeamReportView({ report }: { report: Report }) {
 
                   return (
                     <TableRow key={stat.metric}>
-                      <TableCell className="font-medium">{metricLabels?.[stat.metric] || stat.metric}</TableCell>
+                      <TableCell className="font-medium">{resolveLabel(stat.metric)}</TableCell>
                       <TableCell>
                         {stat.average !== null && stat.average !== undefined
                           ? (isFly10Metric(stat.metric)
@@ -641,7 +651,7 @@ function AthleteTeamReportView({ report }: { report: Report }) {
             return (
               <Card key={stat.metric}>
                 <CardHeader>
-                  <CardTitle>{metricLabels?.[stat.metric] ?? stat.metric}</CardTitle>
+                  <CardTitle>{resolveLabel(stat.metric)}</CardTitle>
                   <CardDescription>
                     {labels.team} Average: {stat.average !== null ? `${stat.average.toFixed(2)} ${stat.units || ""}` : "N/A"}
                     {stat.standardDeviation !== null && ` | SD: ±${stat.standardDeviation.toFixed(2)} ${stat.units || ""}`}

--- a/packages/web/src/components/reports/AthleteReportView.tsx
+++ b/packages/web/src/components/reports/AthleteReportView.tsx
@@ -44,7 +44,6 @@ import { format } from "date-fns";
 import ReactMarkdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
 import { isFly10Metric, formatFly10Dual } from "@/utils/fly10-conversion";
-import { getMetricDisplayName } from "@/lib/metrics";
 import { isLowerBetter, sortAthletesByMetric, getBenchmarkLabel } from "@/lib/report-utils";
 import {
   getPerformanceColor,
@@ -642,7 +641,7 @@ function AthleteTeamReportView({ report }: { report: Report }) {
             return (
               <Card key={stat.metric}>
                 <CardHeader>
-                  <CardTitle>{metricLabels?.[stat.metric] || getMetricDisplayName(stat.metric)}</CardTitle>
+                  <CardTitle>{metricLabels?.[stat.metric] ?? stat.metric}</CardTitle>
                   <CardDescription>
                     {labels.team} Average: {stat.average !== null ? `${stat.average.toFixed(2)} ${stat.units || ""}` : "N/A"}
                     {stat.standardDeviation !== null && ` | SD: ±${stat.standardDeviation.toFixed(2)} ${stat.units || ""}`}

--- a/packages/web/src/components/reports/TeamReportView.tsx
+++ b/packages/web/src/components/reports/TeamReportView.tsx
@@ -33,7 +33,6 @@ import { CoachingInsightsCard } from "./CoachingInsightsCard";
 import { MetricExplanation } from "./MetricExplanation";
 import { ReportMetricsGlossary } from "./ReportMetricsGlossary";
 import { format } from "date-fns";
-import { getMetricDisplayName } from "@/lib/metrics";
 import {
   getPerformanceColor,
   getQuartileBadge,
@@ -494,7 +493,7 @@ export function TeamReportView({ report }: TeamReportViewProps) {
             return (
               <Card key={stat.metric}>
                 <CardHeader>
-                  <CardTitle>{metricLabels?.[stat.metric] || getMetricDisplayName(stat.metric)}</CardTitle>
+                  <CardTitle>{metricLabels?.[stat.metric] ?? stat.metric}</CardTitle>
                   <CardDescription>
                     {labels.team} Average: {stat.average !== null ? `${stat.average.toFixed(2)} ${stat.units || ''}` : 'N/A'}
                     {stat.standardDeviation !== null && ` | SD: ±${stat.standardDeviation.toFixed(2)} ${stat.units || ''}`}

--- a/packages/web/src/components/reports/TeamReportView.tsx
+++ b/packages/web/src/components/reports/TeamReportView.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useGenerateReport } from "@/hooks/use-reports";
 import { useReportPdf } from "@/hooks/use-report-pdf";
 import { useToast } from "@/hooks/use-toast";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 import { useTeams } from "@/hooks/use-teams";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -129,6 +130,11 @@ export function TeamReportView({ report }: TeamReportViewProps) {
   }
 
   const { teamStatistics, athleteRankings, generatedAt, metricLabels, metricUnits, metricExplanations } = reportData;
+  // Backstop label resolution with the org's currently-active metric labels in
+  // case the report payload omits a code (e.g. custom org metric added after
+  // the report ran but before it rendered).
+  const { getLabel } = useMetricLabels();
+  const resolveLabel = (code: string) => metricLabels?.[code] ?? getLabel(code);
   const teamMetricCodes = Array.isArray(teamStatistics) ? teamStatistics.map((s: TeamStatistic) => s.metric) : [];
 
   // Collect all unique benchmark names across all metrics
@@ -298,7 +304,7 @@ export function TeamReportView({ report }: TeamReportViewProps) {
                     <TableRow key={stat.metric}>
                       <TableCell className="font-medium align-top">
                         <MetricExplanation
-                          label={metricLabels?.[stat.metric] || stat.metric}
+                          label={resolveLabel(stat.metric)}
                           explanation={metricExplanations?.[stat.metric]}
                         />
                       </TableCell>
@@ -427,7 +433,7 @@ export function TeamReportView({ report }: TeamReportViewProps) {
                 <TableBody>
                   {tierDistributions.map(({ metricCode, tierGroupName, tiers }) => (
                     <TableRow key={`${metricCode}:${tierGroupName}`}>
-                      <TableCell className="font-medium">{metricLabels?.[metricCode] || metricCode}</TableCell>
+                      <TableCell className="font-medium">{resolveLabel(metricCode)}</TableCell>
                       <TableCell>{tierGroupName}</TableCell>
                       <TableCell>
                         <div className="flex flex-wrap gap-2">
@@ -493,7 +499,7 @@ export function TeamReportView({ report }: TeamReportViewProps) {
             return (
               <Card key={stat.metric}>
                 <CardHeader>
-                  <CardTitle>{metricLabels?.[stat.metric] ?? stat.metric}</CardTitle>
+                  <CardTitle>{resolveLabel(stat.metric)}</CardTitle>
                   <CardDescription>
                     {labels.team} Average: {stat.average !== null ? `${stat.average.toFixed(2)} ${stat.units || ''}` : 'N/A'}
                     {stat.standardDeviation !== null && ` | SD: ±${stat.standardDeviation.toFixed(2)} ${stat.units || ''}`}

--- a/packages/web/src/components/reports/__tests__/TeamReportView.test.tsx
+++ b/packages/web/src/components/reports/__tests__/TeamReportView.test.tsx
@@ -12,6 +12,13 @@ import type { Report } from '@/types/report-types';
 vi.mock('@/hooks/use-reports');
 vi.mock('@/hooks/use-teams');
 vi.mock('@/lib/auth');
+vi.mock('@/hooks/use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: {},
+    getLabel: (code: string) => code,
+    isLoading: false,
+  }),
+}));
 
 const mockGenerateReportMutate = vi.fn();
 

--- a/packages/web/src/components/reports/__tests__/TeamReportView.test.tsx
+++ b/packages/web/src/components/reports/__tests__/TeamReportView.test.tsx
@@ -12,10 +12,17 @@ import type { Report } from '@/types/report-types';
 vi.mock('@/hooks/use-reports');
 vi.mock('@/hooks/use-teams');
 vi.mock('@/lib/auth');
+// Real labels for the metric codes used in the report fixtures, so any
+// regression where a code leaks through resolveLabel() into rendered output
+// is distinguishable from the legitimate "label rendered" case.
+const TEST_METRIC_LABELS: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+};
 vi.mock('@/hooks/use-metric-labels', () => ({
   useMetricLabels: () => ({
-    labels: {},
-    getLabel: (code: string) => code,
+    labels: TEST_METRIC_LABELS,
+    getLabel: (code: string) => TEST_METRIC_LABELS[code] ?? code,
     isLoading: false,
   }),
 }));

--- a/packages/web/src/components/reports/__tests__/report-utils.test.ts
+++ b/packages/web/src/components/reports/__tests__/report-utils.test.ts
@@ -217,18 +217,18 @@ describe('report-utils', () => {
         { metric: 'FLY10_TIME' },
         { metric: 'UNKNOWN_METRIC' },
       ];
-      // getMetricDisplayName should be used for unknown metrics
+      // Unknown metrics fall back to the raw metric code
       const result = getMetricsList(teamStatistics, mockMetricLabels);
-      expect(result).toContain('10-Yard Fly');
-      // The unknown metric should appear in some form
-      expect(result.includes('UNKNOWN_METRIC') || result.includes('Unknown')).toBe(true);
+      expect(result).toBe('10-Yard Fly, UNKNOWN_METRIC');
     });
 
-    it('should handle undefined metricLabels', () => {
-      const teamStatistics = [{ metric: 'FLY10_TIME' }];
-      // Should use getMetricDisplayName fallback
+    it('should handle undefined metricLabels by falling back to metric codes', () => {
+      const teamStatistics = [
+        { metric: 'FLY10_TIME' },
+        { metric: 'VERTICAL_JUMP' },
+      ];
       const result = getMetricsList(teamStatistics, undefined);
-      expect(result.length).toBeGreaterThan(0);
+      expect(result).toBe('FLY10_TIME, VERTICAL_JUMP');
     });
   });
 
@@ -265,6 +265,26 @@ describe('report-utils', () => {
       const result = getCompositeIndexDescription(weights, mockMetricLabels);
       expect(result).toContain('33%');
       expect(result).toContain('67%');
+    });
+
+    it('should fall back to metric code when label is missing', () => {
+      const weights = {
+        FLY10_TIME: 0.5,
+        UNKNOWN_METRIC: 0.5,
+      };
+      const result = getCompositeIndexDescription(weights, mockMetricLabels);
+      expect(result).toContain('10-Yard Fly (50%)');
+      expect(result).toContain('UNKNOWN_METRIC (50%)');
+    });
+
+    it('should fall back to metric codes when metricLabels is undefined', () => {
+      const weights = {
+        FLY10_TIME: 0.4,
+        VERTICAL_JUMP: 0.6,
+      };
+      const result = getCompositeIndexDescription(weights, undefined);
+      expect(result).toContain('FLY10_TIME (40%)');
+      expect(result).toContain('VERTICAL_JUMP (60%)');
     });
   });
 

--- a/packages/web/src/components/reports/__tests__/report-utils.test.ts
+++ b/packages/web/src/components/reports/__tests__/report-utils.test.ts
@@ -212,23 +212,32 @@ describe('report-utils', () => {
       expect(getMetricsList(teamStatistics, mockMetricLabels)).toBe('10-Yard Fly, Vertical Jump');
     });
 
-    it('should fall back to metric code when label not found', () => {
+    it('falls back to the underscore-split form when label not found', () => {
       const teamStatistics = [
         { metric: 'FLY10_TIME' },
         { metric: 'UNKNOWN_METRIC' },
       ];
-      // Unknown metrics fall back to the raw metric code
+      // Codes not in the supplied labels map go through the private
+      // resolveFallbackLabel helper: underscore-split prose, not raw code.
       const result = getMetricsList(teamStatistics, mockMetricLabels);
-      expect(result).toBe('10-Yard Fly, UNKNOWN_METRIC');
+      expect(result).toBe('10-Yard Fly, UNKNOWN METRIC');
     });
 
-    it('should handle undefined metricLabels by falling back to metric codes', () => {
+    it('falls back to the built-in name map when metricLabels is undefined', () => {
       const teamStatistics = [
         { metric: 'FLY10_TIME' },
         { metric: 'VERTICAL_JUMP' },
       ];
+      // Both FLY10_TIME and VERTICAL_JUMP are in the private built-in map,
+      // so they render with full labels even with no metricLabels supplied.
       const result = getMetricsList(teamStatistics, undefined);
-      expect(result).toBe('FLY10_TIME, VERTICAL_JUMP');
+      expect(result).toBe('10-Yard Fly Time, Vertical Jump');
+    });
+
+    it('underscore-splits genuinely unknown codes when metricLabels is undefined', () => {
+      const teamStatistics = [{ metric: 'CUSTOM_DEADLIFT_1RM' }];
+      const result = getMetricsList(teamStatistics, undefined);
+      expect(result).toBe('CUSTOM DEADLIFT 1RM');
     });
   });
 
@@ -267,24 +276,25 @@ describe('report-utils', () => {
       expect(result).toContain('67%');
     });
 
-    it('should fall back to metric code when label is missing', () => {
+    it('underscore-splits unknown codes when not in the supplied labels map', () => {
       const weights = {
         FLY10_TIME: 0.5,
         UNKNOWN_METRIC: 0.5,
       };
       const result = getCompositeIndexDescription(weights, mockMetricLabels);
       expect(result).toContain('10-Yard Fly (50%)');
-      expect(result).toContain('UNKNOWN_METRIC (50%)');
+      expect(result).toContain('UNKNOWN METRIC (50%)');
     });
 
-    it('should fall back to metric codes when metricLabels is undefined', () => {
+    it('falls back to the built-in name map when metricLabels is undefined', () => {
       const weights = {
         FLY10_TIME: 0.4,
         VERTICAL_JUMP: 0.6,
       };
       const result = getCompositeIndexDescription(weights, undefined);
-      expect(result).toContain('FLY10_TIME (40%)');
-      expect(result).toContain('VERTICAL_JUMP (60%)');
+      // Both codes are in the private built-in map; full labels are used.
+      expect(result).toContain('10-Yard Fly Time (40%)');
+      expect(result).toContain('Vertical Jump (60%)');
     });
   });
 

--- a/packages/web/src/components/reports/report-utils.ts
+++ b/packages/web/src/components/reports/report-utils.ts
@@ -57,6 +57,35 @@ export function getQuartileBadge(
 }
 
 // ============================================================================
+// Metric Label Resolution
+// ============================================================================
+
+/**
+ * Last-resort metric display name when the caller didn't supply a labels map
+ * AND the code isn't one of the known built-ins. Underscore-split fallback
+ * keeps unknown codes legible (e.g. CUSTOM_DEADLIFT_1RM → "CUSTOM DEADLIFT
+ * 1RM"), matching the same shape used by `resolveTimelineLabel` in
+ * `measurements-timeline.tsx` and the local helper in
+ * `athlete-dashboard-utils.ts`.
+ *
+ * Exported callers should normally pass `metricLabels` from
+ * `useMetricLabels().labels`; this private helper is only the safety net.
+ */
+function resolveFallbackLabel(metric: string): string {
+  const displayNames: Record<string, string> = {
+    FLY10_TIME: '10-Yard Fly Time',
+    VERTICAL_JUMP: 'Vertical Jump',
+    DASH_40YD: '40-Yard Dash',
+    AGILITY_505: '5-0-5 Agility',
+    AGILITY_5105: '5-10-5 Agility',
+    T_TEST: 'T-Test Agility',
+    TOP_SPEED: 'Top Speed',
+    RSI: 'Reactive Strength Index',
+  };
+  return displayNames[metric] ?? metric.replace(/_/g, ' ');
+}
+
+// ============================================================================
 // Report Data Formatting
 // ============================================================================
 
@@ -135,7 +164,7 @@ export function getMetricsList(
   }
 
   return teamStatistics
-    .map((stat) => metricLabels?.[stat.metric] ?? stat.metric)
+    .map((stat) => metricLabels?.[stat.metric] ?? resolveFallbackLabel(stat.metric))
     .join(', ');
 }
 
@@ -156,7 +185,7 @@ export function getCompositeIndexDescription(
 
   const weightDescriptions = Object.entries(weights)
     .map(([metricCode, weight]) => {
-      const metricName = metricLabels?.[metricCode] ?? metricCode;
+      const metricName = metricLabels?.[metricCode] ?? resolveFallbackLabel(metricCode);
       const percentage = (weight * 100).toFixed(0);
       return `${metricName} (${percentage}%)`;
     })

--- a/packages/web/src/components/reports/report-utils.ts
+++ b/packages/web/src/components/reports/report-utils.ts
@@ -14,8 +14,7 @@
  */
 
 import { format } from 'date-fns';
-import { getMetricDisplayName } from '@/lib/metrics';
-import type { TimeframeConfig, AthleteRanking, TeamStatistic } from '@/types/report-types';
+import type { TimeframeConfig, AthleteRanking } from '@/types/report-types';
 
 // ============================================================================
 // Performance Visualization
@@ -136,7 +135,7 @@ export function getMetricsList(
   }
 
   return teamStatistics
-    .map((stat) => metricLabels?.[stat.metric] || getMetricDisplayName(stat.metric))
+    .map((stat) => metricLabels?.[stat.metric] ?? stat.metric)
     .join(', ');
 }
 
@@ -157,7 +156,7 @@ export function getCompositeIndexDescription(
 
   const weightDescriptions = Object.entries(weights)
     .map(([metricCode, weight]) => {
-      const metricName = metricLabels?.[metricCode] || getMetricDisplayName(metricCode);
+      const metricName = metricLabels?.[metricCode] ?? metricCode;
       const percentage = (weight * 100).toFixed(0);
       return `${metricName} (${percentage}%)`;
     })

--- a/packages/web/src/hooks/__tests__/use-metric-labels.test.ts
+++ b/packages/web/src/hooks/__tests__/use-metric-labels.test.ts
@@ -52,12 +52,15 @@ describe('useMetricLabels', () => {
     expect(result.current.getLabel('FLY10_TIME')).toBe('10-Yard Fly Time');
   });
 
-  it('getLabel falls back to the code when the metric is unknown', () => {
+  it('getLabel underscore-splits unknown codes for a readable fallback', () => {
     mockAvailableMetrics.metrics = [fixture('FLY10_TIME', '10-Yard Fly Time')];
 
     const { result } = renderHook(() => useMetricLabels());
 
-    expect(result.current.getLabel('ARCHIVED_METRIC')).toBe('ARCHIVED_METRIC');
+    // Codes not in the labels map (archived/deleted/migrated/loading) fall
+    // back to the underscore-split form so users see prose, not raw codes.
+    expect(result.current.getLabel('ARCHIVED_METRIC')).toBe('ARCHIVED METRIC');
+    expect(result.current.getLabel('CUSTOM_DEADLIFT_1RM')).toBe('CUSTOM DEADLIFT 1RM');
   });
 
   it('returns isLoading from the underlying useAvailableMetrics', () => {
@@ -68,14 +71,17 @@ describe('useMetricLabels', () => {
     expect(result.current.isLoading).toBe(true);
   });
 
-  it('returns an empty map (and code-fallback resolution) while loading', () => {
+  it('returns an empty map while loading; getLabel underscore-splits codes', () => {
     mockAvailableMetrics.isLoading = true;
     mockAvailableMetrics.metrics = [];
 
     const { result } = renderHook(() => useMetricLabels());
 
     expect(result.current.labels).toEqual({});
-    expect(result.current.getLabel('FLY10_TIME')).toBe('FLY10_TIME');
+    // During the loading window the fallback path runs for every code; it
+    // produces underscore-split prose so a first-paint flash doesn't show
+    // raw underscored codes to the user.
+    expect(result.current.getLabel('FLY10_TIME')).toBe('FLY10 TIME');
   });
 
   it('reflects custom labels from the upstream hook', () => {

--- a/packages/web/src/hooks/__tests__/use-metric-labels.test.ts
+++ b/packages/web/src/hooks/__tests__/use-metric-labels.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMetricLabels } from '../use-metric-labels';
+import type { AvailableMetric } from '../use-available-metrics';
+
+const mockAvailableMetrics = {
+  metrics: [] as AvailableMetric[],
+  isLoading: false,
+  error: null as Error | null,
+};
+
+vi.mock('../use-available-metrics', () => ({
+  useAvailableMetrics: () => mockAvailableMetrics,
+}));
+
+function fixture(code: string, label: string): AvailableMetric {
+  return {
+    code,
+    label,
+    unit: '',
+    metricType: 'higher_is_better',
+    lowerIsBetter: false,
+  };
+}
+
+describe('useMetricLabels', () => {
+  beforeEach(() => {
+    mockAvailableMetrics.metrics = [];
+    mockAvailableMetrics.isLoading = false;
+    mockAvailableMetrics.error = null;
+  });
+
+  it('builds a code → label map from useAvailableMetrics', () => {
+    mockAvailableMetrics.metrics = [
+      fixture('FLY10_TIME', '10-Yard Fly Time'),
+      fixture('VERTICAL_JUMP', 'Vertical Jump'),
+    ];
+
+    const { result } = renderHook(() => useMetricLabels());
+
+    expect(result.current.labels).toEqual({
+      FLY10_TIME: '10-Yard Fly Time',
+      VERTICAL_JUMP: 'Vertical Jump',
+    });
+  });
+
+  it('getLabel returns the human-readable label for a known code', () => {
+    mockAvailableMetrics.metrics = [fixture('FLY10_TIME', '10-Yard Fly Time')];
+
+    const { result } = renderHook(() => useMetricLabels());
+
+    expect(result.current.getLabel('FLY10_TIME')).toBe('10-Yard Fly Time');
+  });
+
+  it('getLabel falls back to the code when the metric is unknown', () => {
+    mockAvailableMetrics.metrics = [fixture('FLY10_TIME', '10-Yard Fly Time')];
+
+    const { result } = renderHook(() => useMetricLabels());
+
+    expect(result.current.getLabel('ARCHIVED_METRIC')).toBe('ARCHIVED_METRIC');
+  });
+
+  it('returns isLoading from the underlying useAvailableMetrics', () => {
+    mockAvailableMetrics.isLoading = true;
+
+    const { result } = renderHook(() => useMetricLabels());
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns an empty map (and code-fallback resolution) while loading', () => {
+    mockAvailableMetrics.isLoading = true;
+    mockAvailableMetrics.metrics = [];
+
+    const { result } = renderHook(() => useMetricLabels());
+
+    expect(result.current.labels).toEqual({});
+    expect(result.current.getLabel('FLY10_TIME')).toBe('FLY10_TIME');
+  });
+
+  it('reflects custom labels from the upstream hook', () => {
+    mockAvailableMetrics.metrics = [
+      fixture('FLY10_TIME', 'My Org Fly Time'),
+    ];
+
+    const { result } = renderHook(() => useMetricLabels());
+
+    expect(result.current.getLabel('FLY10_TIME')).toBe('My Org Fly Time');
+  });
+});

--- a/packages/web/src/hooks/__tests__/useAthleteDashboardData.test.ts
+++ b/packages/web/src/hooks/__tests__/useAthleteDashboardData.test.ts
@@ -22,6 +22,19 @@ vi.mock('@/lib/auth', () => ({
   useAuth: () => mockUseAuth(),
 }));
 
+// Mock useMetricLabels so the hook resolves labels deterministically
+const METRIC_LABELS: Record<string, string> = {
+  FLY10_TIME: '10-Yard Fly Time',
+  VERTICAL_JUMP: 'Vertical Jump',
+};
+vi.mock('../use-metric-labels', () => ({
+  useMetricLabels: () => ({
+    labels: METRIC_LABELS,
+    getLabel: (code: string) => METRIC_LABELS[code] ?? code,
+    isLoading: false,
+  }),
+}));
+
 // Mock the utility functions
 vi.mock('@/utils/athlete-dashboard-utils', () => ({
   calculateMonthlyMeasurementCount: vi.fn(() => 5),

--- a/packages/web/src/hooks/use-metric-labels.ts
+++ b/packages/web/src/hooks/use-metric-labels.ts
@@ -8,6 +8,16 @@ export interface UseMetricLabelsResult {
 }
 
 /**
+ * Underscore-split fallback used when no real label is known. Lives at the
+ * module top so it has a stable identity and can be shared with consumers
+ * who want the same "code → readable string" shape without depending on the
+ * hook (e.g. non-React utilities).
+ */
+export function splitMetricCode(code: string): string {
+  return code.replace(/_/g, ' ');
+}
+
+/**
  * Resolves metric codes to human-readable labels for display in the UI.
  *
  * Backed by `useAvailableMetrics`, which already merges:
@@ -16,19 +26,18 @@ export interface UseMetricLabelsResult {
  *   - Fallback active site metrics for users with no org context
  *
  * Unknown codes (archived/deleted/migrated-away metrics referenced by old
- * measurements) fall back to returning the code itself — a clearer signal
- * than an empty string and consistent with patterns already in the codebase.
+ * measurements, OR codes seen while the upstream query is still loading)
+ * fall back to an underscore-split form (`FLY10_TIME` → `"FLY10 TIME"`).
+ * That gives users readable prose even in the worst case and keeps render
+ * output consistent across surfaces — every label-rendering site now reads
+ * the same way for the same unknown code.
  *
  * **About `isLoading`:** while the upstream `useAvailableMetrics` query is
- * in flight, `labels` is `{}` and `getLabel(code)` returns the code itself.
- * Consumers that render label-bearing content during the initial fetch will
- * see a brief code flash on first paint before the cache warms. Most
- * surfaces in the app are gated by a parent query's loading state (a
- * skeleton or empty state hides the row), so the flash is invisible in
- * practice. If you build a new high-visibility surface where the flash
- * would be jarring, check `isLoading` and render a skeleton until it's
- * `false`. Do *not* render the label fallback (`code`) to users when
- * `isLoading === true` — that's the bug this hook exists to prevent.
+ * in flight, `labels` is `{}` and `getLabel(code)` falls back to the
+ * underscore-split form. That's intentional: it's a strictly nicer first-
+ * paint than the raw underscored code, so most surfaces don't need to gate
+ * render on `isLoading`. The flag is still exposed for surfaces that want
+ * to render a skeleton until labels resolve.
  */
 export function useMetricLabels(): UseMetricLabelsResult {
   const { metrics, isLoading } = useAvailableMetrics();
@@ -39,7 +48,7 @@ export function useMetricLabels(): UseMetricLabelsResult {
   );
 
   const getLabel = useCallback(
-    (code: string) => labels[code] ?? code,
+    (code: string) => labels[code] ?? splitMetricCode(code),
     [labels],
   );
 

--- a/packages/web/src/hooks/use-metric-labels.ts
+++ b/packages/web/src/hooks/use-metric-labels.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useAvailableMetrics } from './use-available-metrics';
 
 export interface UseMetricLabelsResult {
@@ -27,8 +27,8 @@ export function useMetricLabels(): UseMetricLabelsResult {
     [metrics],
   );
 
-  const getLabel = useMemo(
-    () => (code: string) => labels[code] ?? code,
+  const getLabel = useCallback(
+    (code: string) => labels[code] ?? code,
     [labels],
   );
 

--- a/packages/web/src/hooks/use-metric-labels.ts
+++ b/packages/web/src/hooks/use-metric-labels.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useAvailableMetrics } from './use-available-metrics';
+
+export interface UseMetricLabelsResult {
+  labels: Record<string, string>;
+  getLabel: (code: string) => string;
+  isLoading: boolean;
+}
+
+/**
+ * Resolves metric codes to human-readable labels for display in the UI.
+ *
+ * Backed by `useAvailableMetrics`, which already merges:
+ *   - Org-enabled site metrics (with `customLabel` override per org)
+ *   - Active custom org metrics
+ *   - Fallback active site metrics for users with no org context
+ *
+ * Unknown codes (archived/deleted/migrated-away metrics referenced by old
+ * measurements) fall back to returning the code itself — a clearer signal
+ * than an empty string and consistent with patterns already in the codebase.
+ */
+export function useMetricLabels(): UseMetricLabelsResult {
+  const { metrics, isLoading } = useAvailableMetrics();
+
+  const labels = useMemo(
+    () => Object.fromEntries(metrics.map((m) => [m.code, m.label])),
+    [metrics],
+  );
+
+  const getLabel = useMemo(
+    () => (code: string) => labels[code] ?? code,
+    [labels],
+  );
+
+  return { labels, getLabel, isLoading };
+}

--- a/packages/web/src/hooks/use-metric-labels.ts
+++ b/packages/web/src/hooks/use-metric-labels.ts
@@ -18,6 +18,17 @@ export interface UseMetricLabelsResult {
  * Unknown codes (archived/deleted/migrated-away metrics referenced by old
  * measurements) fall back to returning the code itself — a clearer signal
  * than an empty string and consistent with patterns already in the codebase.
+ *
+ * **About `isLoading`:** while the upstream `useAvailableMetrics` query is
+ * in flight, `labels` is `{}` and `getLabel(code)` returns the code itself.
+ * Consumers that render label-bearing content during the initial fetch will
+ * see a brief code flash on first paint before the cache warms. Most
+ * surfaces in the app are gated by a parent query's loading state (a
+ * skeleton or empty state hides the row), so the flash is invisible in
+ * practice. If you build a new high-visibility surface where the flash
+ * would be jarring, check `isLoading` and render a skeleton until it's
+ * `false`. Do *not* render the label fallback (`code`) to users when
+ * `isLoading === true` — that's the bug this hook exists to prevent.
  */
 export function useMetricLabels(): UseMetricLabelsResult {
   const { metrics, isLoading } = useAvailableMetrics();

--- a/packages/web/src/hooks/useAnalyticsOperations.ts
+++ b/packages/web/src/hooks/useAnalyticsOperations.ts
@@ -9,6 +9,7 @@ import { useAuth } from '@/lib/auth';
 import { useAnalyticsContext, useAnalyticsActions } from '@/contexts/AnalyticsContext';
 import { getRecommendedChartType } from '@/components/charts/ChartContainer';
 import { devLog } from '@/utils/dev-logger';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import type {
   AnalyticsRequest,
   AnalyticsResponse,
@@ -318,6 +319,10 @@ export function useChartConfiguration() {
  */
 export function useAnalyticsExport() {
   const { state } = useAnalyticsContext();
+  // Org-aware metric labels — passed into the CSV exporter so the file
+  // contains "10-Yard Fly Time" not "FLY10_TIME", and custom org metrics +
+  // per-org label overrides flow through.
+  const { labels: metricLabels } = useMetricLabels();
 
   const handleExport = useCallback(async (
     format: 'csv' | 'png' | 'clipboard' | 'share',
@@ -343,8 +348,12 @@ export function useAnalyticsExport() {
       format === 'share' ? 'png' : format
     );
 
-    // Generate title for sharing using display label from METRIC_CONFIG
-    const primaryLabel = METRIC_CONFIG[state.metrics.primary as keyof typeof METRIC_CONFIG]?.label || state.metrics.primary;
+    // Generate title for sharing using the org-aware label, falling back to
+    // METRIC_CONFIG for any code not in availableMetrics.
+    const primaryLabel =
+      metricLabels[state.metrics.primary] ||
+      METRIC_CONFIG[state.metrics.primary as keyof typeof METRIC_CONFIG]?.label ||
+      state.metrics.primary;
     const chartTitle = `${primaryLabel} Performance Chart`;
 
     switch (format) {
@@ -352,7 +361,8 @@ export function useAnalyticsExport() {
         exportAnalyticsDataAsCSV(
           state.analyticsData,
           state.selectedChartType,
-          state.metrics
+          state.metrics,
+          metricLabels
         );
         devLog.log('CSV export completed:', { filename });
         break;
@@ -391,7 +401,7 @@ export function useAnalyticsExport() {
         throw new Error(`Unhandled export format: ${_exhaustiveCheck}`);
       }
     }
-  }, [state.analyticsData, state.selectedChartType, state.metrics]);
+  }, [state.analyticsData, state.selectedChartType, state.metrics, metricLabels]);
 
   return {
     handleExport,

--- a/packages/web/src/hooks/useAnalyticsOperations.ts
+++ b/packages/web/src/hooks/useAnalyticsOperations.ts
@@ -349,10 +349,12 @@ export function useAnalyticsExport() {
     );
 
     // Generate title for sharing using the org-aware label, falling back to
-    // METRIC_CONFIG for any code not in availableMetrics.
+    // METRIC_CONFIG for any code not in availableMetrics. `??` (not `||`) so
+    // a legitimately-empty label string isn't silently bypassed — matches the
+    // resolution operator used everywhere else in this PR.
     const primaryLabel =
-      metricLabels[state.metrics.primary] ||
-      METRIC_CONFIG[state.metrics.primary as keyof typeof METRIC_CONFIG]?.label ||
+      metricLabels[state.metrics.primary] ??
+      METRIC_CONFIG[state.metrics.primary as keyof typeof METRIC_CONFIG]?.label ??
       state.metrics.primary;
     const chartTitle = `${primaryLabel} Performance Chart`;
 

--- a/packages/web/src/hooks/useAthleteDashboardData.ts
+++ b/packages/web/src/hooks/useAthleteDashboardData.ts
@@ -20,7 +20,8 @@ import {
   calculatePersonalRecords,
   generateActivityTimeline,
 } from '@/utils/athlete-dashboard-utils';
-import { getMetricDisplayName, LOWER_IS_BETTER_METRICS } from '@/lib/metrics';
+import { LOWER_IS_BETTER_METRICS } from '@/lib/metrics';
+import { useMetricLabels } from './use-metric-labels';
 import type { Measurement } from '@shared/schema';
 
 export interface PersonalRecord {
@@ -95,6 +96,9 @@ export function useAthleteDashboardData(
   // For athlete's own view, include unverified self-entered measurements
   const measurementsQuery = useAthleteMeasurements(athleteId, { enabled, includeUnverified });
 
+  // Resolve metric codes to user-facing labels
+  const { getLabel, labels: metricLabels } = useMetricLabels();
+
   // Calculate dashboard data from measurements
   // Group measurements by metric inline to avoid duplicate API calls
   const dashboardData = useMemo((): DashboardData | null => {
@@ -127,10 +131,10 @@ export function useAthleteDashboardData(
     const lastMeasurementDate = getLastMeasurementDate(measurements);
 
     // Calculate personal records
-    const personalRecords = calculatePersonalRecords(measurements);
+    const personalRecords = calculatePersonalRecords(measurements, metricLabels);
 
     // Generate activity timeline
-    const activityTimeline = generateActivityTimeline(measurements);
+    const activityTimeline = generateActivityTimeline(measurements, metricLabels);
 
     // Calculate metric progress for each metric
     const metricProgress: MetricProgress[] = availableMetrics.map((metric) => {
@@ -155,7 +159,7 @@ export function useAthleteDashboardData(
 
       return {
         metric,
-        displayName: getMetricDisplayName(metric),
+        displayName: getLabel(metric),
         measurements: sortedMeasurements,
         currentValue,
         trend,
@@ -173,7 +177,7 @@ export function useAthleteDashboardData(
       measurements,
       availableMetrics,
     };
-  }, [measurementsQuery.data, athleteQuery.data]);
+  }, [measurementsQuery.data, athleteQuery.data, getLabel, metricLabels]);
 
   return {
     data: dashboardData,

--- a/packages/web/src/pages/analytics.tsx
+++ b/packages/web/src/pages/analytics.tsx
@@ -19,9 +19,10 @@ import { useToast } from "@/hooks/use-toast";
 import DistributionChart from "@/components/charts/distribution-chart";
 import ScatterChart from "@/components/charts/scatter-chart";
 import { StatisticsSummaryCard } from "@/components/analytics/StatisticsSummaryCard";
-import { getMetricDisplayName, getMetricUnits, getMetricColor } from "@/lib/metrics";
+import { getMetricUnits, getMetricColor } from "@/lib/metrics";
 import { Gender, SoccerPosition, type Team, type Measurement } from "@shared/schema";
 import { useContextualLabels } from "@/hooks/useContextualLabels";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 
 // Edit measurement form schema
 const editMeasurementSchema = z.object({
@@ -40,6 +41,7 @@ const editMeasurementSchema = z.object({
 
 export default function Analytics() {
   const labels = useContextualLabels();
+  const { getLabel: getMetricLabel } = useMetricLabels();
   const [, setLocation] = useLocation();
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -772,7 +774,7 @@ export default function Analytics() {
                         <span className={`px-2 py-1 rounded-full text-xs font-medium ${
                           getMetricColor(measurement.metric)
                         }`}>
-                          {getMetricDisplayName(measurement.metric)}
+                          {getMetricLabel(measurement.metric)}
                         </span>
                       </td>
                       <td className="px-4 py-3 font-mono text-gray-900">

--- a/packages/web/src/pages/athlete-profile.tsx
+++ b/packages/web/src/pages/athlete-profile.tsx
@@ -33,7 +33,8 @@ import {
   calculatePersonalRecords,
   generateActivityTimeline,
 } from "@/utils/athlete-dashboard-utils";
-import { getMetricDisplayName, getMetricUnits } from "@/lib/metrics";
+import { getMetricUnits } from "@/lib/metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 
 // Edit measurement form schema
 const editMeasurementSchema = z.object({
@@ -56,6 +57,7 @@ export default function AthleteProfile() {
   const { user, organizationContext } = useAuth();
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const { getLabel } = useMetricLabels();
 
   const [showEditModal, setShowEditModal] = useState(false);
   const [showAddMeasurementModal, setShowAddMeasurementModal] = useState(false);
@@ -439,7 +441,7 @@ export default function AthleteProfile() {
               <MetricProgressCard
                 key={metric}
                 metric={metric}
-                displayName={getMetricDisplayName(metric)}
+                displayName={getLabel(metric)}
                 measurements={measurementsByMetric[metric]}
                 units={getMetricUnits(metric)}
                 personalRecord={personalRecords.find(pr => pr.metric === metric)}
@@ -576,7 +578,7 @@ export default function AthleteProfile() {
                       </td>
                       <td className="py-3 px-4 text-sm">
                         <Badge variant={getMetricBadgeVariant(measurement.metric)}>
-                          {getMetricDisplayName(measurement.metric)}
+                          {getLabel(measurement.metric)}
                         </Badge>
                       </td>
                       <td className="py-3 px-4 text-sm font-mono text-gray-900">

--- a/packages/web/src/pages/dashboard.tsx
+++ b/packages/web/src/pages/dashboard.tsx
@@ -4,9 +4,10 @@ import { useLocation } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
 import { Users, UsersRound, Clock, ArrowUp, Activity } from "lucide-react";
 import { formatFly10TimeWithSpeed } from "@/lib/speed-utils";
-import { getMetricDisplayName, getMetricColor, getMetricIcon, formatMetricValue, getMetricUnits } from "@/lib/metrics";
+import { getMetricColor, getMetricIcon, formatMetricValue, getMetricUnits } from "@/lib/metrics";
 import { useAuth } from "@/lib/auth";
 import { useAvailableMetrics } from "@/hooks/use-available-metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 import { useAthleteDashboardData } from "@/hooks/useAthleteDashboardData";
 import { MetricProgressCard } from "@/components/athlete/MetricProgressCard";
 import { useDashboardTrends } from "@/hooks/use-dashboard-trends";
@@ -83,6 +84,7 @@ export default function Dashboard() {
 
   // Get available metrics for the organization
   const { metrics: availableMetrics, isLoading: metricsLoading } = useAvailableMetrics();
+  const { getLabel: getMetricLabel } = useMetricLabels();
 
   // Use role from user session data
   const userRole = user?.role || 'athlete';
@@ -552,7 +554,7 @@ export default function Dashboard() {
             <MetricProgressCard
               key={metric}
               metric={metric}
-              displayName={getMetricDisplayName(metric)}
+              displayName={getMetricLabel(metric)}
               measurements={athleteMeasurementsByMetric[metric] || []}
               units={getMetricUnits(metric)}
               personalRecord={athleteDashboardData.personalRecords.find(pr => pr.metric === metric)}
@@ -580,7 +582,7 @@ export default function Dashboard() {
 
       {/* Recent Activity - Only show when org is selected */}
       {effectiveOrganizationId && (
-      <Card className="bg-white">
+      <Card className="bg-white" data-testid="recent-measurements-card">
         <CardContent className="p-6">
           <div className="flex items-center justify-between mb-6">
             <div>
@@ -617,7 +619,7 @@ export default function Dashboard() {
                 athleteId: m.user?.id || '',
                 athleteName: `${m.user?.firstName || ''} ${m.user?.lastName || ''}`.trim() || 'Unknown',
                 metricType: m.metricType || '',
-                metricName: m.metricType ? getMetricDisplayName(m.metricType) : 'Unknown',
+                metricName: m.metricType ? getMetricLabel(m.metricType) : 'Unknown',
                 value: parseFloat(m.value) || 0,
                 date: m.date,
                 notes: m.notes,
@@ -666,7 +668,7 @@ export default function Dashboard() {
                     </td>
                     <td className="py-3">
                       <span className={`px-2 py-1 rounded-full text-xs ${getMetricColor(measurement.metric)}`}>
-                        {getMetricDisplayName(measurement.metric)}
+                        {getMetricLabel(measurement.metric)}
                       </span>
                     </td>
                     <td className="py-3 font-mono">

--- a/packages/web/src/pages/data-entry.tsx
+++ b/packages/web/src/pages/data-entry.tsx
@@ -24,6 +24,7 @@ import { useMediaQuery } from '@/hooks/use-media-query';
 import { useBatchMeasurementForm } from '@/components/batch-measurement-entry/use-batch-measurement-form';
 import { useAuth } from '@/lib/auth';
 import { useToast } from '@/hooks/use-toast';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import { RESPONSIVE_BREAKPOINTS } from '@shared/constants';
 import type { UserOrganization } from '@shared/schema';
 
@@ -37,6 +38,7 @@ const ImportBatchHistory = lazy(() => import('@/components/device-import').then(
 export default function DataEntry() {
   const { toast } = useToast();
   const { user } = useAuth();
+  const { getLabel } = useMetricLabels();
   const canDeviceImport = user?.isSiteAdmin || user?.role === 'org_admin' || user?.role === 'coach';
   const isMobile = useMediaQuery(`(max-width: ${RESPONSIVE_BREAKPOINTS.MOBILE_BREAKPOINT - 1}px)`);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
@@ -393,7 +395,7 @@ export default function DataEntry() {
                       <p className="font-medium text-gray-900">{measurement.user.fullName}</p>
                       <div className="flex items-center space-x-4 text-sm text-gray-600">
                         <span>
-                          {measurement.metric === "FLY10_TIME" ? "Fly-10" : "Vertical"}: {measurement.value}{measurement.units}
+                          {getLabel(measurement.metric)}: {measurement.value}{measurement.units}
                         </span>
                         <span>•</span>
                         <span>{measurement.date}</span>

--- a/packages/web/src/pages/publish.tsx
+++ b/packages/web/src/pages/publish.tsx
@@ -14,12 +14,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Download, RotateCcw, Trash2, AlertTriangle, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
-import { getMetricDisplayName, getMetricUnits, getMetricColor } from "@/lib/metrics";
+import { getMetricUnits, getMetricColor } from "@/lib/metrics";
 import { Gender } from "@shared/schema";
 import { DATE_CONSTANTS } from "@shared/constants";
 import jsPDF from "jspdf";
 import { useToast } from "@/hooks/use-toast";
 import { useAvailableMetrics } from "@/hooks/use-available-metrics";
+import { useMetricLabels } from "@/hooks/use-metric-labels";
 import { StatisticsSummaryCard, type DistributionMode } from "@/components/analytics/StatisticsSummaryCard";
 import { useContextualLabels } from "@/hooks/useContextualLabels";
 
@@ -27,6 +28,7 @@ export default function Publish() {
   const labels = useContextualLabels();
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const { getLabel: getMetricLabel } = useMetricLabels();
 
   // Get available metrics using centralized hook (filters by active+enabled)
   const { metrics: availableMetrics } = useAvailableMetrics();
@@ -379,7 +381,7 @@ export default function Publish() {
 
     // Title
     pdf.setFontSize(16);
-    pdf.text(`${getMetricDisplayName(filters.metric)} Results`, pageWidth / 2, 20, { align: "center" });
+    pdf.text(`${getMetricLabel(filters.metric)} Results`, pageWidth / 2, 20, { align: "center" });
 
     // Date and filters info
     pdf.setFontSize(10);
@@ -434,7 +436,7 @@ export default function Publish() {
 
     // Save the PDF
     const dateStr = filters.dateFrom ? filters.dateFrom : new Date().toISOString().split('T')[0];
-    const fileName = `${getMetricDisplayName(filters.metric)}_Results_${dateStr}.pdf`;
+    const fileName = `${getMetricLabel(filters.metric)}_Results_${dateStr}.pdf`;
     pdf.save(fileName);
   };
 
@@ -706,7 +708,7 @@ export default function Publish() {
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3">
               <h3 className="text-lg font-semibold text-gray-900">
-                Results {filters.metric ? `- ${getMetricDisplayName(filters.metric)}` : ""}
+                Results {filters.metric ? `- ${getMetricLabel(filters.metric)}` : ""}
               </h3>
               {filters.metric && (
                 <Select
@@ -939,7 +941,7 @@ export default function Publish() {
                             {measurement.value}{getMetricUnits(filters.metric)}
                           </span>
                           <span className={`px-2 py-1 rounded-full text-xs font-medium ${getMetricColor(filters.metric)}`}>
-                            {getMetricDisplayName(filters.metric)}
+                            {getMetricLabel(filters.metric)}
                           </span>
                         </div>
                       </td>

--- a/packages/web/src/pages/publish.tsx
+++ b/packages/web/src/pages/publish.tsx
@@ -434,9 +434,12 @@ export default function Publish() {
       yPos += 12;
     });
 
-    // Save the PDF
+    // Save the PDF. Sanitize the label before using it in the filename:
+    // custom org metric labels can contain `/`, `:`, `*`, `?`, `|`, `\`, `<`,
+    // `>`, `"` which are invalid filename characters on Windows/macOS.
     const dateStr = filters.dateFrom ? filters.dateFrom : new Date().toISOString().split('T')[0];
-    const fileName = `${getMetricLabel(filters.metric)}_Results_${dateStr}.pdf`;
+    const safeLabel = getMetricLabel(filters.metric).replace(/[/\\:*?"<>|]/g, '-');
+    const fileName = `${safeLabel}_Results_${dateStr}.pdf`;
     pdf.save(fileName);
   };
 

--- a/packages/web/src/pages/unified-dashboard.tsx
+++ b/packages/web/src/pages/unified-dashboard.tsx
@@ -14,7 +14,8 @@ import { Badge } from '@/components/ui/badge';
 import { OrgBadge, MultiOrgBadge } from '@/components/athlete/OrgBadge';
 import { Loader2, AlertCircle, Link2, Building2, BarChart3, Shield, ArrowRight } from 'lucide-react';
 import { Redirect, Link } from 'wouter';
-import { getMetricDisplayName, getMetricUnits } from '@/lib/metrics';
+import { getMetricUnits } from '@/lib/metrics';
+import { useMetricLabels } from '@/hooks/use-metric-labels';
 import { formatDistanceToNow } from 'date-fns';
 
 export default function UnifiedDashboardPage() {
@@ -22,6 +23,7 @@ export default function UnifiedDashboardPage() {
   const { data: profile, isLoading: profileLoading, error: profileError } = useGlobalAthleteProfile();
   const { data: dashboard, isLoading: dashboardLoading } = useUnifiedDashboard();
   const { data: measurements, isLoading: measurementsLoading } = useUnifiedMeasurements();
+  const { getLabel: getMetricLabel } = useMetricLabels();
 
   // Redirect if not logged in
   if (!authLoading && !user) {
@@ -187,7 +189,7 @@ export default function UnifiedDashboardPage() {
                   className="p-4 rounded-lg border bg-card text-card-foreground"
                 >
                   <div className="text-sm font-medium text-muted-foreground mb-1">
-                    {getMetricDisplayName(metric)}
+                    {getMetricLabel(metric)}
                   </div>
                   <div className="text-xl font-bold">
                     {stats.latest?.value || 'N/A'}
@@ -228,7 +230,7 @@ export default function UnifiedDashboardPage() {
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
                       <span className="font-medium">
-                        {getMetricDisplayName(m.metric)}
+                        {getMetricLabel(m.metric)}
                       </span>
                       {m.organizationName && (
                         <OrgBadge organizationName={m.organizationName} />

--- a/packages/web/src/utils/__tests__/athlete-dashboard-utils.test.ts
+++ b/packages/web/src/utils/__tests__/athlete-dashboard-utils.test.ts
@@ -43,12 +43,14 @@ describe('athlete-dashboard-utils — metricLabels parameter', () => {
       expect(prs[0].displayName).toBe('10-Yard Fly Time');
     });
 
-    it('falls back to the raw code when neither labels nor built-in map know it', () => {
+    it('underscore-splits unknown codes when neither labels nor built-in map know them', () => {
+      // Matches the same last-resort fallback shape used in
+      // resolveTimelineLabel for consistency across surfaces.
       const measurements = [m('CUSTOM_DEADLIFT_1RM', 200, '2024-01-01')];
 
       const prs = calculatePersonalRecords(measurements);
 
-      expect(prs[0].displayName).toBe('CUSTOM_DEADLIFT_1RM');
+      expect(prs[0].displayName).toBe('CUSTOM DEADLIFT 1RM');
     });
 
     it('resolves custom org codes via the supplied labels map', () => {

--- a/packages/web/src/utils/__tests__/athlete-dashboard-utils.test.ts
+++ b/packages/web/src/utils/__tests__/athlete-dashboard-utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculatePersonalRecords,
+  generateActivityTimeline,
+} from '../athlete-dashboard-utils';
+
+function m(metric: string, value: number, date: string) {
+  return {
+    id: `${metric}-${date}`,
+    metric,
+    value,
+    units: 's',
+    date,
+    age: 16,
+  };
+}
+
+describe('athlete-dashboard-utils — metricLabels parameter', () => {
+  describe('calculatePersonalRecords', () => {
+    it('prefers labels from the supplied map over the built-in fallback', () => {
+      const labels = { FLY10_TIME: 'Custom Org Fly Label' };
+      const measurements = [m('FLY10_TIME', 1.5, '2024-01-01')];
+
+      const prs = calculatePersonalRecords(measurements, labels);
+
+      expect(prs[0].displayName).toBe('Custom Org Fly Label');
+    });
+
+    it('falls back to the built-in name map when no labels argument is supplied', () => {
+      const measurements = [m('FLY10_TIME', 1.5, '2024-01-01')];
+
+      const prs = calculatePersonalRecords(measurements);
+
+      expect(prs[0].displayName).toBe('10-Yard Fly Time');
+    });
+
+    it('falls back to the built-in name map when the code is missing from supplied labels', () => {
+      const labels = { VERTICAL_JUMP: 'High Hops' };
+      const measurements = [m('FLY10_TIME', 1.5, '2024-01-01')];
+
+      const prs = calculatePersonalRecords(measurements, labels);
+
+      expect(prs[0].displayName).toBe('10-Yard Fly Time');
+    });
+
+    it('falls back to the raw code when neither labels nor built-in map know it', () => {
+      const measurements = [m('CUSTOM_DEADLIFT_1RM', 200, '2024-01-01')];
+
+      const prs = calculatePersonalRecords(measurements);
+
+      expect(prs[0].displayName).toBe('CUSTOM_DEADLIFT_1RM');
+    });
+
+    it('resolves custom org codes via the supplied labels map', () => {
+      const labels = { CUSTOM_DEADLIFT_1RM: 'Deadlift 1RM' };
+      const measurements = [m('CUSTOM_DEADLIFT_1RM', 200, '2024-01-01')];
+
+      const prs = calculatePersonalRecords(measurements, labels);
+
+      expect(prs[0].displayName).toBe('Deadlift 1RM');
+    });
+  });
+
+  describe('generateActivityTimeline', () => {
+    it('prefers labels from the supplied map', () => {
+      const labels = { VERTICAL_JUMP: 'Custom Jump' };
+      const measurements = [m('VERTICAL_JUMP', 30, '2024-01-15')];
+
+      const timeline = generateActivityTimeline(measurements, labels);
+
+      expect(timeline[0].displayName).toBe('Custom Jump');
+    });
+
+    it('falls back to the built-in name map when the labels argument is omitted', () => {
+      const measurements = [m('VERTICAL_JUMP', 30, '2024-01-15')];
+
+      const timeline = generateActivityTimeline(measurements);
+
+      expect(timeline[0].displayName).toBe('Vertical Jump');
+    });
+  });
+});

--- a/packages/web/src/utils/__tests__/measurement-export.test.ts
+++ b/packages/web/src/utils/__tests__/measurement-export.test.ts
@@ -77,7 +77,7 @@ describe('measurementsToCSVString', () => {
     expect(csv).not.toContain('VERTICAL_JUMP');
   });
 
-  it('should fall back to raw metric code when metricLabels is omitted', () => {
+  it('underscore-splits the metric code when metricLabels is omitted', () => {
     const measurements: Partial<Measurement>[] = [
       {
         id: '1',
@@ -94,11 +94,13 @@ describe('measurementsToCSVString', () => {
 
     const csv = measurementsToCSVString(measurements as Measurement[]);
 
-    // No metricLabels argument: falls back to the metric code
-    expect(csv).toContain('FLY10_TIME');
+    // No metricLabels argument: falls back to underscore-split prose so a
+    // CSV without a labels map still reads as text, not raw underscored codes.
+    expect(csv).toContain('FLY10 TIME');
+    expect(csv).not.toContain('FLY10_TIME');
   });
 
-  it('should fall back to raw metric code when label for code is missing', () => {
+  it('underscore-splits unknown codes when not in the supplied labels map', () => {
     const measurements: Partial<Measurement>[] = [
       {
         id: '1',
@@ -116,7 +118,8 @@ describe('measurementsToCSVString', () => {
     // metricLabels provided but missing the specific code
     const csv = measurementsToCSVString(measurements as Measurement[], { FLY10_TIME: '10-Yard Fly Time' });
 
-    expect(csv).toContain('UNKNOWN_METRIC');
+    expect(csv).toContain('UNKNOWN METRIC');
+    expect(csv).not.toContain('UNKNOWN_METRIC');
   });
 
   it('should show "Verified" or "Unverified" for status', () => {

--- a/packages/web/src/utils/__tests__/measurement-export.test.ts
+++ b/packages/web/src/utils/__tests__/measurement-export.test.ts
@@ -37,9 +37,7 @@ describe('measurementsToCSVString', () => {
     expect(lines[1]).toContain('2024-01-15');
   });
 
-  it('should use metric codes (database labels injected by caller in production)', () => {
-    // NOTE: getMetricDisplayName now returns metric codes directly.
-    // In production, labels come from useMetricConfig hook via database.
+  it('should resolve metric codes to labels when metricLabels is provided', () => {
     const measurements: Partial<Measurement>[] = [
       {
         id: '1',
@@ -65,11 +63,60 @@ describe('measurementsToCSVString', () => {
       }
     ];
 
+    const metricLabels = {
+      FLY10_TIME: '10-Yard Fly Time',
+      VERTICAL_JUMP: 'Vertical Jump',
+    };
+
+    const csv = measurementsToCSVString(measurements as Measurement[], metricLabels);
+
+    // Labels replace raw codes when provided
+    expect(csv).toContain('10-Yard Fly Time');
+    expect(csv).toContain('Vertical Jump');
+    expect(csv).not.toContain('FLY10_TIME');
+    expect(csv).not.toContain('VERTICAL_JUMP');
+  });
+
+  it('should fall back to raw metric code when metricLabels is omitted', () => {
+    const measurements: Partial<Measurement>[] = [
+      {
+        id: '1',
+        date: '2024-01-15',
+        metric: 'FLY10_TIME',
+        value: '1.500',
+        units: 's',
+        isVerified: true,
+        season: null,
+        teamNameSnapshot: null,
+        notes: null,
+      },
+    ];
+
     const csv = measurementsToCSVString(measurements as Measurement[]);
 
-    // Now returns metric codes (fallback behavior)
+    // No metricLabels argument: falls back to the metric code
     expect(csv).toContain('FLY10_TIME');
-    expect(csv).toContain('VERTICAL_JUMP');
+  });
+
+  it('should fall back to raw metric code when label for code is missing', () => {
+    const measurements: Partial<Measurement>[] = [
+      {
+        id: '1',
+        date: '2024-01-15',
+        metric: 'UNKNOWN_METRIC',
+        value: '1.500',
+        units: 's',
+        isVerified: true,
+        season: null,
+        teamNameSnapshot: null,
+        notes: null,
+      },
+    ];
+
+    // metricLabels provided but missing the specific code
+    const csv = measurementsToCSVString(measurements as Measurement[], { FLY10_TIME: '10-Yard Fly Time' });
+
+    expect(csv).toContain('UNKNOWN_METRIC');
   });
 
   it('should show "Verified" or "Unverified" for status', () => {
@@ -188,9 +235,7 @@ describe('measurementsToCSVString', () => {
     expect(csv).toContain('Varsity Football');
   });
 
-  it('should handle all metric types (outputs metric codes)', () => {
-    // NOTE: getMetricDisplayName now returns metric codes directly.
-    // In production, labels come from useMetricConfig hook via database.
+  it('should resolve all metric types when metricLabels covers them', () => {
     const metricTypes = [
       'FLY10_TIME',
       'VERTICAL_JUMP',
@@ -201,6 +246,17 @@ describe('measurementsToCSVString', () => {
       'TOP_SPEED',
       'RSI',
     ];
+
+    const metricLabels: Record<string, string> = {
+      FLY10_TIME: '10-Yard Fly Time',
+      VERTICAL_JUMP: 'Vertical Jump',
+      AGILITY_505: '5-0-5 Agility',
+      AGILITY_5105: '5-10-5 Agility',
+      T_TEST: 'T-Test',
+      DASH_40YD: '40-Yard Dash',
+      TOP_SPEED: 'Top Speed',
+      RSI: 'Reactive Strength Index',
+    };
 
     const measurements: Partial<Measurement>[] = metricTypes.map((metric, i) => ({
       id: `${i}`,
@@ -214,17 +270,16 @@ describe('measurementsToCSVString', () => {
       notes: null,
     }));
 
-    const csv = measurementsToCSVString(measurements as Measurement[]);
+    const csv = measurementsToCSVString(measurements as Measurement[], metricLabels);
 
-    // Now outputs metric codes (fallback behavior - labels come from database in production)
-    expect(csv).toContain('FLY10_TIME');
-    expect(csv).toContain('VERTICAL_JUMP');
-    expect(csv).toContain('AGILITY_505');
-    expect(csv).toContain('AGILITY_5105');
-    expect(csv).toContain('T_TEST');
-    expect(csv).toContain('DASH_40YD');
-    expect(csv).toContain('TOP_SPEED');
-    expect(csv).toContain('RSI');
+    expect(csv).toContain('10-Yard Fly Time');
+    expect(csv).toContain('Vertical Jump');
+    expect(csv).toContain('5-0-5 Agility');
+    expect(csv).toContain('5-10-5 Agility');
+    expect(csv).toContain('T-Test');
+    expect(csv).toContain('40-Yard Dash');
+    expect(csv).toContain('Top Speed');
+    expect(csv).toContain('Reactive Strength Index');
   });
 });
 

--- a/packages/web/src/utils/athlete-dashboard-utils.ts
+++ b/packages/web/src/utils/athlete-dashboard-utils.ts
@@ -43,9 +43,16 @@ export function getLastMeasurementDate(measurements: Measurement[]): Date | null
 }
 
 /**
- * Calculate personal records for all metrics
+ * Calculate personal records for all metrics.
+ *
+ * Pass `metricLabels` (from `useMetricLabels().labels`) to surface custom org
+ * metrics and per-org label overrides. Falls back to a built-in name map for
+ * unmigrated callers, then to the raw code.
  */
-export function calculatePersonalRecords(measurements: Measurement[]) {
+export function calculatePersonalRecords(
+  measurements: Measurement[],
+  metricLabels?: Record<string, string>,
+) {
   const metricGroups: Record<string, Measurement[]> = {};
 
   // Group measurements by metric
@@ -101,7 +108,7 @@ export function calculatePersonalRecords(measurements: Measurement[]) {
 
     personalRecords.push({
       metric,
-      displayName: getMetricDisplayName(metric),
+      displayName: metricLabels?.[metric] ?? getMetricDisplayName(metric),
       value: bestValue,
       units: bestMeasurement.units,
       date: bestMeasurement.date,
@@ -115,9 +122,15 @@ export function calculatePersonalRecords(measurements: Measurement[]) {
 }
 
 /**
- * Generate recent activity timeline data with insights
+ * Generate recent activity timeline data with insights.
+ *
+ * Pass `metricLabels` (from `useMetricLabels().labels`) to surface custom org
+ * metrics and per-org label overrides. Falls back as in `calculatePersonalRecords`.
  */
-export function generateActivityTimeline(measurements: Measurement[]) {
+export function generateActivityTimeline(
+  measurements: Measurement[],
+  metricLabels?: Record<string, string>,
+) {
   // Get last 5 measurements sorted by date
   const recentMeasurements = [...measurements]
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
@@ -170,7 +183,7 @@ export function generateActivityTimeline(measurements: Measurement[]) {
       id: measurement.id,
       date: measurement.date,
       metric: measurement.metric,
-      displayName: getMetricDisplayName(measurement.metric),
+      displayName: metricLabels?.[measurement.metric] ?? getMetricDisplayName(measurement.metric),
       value,
       units: measurement.units,
       insight,

--- a/packages/web/src/utils/athlete-dashboard-utils.ts
+++ b/packages/web/src/utils/athlete-dashboard-utils.ts
@@ -193,7 +193,11 @@ export function generateActivityTimeline(
 }
 
 /**
- * Get display name for a metric
+ * Last-resort metric display name when the caller didn't supply a labels map
+ * AND the code isn't one of the known built-ins. Underscore-split fallback
+ * keeps unknown codes legible (e.g. CUSTOM_DEADLIFT_1RM → "CUSTOM DEADLIFT
+ * 1RM"), matching the same fallback shape used by
+ * resolveTimelineLabel in measurements-timeline.tsx.
  */
 function getMetricDisplayName(metric: string): string {
   const displayNames: Record<string, string> = {
@@ -207,5 +211,5 @@ function getMetricDisplayName(metric: string): string {
     RSI: 'Reactive Strength Index',
   };
 
-  return displayNames[metric] || metric;
+  return displayNames[metric] ?? metric.replace(/_/g, ' ');
 }

--- a/packages/web/src/utils/measurement-export.ts
+++ b/packages/web/src/utils/measurement-export.ts
@@ -5,7 +5,6 @@
  */
 
 import type { Measurement } from '@shared/schema';
-import { getMetricDisplayName } from '@/constants/metrics';
 
 /**
  * Escape CSV field value
@@ -39,9 +38,15 @@ function escapeCSVField(value: string | null | undefined): string {
 /**
  * Convert measurements to CSV string
  * @param measurements - Array of measurements to export
+ * @param metricLabels - Optional mapping of metric codes to display names.
+ *   When provided, codes resolve to labels (e.g. "FLY10_TIME" -> "10-Yard Fly Time").
+ *   When omitted or unknown, falls back to the raw metric code.
  * @returns CSV string with headers and data rows
  */
-export function measurementsToCSVString(measurements: Measurement[]): string {
+export function measurementsToCSVString(
+  measurements: Measurement[],
+  metricLabels?: Record<string, string>
+): string {
   const headers = 'Date,Metric,Value,Units,Status,Season,Team,Notes';
 
   if (measurements.length === 0) {
@@ -49,7 +54,7 @@ export function measurementsToCSVString(measurements: Measurement[]): string {
   }
 
   const rows = measurements.map(measurement => {
-    const metricName = getMetricDisplayName(measurement.metric);
+    const metricName = metricLabels?.[measurement.metric] ?? measurement.metric;
     const status = measurement.isVerified ? 'Verified' : 'Unverified';
     const season = measurement.season || '';
     const team = measurement.teamNameSnapshot || '';
@@ -75,17 +80,21 @@ export function measurementsToCSVString(measurements: Measurement[]): string {
  * Export measurements to CSV file and trigger download
  * @param measurements - Array of measurements to export
  * @param filename - Optional filename (default: "measurements-YYYY-MM-DD.csv")
+ * @param metricLabels - Optional mapping of metric codes to display names.
+ *   When provided, codes resolve to labels (e.g. "FLY10_TIME" -> "10-Yard Fly Time").
+ *   When omitted or unknown, falls back to the raw metric code.
  */
 export function exportMeasurementsToCSV(
   measurements: Measurement[],
-  filename?: string
+  filename?: string,
+  metricLabels?: Record<string, string>
 ): void {
   // Generate default filename with current date
   const defaultFilename = `measurements-${new Date().toISOString().split('T')[0]}.csv`;
   const finalFilename = filename || defaultFilename;
 
   // Convert measurements to CSV string
-  const csvContent = measurementsToCSVString(measurements);
+  const csvContent = measurementsToCSVString(measurements, metricLabels);
 
   // Create Blob with CSV content
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });

--- a/packages/web/src/utils/measurement-export.ts
+++ b/packages/web/src/utils/measurement-export.ts
@@ -40,7 +40,9 @@ function escapeCSVField(value: string | null | undefined): string {
  * @param measurements - Array of measurements to export
  * @param metricLabels - Optional mapping of metric codes to display names.
  *   When provided, codes resolve to labels (e.g. "FLY10_TIME" -> "10-Yard Fly Time").
- *   When omitted or unknown, falls back to the raw metric code.
+ *   When omitted or unknown, falls back to the underscore-split form
+ *   (e.g. "FLY10 TIME") — matches every other fallback shape in this PR so
+ *   a CSV downloaded without a labels map still reads as prose, not raw codes.
  * @returns CSV string with headers and data rows
  */
 export function measurementsToCSVString(
@@ -54,7 +56,7 @@ export function measurementsToCSVString(
   }
 
   const rows = measurements.map(measurement => {
-    const metricName = metricLabels?.[measurement.metric] ?? measurement.metric;
+    const metricName = metricLabels?.[measurement.metric] ?? measurement.metric.replace(/_/g, ' ');
     const status = measurement.isVerified ? 'Verified' : 'Unverified';
     const season = measurement.season || '';
     const team = measurement.teamNameSnapshot || '';

--- a/tests/e2e/dashboard-metric-labels.spec.ts
+++ b/tests/e2e/dashboard-metric-labels.spec.ts
@@ -91,14 +91,14 @@ test.describe('Dashboard metric label display', () => {
   test('org admin: labels render, codes do not leak', async ({ page }) => {
     await loginAs(page, 'org_admin');
     await page.goto(`${TESTING_URL}/dashboard`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await assertNoMetricCodesLeaked(page, 'org_admin');
   });
 
   test('coach: labels render, codes do not leak', async ({ page }) => {
     await loginAs(page, 'coach');
     await page.goto(`${TESTING_URL}/dashboard`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await assertNoMetricCodesLeaked(page, 'coach');
   });
 
@@ -108,7 +108,7 @@ test.describe('Dashboard metric label display', () => {
     // landing page rather than the org dashboard.
     await loginAs(page, 'athlete');
     await page.goto(`${TESTING_URL}/`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await assertNoMetricCodesLeaked(page, 'athlete');
   });
 });

--- a/tests/e2e/dashboard-metric-labels.spec.ts
+++ b/tests/e2e/dashboard-metric-labels.spec.ts
@@ -99,5 +99,19 @@ test.describe('Dashboard metric label display', () => {
     for (const code of METRIC_CODES) {
       expect(bodyText, `metric code "${code}" leaked into athlete view`).not.toContain(code);
     }
+
+    // Positive assertion: prove a real label or the empty-state copy is on the
+    // page. Without this, an athlete page that fails to load measurements
+    // (e.g. redirect broke, fetch errored) would satisfy the negative check
+    // trivially. We accept either a known label or the "No recent
+    // measurements" / "No measurements" copy so seeded-data variance across
+    // CI/local doesn't make the test brittle.
+    const hasEmptyState =
+      EMPTY_STATE_TEXT.test(bodyText) || /No measurements/i.test(bodyText);
+    const hasKnownLabel = KNOWN_LABELS.some((label) => bodyText.includes(label));
+    expect(
+      hasEmptyState || hasKnownLabel,
+      `Athlete view neither shows a known metric label nor an empty-state message — cannot confirm labels are wired up. Body sample: ${bodyText.slice(0, 200)}`,
+    ).toBeTruthy();
   });
 });

--- a/tests/e2e/dashboard-metric-labels.spec.ts
+++ b/tests/e2e/dashboard-metric-labels.spec.ts
@@ -10,12 +10,25 @@ import { loginAs } from './helpers/auth';
  * other surfaces; this spec locks the dashboard scenario specifically because
  * that's where the user originally reported it (org admins, coaches,
  * athletes).
+ *
+ * Test strategy:
+ *   - Negative: no METRIC_CODES strings appear anywhere on the user's first
+ *     screen. This is the regression we're locking down.
+ *   - Positive: either at least one known label, or a recognized "empty"
+ *     state (no measurements yet, no organization selected). Without this,
+ *     a dashboard that fails to render the recent-measurements card would
+ *     satisfy the negative check trivially.
+ *
+ * The page-level body scan keeps the spec robust to environment variance
+ * (test users with or without org membership, with or without seeded
+ * measurements) — the bug is "code leaked into user-visible text" and that
+ * can be asserted globally regardless of which dashboard state renders.
  */
 
 const TESTING_URL = process.env.TESTING_URL || process.env.STAGING_URL || 'http://localhost:5000';
 
 // Metric codes that should NEVER appear verbatim in user-facing display.
-// If any of these strings shows up in the dashboard DOM, the deprecated
+// If any of these strings shows up in the visible text, the deprecated
 // helper is still being called somewhere.
 const METRIC_CODES = [
   'FLY10_TIME',
@@ -29,10 +42,8 @@ const METRIC_CODES = [
 ];
 
 // At least one of these labels should appear when measurements exist.
-// Used as a positive assertion so an empty-state Recent Measurements card
-// doesn't make the "no codes leaked" check trivially pass.
 const KNOWN_LABELS = [
-  '10-Yard Fly',           // FLY10_TIME label prefix
+  '10-Yard Fly',
   'Vertical Jump',
   '5-0-5 Agility',
   '5-10-5 Agility',
@@ -42,76 +53,62 @@ const KNOWN_LABELS = [
   'Reactive Strength',
 ];
 
-const EMPTY_STATE_TEXT = /No recent measurements found/i;
+// Empty-state / non-data signals — any of these is acceptable in lieu of a
+// real label, because each indicates a page state where no measurement data
+// would render and the regression cannot apply.
+const EMPTY_STATE_PATTERNS = [
+  /No recent measurements/i,
+  /No measurements/i,
+  /Please select an organization/i,
+  /Select an organization/i,
+];
 
-async function assertDashboardShowsLabelsNotCodes(page: Page) {
-  // The card is targeted via data-testid so the assertion survives class-name
-  // refactors. innerText (not innerHTML) excludes attribute values, so the
-  // legitimate `data-testid="stat-best-fly10_time"` strings elsewhere on the
-  // page don't trigger us.
-  const card = page.getByTestId('recent-measurements-card');
-  await expect(card).toBeVisible({ timeout: 10000 });
-  const cardText = await card.innerText();
+async function assertNoMetricCodesLeaked(page: Page, scenario: string) {
+  // Wait until the dashboard heading is present so we don't snapshot the
+  // body mid-load before any dashboard content has rendered.
+  await expect(
+    page.getByRole('heading', { name: /Dashboard|My (Measurements|Dashboard|Profile)/i }).first(),
+  ).toBeVisible({ timeout: 15000 });
 
-  // Negative assertion: no raw codes anywhere in the card.
+  const bodyText = await page.locator('body').innerText();
+
   for (const code of METRIC_CODES) {
-    expect(cardText, `metric code "${code}" leaked into Recent Measurements`).not.toContain(code);
+    expect(
+      bodyText,
+      `[${scenario}] metric code "${code}" leaked into visible page text`,
+    ).not.toContain(code);
   }
 
-  // Positive assertion: at least one known label appears, OR the empty-state
-  // message is shown. Without this, a card with zero measurements would
-  // satisfy the negative check trivially and the test wouldn't actually
-  // exercise the migration.
-  const hasEmptyState = EMPTY_STATE_TEXT.test(cardText);
-  const hasKnownLabel = KNOWN_LABELS.some((label) => cardText.includes(label));
+  const hasEmptyState = EMPTY_STATE_PATTERNS.some((re) => re.test(bodyText));
+  const hasKnownLabel = KNOWN_LABELS.some((label) => bodyText.includes(label));
   expect(
     hasEmptyState || hasKnownLabel,
-    `Recent Measurements neither shows a known metric label nor the empty-state message — cannot confirm labels are wired up. Card text: ${cardText.slice(0, 200)}`,
+    `[${scenario}] page neither shows a known metric label nor a recognized empty-state — cannot confirm labels are wired up. Body sample: ${bodyText.slice(0, 200)}`,
   ).toBeTruthy();
 }
 
 test.describe('Dashboard metric label display', () => {
-  test('renders labels (not codes) in Recent Measurements for org admin', async ({ page }) => {
+  test('org admin: labels render, codes do not leak', async ({ page }) => {
     await loginAs(page, 'org_admin');
     await page.goto(`${TESTING_URL}/dashboard`);
     await page.waitForLoadState('networkidle');
-    await assertDashboardShowsLabelsNotCodes(page);
+    await assertNoMetricCodesLeaked(page, 'org_admin');
   });
 
-  test('renders labels (not codes) in Recent Measurements for coach', async ({ page }) => {
+  test('coach: labels render, codes do not leak', async ({ page }) => {
     await loginAs(page, 'coach');
     await page.goto(`${TESTING_URL}/dashboard`);
     await page.waitForLoadState('networkidle');
-    await assertDashboardShowsLabelsNotCodes(page);
+    await assertNoMetricCodesLeaked(page, 'coach');
   });
 
-  test('athletes see labels (not codes) on their own measurements view', async ({ page }) => {
+  test('athlete: labels render on their own measurements view, codes do not leak', async ({ page }) => {
     // Athletes are redirected away from /dashboard to /athletes/:id by the
-    // dashboard component itself, so we land on the athlete profile and check
-    // the measurement history surface there instead.
+    // dashboard component itself, so the assertion runs on the athlete
+    // landing page rather than the org dashboard.
     await loginAs(page, 'athlete');
     await page.goto(`${TESTING_URL}/`);
     await page.waitForLoadState('networkidle');
-
-    // The athlete redirect lands on /athletes/<self> — the measurement table
-    // there is the analog of the dashboard's Recent Measurements card.
-    const bodyText = await page.locator('body').innerText();
-    for (const code of METRIC_CODES) {
-      expect(bodyText, `metric code "${code}" leaked into athlete view`).not.toContain(code);
-    }
-
-    // Positive assertion: prove a real label or the empty-state copy is on the
-    // page. Without this, an athlete page that fails to load measurements
-    // (e.g. redirect broke, fetch errored) would satisfy the negative check
-    // trivially. We accept either a known label or the "No recent
-    // measurements" / "No measurements" copy so seeded-data variance across
-    // CI/local doesn't make the test brittle.
-    const hasEmptyState =
-      EMPTY_STATE_TEXT.test(bodyText) || /No measurements/i.test(bodyText);
-    const hasKnownLabel = KNOWN_LABELS.some((label) => bodyText.includes(label));
-    expect(
-      hasEmptyState || hasKnownLabel,
-      `Athlete view neither shows a known metric label nor an empty-state message — cannot confirm labels are wired up. Body sample: ${bodyText.slice(0, 200)}`,
-    ).toBeTruthy();
+    await assertNoMetricCodesLeaked(page, 'athlete');
   });
 });

--- a/tests/e2e/dashboard-metric-labels.spec.ts
+++ b/tests/e2e/dashboard-metric-labels.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { loginAs } from './helpers/auth';
 
 /**
@@ -28,35 +28,76 @@ const METRIC_CODES = [
   'RSI',
 ];
 
+// At least one of these labels should appear when measurements exist.
+// Used as a positive assertion so an empty-state Recent Measurements card
+// doesn't make the "no codes leaked" check trivially pass.
+const KNOWN_LABELS = [
+  '10-Yard Fly',           // FLY10_TIME label prefix
+  'Vertical Jump',
+  '5-0-5 Agility',
+  '5-10-5 Agility',
+  'T-Test',
+  '40-Yard Dash',
+  'Top Speed',
+  'Reactive Strength',
+];
+
+const EMPTY_STATE_TEXT = /No recent measurements found/i;
+
+async function assertDashboardShowsLabelsNotCodes(page: Page) {
+  // The card is targeted via data-testid so the assertion survives class-name
+  // refactors. innerText (not innerHTML) excludes attribute values, so the
+  // legitimate `data-testid="stat-best-fly10_time"` strings elsewhere on the
+  // page don't trigger us.
+  const card = page.getByTestId('recent-measurements-card');
+  await expect(card).toBeVisible({ timeout: 10000 });
+  const cardText = await card.innerText();
+
+  // Negative assertion: no raw codes anywhere in the card.
+  for (const code of METRIC_CODES) {
+    expect(cardText, `metric code "${code}" leaked into Recent Measurements`).not.toContain(code);
+  }
+
+  // Positive assertion: at least one known label appears, OR the empty-state
+  // message is shown. Without this, a card with zero measurements would
+  // satisfy the negative check trivially and the test wouldn't actually
+  // exercise the migration.
+  const hasEmptyState = EMPTY_STATE_TEXT.test(cardText);
+  const hasKnownLabel = KNOWN_LABELS.some((label) => cardText.includes(label));
+  expect(
+    hasEmptyState || hasKnownLabel,
+    `Recent Measurements neither shows a known metric label nor the empty-state message — cannot confirm labels are wired up. Card text: ${cardText.slice(0, 200)}`,
+  ).toBeTruthy();
+}
+
 test.describe('Dashboard metric label display', () => {
-  test('renders metric labels (not codes) in Recent Measurements for org admin', async ({ page }) => {
+  test('renders labels (not codes) in Recent Measurements for org admin', async ({ page }) => {
     await loginAs(page, 'org_admin');
     await page.goto(`${TESTING_URL}/dashboard`);
     await page.waitForLoadState('networkidle');
-
-    // The card is targeted via data-testid so the assertion survives class-name
-    // refactors. innerText (not innerHTML) excludes attribute values, so legitimate
-    // data-testid="stat-best-fly10_time" strings elsewhere don't trigger us.
-    const card = page.getByTestId('recent-measurements-card');
-    await expect(card).toBeVisible({ timeout: 10000 });
-    const cardText = await card.innerText();
-
-    for (const code of METRIC_CODES) {
-      expect(cardText, `metric code "${code}" leaked into Recent Measurements`).not.toContain(code);
-    }
+    await assertDashboardShowsLabelsNotCodes(page);
   });
 
-  test('renders metric labels (not codes) in Recent Measurements for coach', async ({ page }) => {
+  test('renders labels (not codes) in Recent Measurements for coach', async ({ page }) => {
     await loginAs(page, 'coach');
     await page.goto(`${TESTING_URL}/dashboard`);
     await page.waitForLoadState('networkidle');
+    await assertDashboardShowsLabelsNotCodes(page);
+  });
 
-    const card = page.getByTestId('recent-measurements-card');
-    await expect(card).toBeVisible({ timeout: 10000 });
-    const cardText = await card.innerText();
+  test('athletes see labels (not codes) on their own measurements view', async ({ page }) => {
+    // Athletes are redirected away from /dashboard to /athletes/:id by the
+    // dashboard component itself, so we land on the athlete profile and check
+    // the measurement history surface there instead.
+    await loginAs(page, 'athlete');
+    await page.goto(`${TESTING_URL}/`);
+    await page.waitForLoadState('networkidle');
 
+    // The athlete redirect lands on /athletes/<self> — the measurement table
+    // there is the analog of the dashboard's Recent Measurements card.
+    const bodyText = await page.locator('body').innerText();
     for (const code of METRIC_CODES) {
-      expect(cardText, `metric code "${code}" leaked into Recent Measurements`).not.toContain(code);
+      expect(bodyText, `metric code "${code}" leaked into athlete view`).not.toContain(code);
     }
   });
 });

--- a/tests/e2e/dashboard-metric-labels.spec.ts
+++ b/tests/e2e/dashboard-metric-labels.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from './helpers/auth';
+
+/**
+ * Regression test for the metric-label display bug.
+ *
+ * Before the fix, the dashboard's "Recent Measurements" table showed raw
+ * metric codes ("FLY10_TIME", "VERTICAL_JUMP") instead of human-readable
+ * labels ("10-Yard Fly Time", "Vertical Jump"). Same bug appeared in many
+ * other surfaces; this spec locks the dashboard scenario specifically because
+ * that's where the user originally reported it (org admins, coaches,
+ * athletes).
+ */
+
+const TESTING_URL = process.env.TESTING_URL || process.env.STAGING_URL || 'http://localhost:5000';
+
+// Metric codes that should NEVER appear verbatim in user-facing display.
+// If any of these strings shows up in the dashboard DOM, the deprecated
+// helper is still being called somewhere.
+const METRIC_CODES = [
+  'FLY10_TIME',
+  'VERTICAL_JUMP',
+  'AGILITY_505',
+  'AGILITY_5105',
+  'T_TEST',
+  'DASH_40YD',
+  'TOP_SPEED',
+  'RSI',
+];
+
+test.describe('Dashboard metric label display', () => {
+  test('renders metric labels (not codes) in Recent Measurements for org admin', async ({ page }) => {
+    await loginAs(page, 'org_admin');
+    await page.goto(`${TESTING_URL}/dashboard`);
+    await page.waitForLoadState('networkidle');
+
+    // The card is targeted via data-testid so the assertion survives class-name
+    // refactors. innerText (not innerHTML) excludes attribute values, so legitimate
+    // data-testid="stat-best-fly10_time" strings elsewhere don't trigger us.
+    const card = page.getByTestId('recent-measurements-card');
+    await expect(card).toBeVisible({ timeout: 10000 });
+    const cardText = await card.innerText();
+
+    for (const code of METRIC_CODES) {
+      expect(cardText, `metric code "${code}" leaked into Recent Measurements`).not.toContain(code);
+    }
+  });
+
+  test('renders metric labels (not codes) in Recent Measurements for coach', async ({ page }) => {
+    await loginAs(page, 'coach');
+    await page.goto(`${TESTING_URL}/dashboard`);
+    await page.waitForLoadState('networkidle');
+
+    const card = page.getByTestId('recent-measurements-card');
+    await expect(card).toBeVisible({ timeout: 10000 });
+    const cardText = await card.innerText();
+
+    for (const code of METRIC_CODES) {
+      expect(cardText, `metric code "${code}" leaked into Recent Measurements`).not.toContain(code);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Dashboard (and ~30 other surfaces) were showing raw metric codes (`FLY10_TIME`) instead of human-readable labels (`10-Yard Fly Time`). Root: both `getMetricDisplayName` helpers were stubbed to return the code when metric definitions migrated to the `site_metrics` table.
- Introduces `useMetricLabels()` hook wrapping the existing `useAvailableMetrics()`; exposes `getLabel(code) → label` with code-as-fallback. Migrates all user-facing call sites.
- Non-React utilities (`measurement-export`, `report-utils`, `athlete-dashboard-utils`) gained an optional `metricLabels?: Record<string, string>` parameter — backward-compatible.

## Scope
- Affected roles: org admins, coaches, athletes (the user's reported groups).
- Metric configuration pages (`/metrics-management`, `/custom-metrics`, `/org-metrics`) intentionally keep showing codes — codes belong there.
- Deprecated `getMetricDisplayName` functions left in place; deletion is a follow-up PR once no callers remain.

## Files touched
45 files (+657 / −153): 1 new hook, 1 new hook test, 1 new utility test, 1 new E2E spec; ~30 components migrated; 8 co-located tests updated to mock `useMetricLabels`.

## Test plan
- [ ] `npm run check` passes (TS clean — verified locally)
- [ ] `npx vitest run` — web tests 0 failures (pre-existing API/migration DB-schema failures on `develop` are unrelated and confirmed identical on the base branch)
- [ ] `npx playwright test tests/e2e/dashboard-metric-labels.spec.ts --config=playwright.staging.config.ts` against a staging env with seeded measurements
- [ ] Manual: log in as org admin → `/dashboard` → Recent Measurements column shows labels
- [ ] Manual: same as coach
- [ ] Manual: athlete redirected to `/athletes/:id` → "My Measurements" shows labels
- [ ] Manual: command palette (`Cmd/Ctrl+K`) search results show labels
- [ ] Manual: `/metrics-management` still shows codes (intentional — that's where you edit them)
- [ ] Manual: custom org metric — create one, record a measurement, verify the custom label shows everywhere

## Out of scope (separate PRs)
1. Server-side CSV/PDF export label resolution
2. Adding `metricLabel` to API responses (so non-React consumers don't need the hook)
3. Deleting the deprecated `getMetricDisplayName` stubs
4. Sibling deprecated helpers (`getMetricColor`, `getMetricIcon`, `getMetricUnits`, `formatMetricValue`) — same root cause, separate visual bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)