### PR TITLE
chore(deps): ignore React major-version bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,18 @@ updates:
     # Auto-merge configuration for patch updates
     pull-request-branch-name:
       separator: "/"
+    ignore:
+      # React 18 → 19 requires a coordinated migration (react, react-dom,
+      # type packages, Radix UI, react-query, react-hook-form, wouter, etc.)
+      # Suppress major bumps until that migration is planned. See PR #392.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
 
   # Enable security updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Adds `ignore` rules to the npm Dependabot block for `react`, `react-dom`, `@types/react`, and `@types/react-dom`, suppressing `version-update:semver-major` bumps only.
- PR #392 (`chore(deps)(deps): bump react-dom and @types/react-dom`) was closed on 2026-05-02 because Dependabot bumped `react-dom` → 19.x while leaving `react` at 18.3.1, producing an unresolvable peer-dep conflict (`@types/react-dom@19.2.3` requires `peer @types/react@"^19.2.0"`). Without this rule, Dependabot recreates the same broken PR every Monday.
- React 18 → 19 will be handled as a **planned, coordinated migration** — upgrading `react`, `react-dom`, `@types/react`, `@types/react-dom`, and auditing 75+ peer-dep consumers (Radix UI, `@tanstack/react-query`, `react-hook-form`, `wouter`, etc.) — not via an automated Dependabot bump.

## Test plan

- [ ] YAML parses cleanly: `python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` exits 0 ✅
- [ ] No other Dependabot config touched — only the four `ignore` entries added inside the existing npm block
- [ ] Minor and patch React updates are **not** blocked (rules target `semver-major` only)

https://claude.ai/code/session_01JsupaEEMhg4VEg32pP2qLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsupaEEMhg4VEg32pP2qLs)_