### PR TITLE
feat(reports): per-chart selection + "you are here" distribution (+ userDefined cleanup)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-report-distribution-and-chart-selection.md
+++ b/docs/superpowers/plans/2026-06-30-report-distribution-and-chart-selection.md
@@ -1,0 +1,559 @@
+# Report Chart Selection + "You Are Here" Distribution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let the creator toggle which charts an individual report includes (radar / benchmark-standing / trends / distribution), add a "you are here" org-wide distribution chart (box + dots, athlete marked), and remove the dead individual `userDefined` config field.
+
+**Architecture:** A pure `resolveChartSelection(config)` (shared) decides which sections render, with no-migration back-compat for legacy reports. The backend adds an additive `distributions` payload (reusing the org-wide peer best-values the percentile already queries) only when that chart is enabled. A `DistributionSection` renders box+dots via the existing `box_swarm_combo` path. Each section stays gated on (toggle ON AND data present).
+
+**Tech Stack:** TypeScript, Drizzle/Postgres, Express, React 18, react-chartjs-2/Chart.js, simple-statistics, Vitest, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-06-30-report-distribution-and-chart-selection-design.md`
+
+**Branch:** `feature/report-distribution-and-chart-selection` (off develop).
+
+**Test commands:** unit `npx vitest run --config vitest.unit.config.ts <path>` (only `__tests__/` dirs are collected — put unit tests there); integration `npx dotenv -e .env.local -- npx vitest run --config vitest.integration.config.ts <path>`; E2E `npx dotenv -e .env.local -- npx playwright test <path> --config=playwright.config.ts`; typecheck `npm run check`. Stage only named files (never `git add -A`).
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/shared/report-charts.ts` — `ChartSelection` type + pure `resolveChartSelection()`.
+- `packages/shared/__tests__/report-charts.test.ts` — unit tests.
+- `packages/api/services/report-distributions.ts` — pure `computeDistribution()` (stats + sampling).
+- `packages/api/services/__tests__/report-distributions.test.ts` — unit tests.
+- `packages/web/src/components/reports/DistributionSection.tsx` — box+dots report chart.
+- `tests/integration/report-chart-selection.test.ts` — generate-payload integration tests.
+- `tests/e2e/report-chart-selection.spec.ts` — E2E + screenshots.
+
+**Modify:**
+- `packages/shared/report-trends-types.ts` (or a new shared types file) — add `MetricDistribution` type.
+- `packages/api/services/report-service.ts` — `ReportConfig.charts`; `IndividualReportData.distributions`; `calculateDistributions()`; wire into `generateIndividualReport`.
+- `packages/web/src/types/report-types.ts` — `IndividualReportConfig.charts`; `IndividualReportData.distributions`; remove individual `benchmarks.userDefined`.
+- `packages/shared/schema-original.ts` — add `charts` to report config zod.
+- `packages/web/src/components/reports/ReportWizard.tsx` — chart-selection step (replace `showTrends` checkbox).
+- `packages/web/src/components/reports/IndividualReportView.tsx` — gate sections via resolver; render `DistributionSection`.
+- `packages/web/src/pages/public-report.tsx` — same.
+
+---
+
+## Task 1: `resolveChartSelection` (shared resolver)
+
+**Files:** Create `packages/shared/report-charts.ts`, `packages/shared/__tests__/report-charts.test.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/shared/__tests__/report-charts.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolveChartSelection } from '../report-charts';
+
+describe('resolveChartSelection', () => {
+  it('uses explicit charts config when present (missing keys -> false)', () => {
+    expect(resolveChartSelection({ charts: { radar: true, distribution: true } })).toEqual({
+      radar: true, benchmarkStanding: false, trends: false, distribution: true,
+    });
+  });
+
+  it('back-compat: absent charts -> radar+benchmark on, trends from showTrends, distribution off', () => {
+    expect(resolveChartSelection({ showTrends: true })).toEqual({
+      radar: true, benchmarkStanding: true, trends: true, distribution: false,
+    });
+    expect(resolveChartSelection({})).toEqual({
+      radar: true, benchmarkStanding: true, trends: false, distribution: false,
+    });
+  });
+
+  it('explicit charts overrides legacy showTrends', () => {
+    expect(resolveChartSelection({ showTrends: true, charts: { trends: false } }).trends).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — confirm RED**
+
+Run: `npx vitest run --config vitest.unit.config.ts packages/shared/__tests__/report-charts.test.ts`
+Expected: FAIL ("Cannot find module '../report-charts'").
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// packages/shared/report-charts.ts
+
+export interface ChartSelection {
+  radar: boolean;
+  benchmarkStanding: boolean;
+  trends: boolean;
+  distribution: boolean;
+}
+
+/** Config subset this resolver reads. */
+interface ChartConfigInput {
+  charts?: Partial<ChartSelection>;
+  showTrends?: boolean;
+}
+
+/**
+ * Resolve which report charts are enabled. New reports carry `charts`; legacy
+ * reports (no `charts`) fall back to historical behavior: radar + benchmark
+ * standing on, trends driven by the old `showTrends` flag, distribution off.
+ */
+export function resolveChartSelection(config: ChartConfigInput | undefined | null): ChartSelection {
+  const c = config?.charts;
+  if (c) {
+    return {
+      radar: c.radar ?? false,
+      benchmarkStanding: c.benchmarkStanding ?? false,
+      trends: c.trends ?? false,
+      distribution: c.distribution ?? false,
+    };
+  }
+  return {
+    radar: true,
+    benchmarkStanding: true,
+    trends: config?.showTrends ?? false,
+    distribution: false,
+  };
+}
+```
+
+- [ ] **Step 4: Run — confirm GREEN.** `npx vitest run --config vitest.unit.config.ts packages/shared/__tests__/report-charts.test.ts` → 3 pass. `npm run check` → pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/report-charts.ts packages/shared/__tests__/report-charts.test.ts
+git commit -m "feat(reports): shared resolveChartSelection with back-compat defaults"
+```
+
+---
+
+## Task 2: `computeDistribution` (stats + sampling)
+
+**Files:** Create `packages/api/services/report-distributions.ts`, `packages/api/services/__tests__/report-distributions.test.ts`. Add the shared `MetricDistribution` type to `packages/shared/report-trends-types.ts`.
+
+- [ ] **Step 1: Add the shared type.** Append to `packages/shared/report-trends-types.ts`:
+
+```typescript
+/** Peer distribution for one metric (org-wide), with the athlete's own value. */
+export interface MetricDistribution {
+  values: number[];   // peer best-performances, sampled for display (<= cap)
+  athleteValue: number;
+  stats: { min: number; q1: number; median: number; q3: number; max: number }; // from the FULL set
+}
+
+/** Map of metric code -> distribution. Present only when the distribution chart is enabled. */
+export type ReportDistributions = Record<string, MetricDistribution>;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// packages/api/services/__tests__/report-distributions.test.ts
+import { describe, it, expect } from 'vitest';
+import { computeDistribution, MAX_DISTRIBUTION_POINTS } from '../report-distributions';
+
+describe('computeDistribution', () => {
+  it('computes five-number stats from the full set', () => {
+    const d = computeDistribution([10, 20, 30, 40, 50], 30, 100)!;
+    expect(d.stats.min).toBe(10);
+    expect(d.stats.max).toBe(50);
+    expect(d.stats.median).toBe(30);
+    expect(d.stats.q1).toBeCloseTo(20, 5);
+    expect(d.stats.q3).toBeCloseTo(40, 5);
+    expect(d.athleteValue).toBe(30);
+    expect(d.values).toHaveLength(5);
+  });
+
+  it('returns null for fewer than 2 peers', () => {
+    expect(computeDistribution([42], 42, 100)).toBeNull();
+    expect(computeDistribution([], 1, 100)).toBeNull();
+  });
+
+  it('samples values deterministically down to the cap; stats use the full set', () => {
+    const full = Array.from({ length: 1000 }, (_, i) => i + 1); // 1..1000
+    const d = computeDistribution(full, 500, 150)!;
+    expect(d.values.length).toBeLessThanOrEqual(150);
+    expect(d.stats.min).toBe(1);
+    expect(d.stats.max).toBe(1000);
+    // deterministic: same input -> same sample
+    expect(computeDistribution(full, 500, 150)!.values).toEqual(d.values);
+  });
+
+  it('does not sample when under the cap', () => {
+    const d = computeDistribution([1, 2, 3, 4], 3, 150)!;
+    expect(d.values).toEqual([1, 2, 3, 4]);
+  });
+});
+```
+
+- [ ] **Step 3: Run — confirm RED.** `npx vitest run --config vitest.unit.config.ts packages/api/services/__tests__/report-distributions.test.ts` → FAIL.
+
+- [ ] **Step 4: Implement**
+
+```typescript
+// packages/api/services/report-distributions.ts
+import { quantile } from 'simple-statistics';
+import type { MetricDistribution } from '@shared/report-trends-types';
+
+export const MAX_DISTRIBUTION_POINTS = 150;
+
+/**
+ * Build a peer distribution for one metric. Stats are computed from the FULL
+ * peer set; `values` is evenly sampled down to `maxPoints` for display.
+ * Returns null when there are fewer than 2 peers (no meaningful box).
+ */
+export function computeDistribution(
+  peerValues: number[],
+  athleteValue: number,
+  maxPoints: number = MAX_DISTRIBUTION_POINTS,
+): MetricDistribution | null {
+  if (!peerValues || peerValues.length < 2) return null;
+
+  const sorted = [...peerValues].sort((a, b) => a - b);
+  const stats = {
+    min: sorted[0],
+    q1: quantile(sorted, 0.25),
+    median: quantile(sorted, 0.5),
+    q3: quantile(sorted, 0.75),
+    max: sorted[sorted.length - 1],
+  };
+
+  let values = peerValues;
+  if (peerValues.length > maxPoints) {
+    // Even, deterministic down-sampling of the sorted set.
+    const step = peerValues.length / maxPoints;
+    values = Array.from({ length: maxPoints }, (_, i) => sorted[Math.floor(i * step)]);
+  }
+
+  return { values, athleteValue, stats };
+}
+```
+
+- [ ] **Step 5: Run — confirm GREEN** (4 tests). `npm run check` → pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/report-trends-types.ts packages/api/services/report-distributions.ts packages/api/services/__tests__/report-distributions.test.ts
+git commit -m "feat(reports): pure computeDistribution (five-number stats + deterministic sampling)"
+```
+
+---
+
+## Task 3: backend `calculateDistributions` + wire into generate
+
+**Files:** Modify `packages/api/services/report-service.ts`.
+
+- [ ] **Step 1: Add imports + config/data types.** Near the other imports:
+
+```typescript
+import { computeDistribution } from './report-distributions';
+import { resolveChartSelection } from '@shared/report-charts';
+import type { ReportDistributions } from '@shared/report-trends-types';
+```
+In `interface ReportConfig` add:
+```typescript
+  charts?: { radar?: boolean; benchmarkStanding?: boolean; trends?: boolean; distribution?: boolean };
+```
+In `interface IndividualReportData` add:
+```typescript
+  distributions?: ReportDistributions;
+```
+
+- [ ] **Step 2: Add `calculateDistributions` method.** Place near `calculatePercentilesAndAverages` (≈ line 615). It mirrors that method's org-wide peer best-value query, then calls `computeDistribution`:
+
+```typescript
+  /** Org-wide peer distribution per metric (same peer set as the percentile). */
+  async calculateDistributions(
+    organizationId: string,
+    metrics: string[],
+    athletePerformances: Record<string, number>,
+    startDate: string,
+    endDate: string,
+  ): Promise<ReportDistributions> {
+    const distributions: ReportDistributions = {};
+    for (const metric of metrics) {
+      const athleteValue = athletePerformances[metric];
+      if (athleteValue === undefined) continue;
+
+      const rows = await db
+        .select({ value: measurements.value, userId: measurements.userId })
+        .from(measurements)
+        .where(and(
+          eq(measurements.organizationId, organizationId),
+          eq(measurements.metric, metric),
+          gte(measurements.date, startDate),
+          lte(measurements.date, endDate),
+        ));
+
+      // Best performance per athlete (same rule as calculatePercentilesAndAverages).
+      const info = await this.getMetricInfo(metric);
+      const bestMap = new Map<string, number>();
+      for (const r of rows) {
+        const v = parseFloat(r.value);
+        const cur = bestMap.get(r.userId);
+        if (cur === undefined) bestMap.set(r.userId, v);
+        else if (info.lowerIsBetter ? v < cur : v > cur) bestMap.set(r.userId, v);
+      }
+
+      const dist = computeDistribution(Array.from(bestMap.values()), athleteValue);
+      if (dist) distributions[metric] = dist;
+    }
+    return distributions;
+  }
+```
+
+- [ ] **Step 3: Wire into `generateIndividualReport`.** After `benchmarkComparisons` / `trends` are built and before the `athletePerformance`/return, add:
+
+```typescript
+    const chartSelection = resolveChartSelection(config);
+    let distributions: ReportDistributions | undefined;
+    if (chartSelection.distribution) {
+      distributions = await this.calculateDistributions(
+        report.organizationId, config.metrics, bestPerformances, startDate, endDate,
+      );
+    }
+```
+Add `distributions` to the returned object (alongside `trends`).
+
+Note: the existing `trends` block is gated on `config.showTrends`. Change that gate to `if (resolveChartSelection(config).trends)` so the trends payload honors the new selection (compute `chartSelection` once and reuse). This keeps legacy `showTrends` working (resolver maps it) and lets the new `charts.trends` toggle control it.
+
+- [ ] **Step 4: Verify** `npm run check` → pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/services/report-service.ts
+git commit -m "feat(reports): compute org-wide distributions when the distribution chart is enabled"
+```
+
+---
+
+## Task 4: frontend config types + zod
+
+**Files:** Modify `packages/web/src/types/report-types.ts`, `packages/shared/schema-original.ts`.
+
+- [ ] **Step 1: Frontend types.** In `IndividualReportConfig` (report-types.ts): add `charts?: { radar?: boolean; benchmarkStanding?: boolean; trends?: boolean; distribution?: boolean };`, keep `showTrends?: boolean`, and REMOVE the `userDefined` sub-field from `benchmarks` (individual reports can't use it — it's the dead path). In `IndividualReportData` add `distributions?: ReportDistributions;` with `import type { ReportDistributions } from '@shared/report-trends-types';`.
+
+- [ ] **Step 2: Zod.** In `insertReportSchema` (and `updateReportSchema`) config object in `schema-original.ts`, add:
+```typescript
+    charts: z.object({
+      radar: z.boolean().optional(),
+      benchmarkStanding: z.boolean().optional(),
+      trends: z.boolean().optional(),
+      distribution: z.boolean().optional(),
+    }).optional(),
+```
+Leave `benchmarks.userDefined` in the zod (the shared config shape is still used by **team** reports' `getBenchmarksForReport`). Add a one-line comment: `// benchmarks.userDefined applies to team reports only`.
+
+- [ ] **Step 3: Verify** `npm run check` → pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/src/types/report-types.ts packages/shared/schema-original.ts
+git commit -m "feat(reports): add charts selection to config schema; drop dead individual userDefined type"
+```
+
+---
+
+## Task 5: `DistributionSection` component
+
+**Files:** Create `packages/web/src/components/reports/DistributionSection.tsx`.
+
+This reuses the box+dots (`box_swarm_combo`) visual via `BoxPlotChart`. READ `packages/web/src/components/charts/BoxPlotChart.tsx` FIRST to confirm: (a) whether it derives the box from `rawData`/`data` when `statistics` is omitted, or requires a `StatisticalSummary`; (b) the exact `ChartDataPoint` fields it reads; (c) whether it renders analytics-only chrome (stats expander, athlete-name toggle) that should be suppressed for a report — if so, add a minimal `compact` prop to BoxPlotChart (mirroring the radar `compact` fix already in the codebase) and pass it. Then:
+
+- [ ] **Step 1: Implement** (per-metric box+dots from `distributions`)
+
+```tsx
+// packages/web/src/components/reports/DistributionSection.tsx
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BoxPlotChart } from '@/components/charts/BoxPlotChart';
+import type { ReportDistributions } from '@shared/report-trends-types';
+
+interface Props {
+  athleteId: string;
+  athleteName: string;
+  distributions: ReportDistributions;
+  metricLabels?: Record<string, string>;
+  metricUnits?: Record<string, string>;
+}
+
+export function DistributionSection({ athleteId, athleteName, distributions, metricLabels = {}, metricUnits = {} }: Props) {
+  const entries = Object.entries(distributions);
+  if (entries.length === 0) return null;
+  return (
+    <Card data-report-chart="distribution" data-report-chart-title="Distribution vs peers">
+      <CardHeader><CardTitle>Where You Stand (vs your group)</CardTitle></CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-muted-foreground">
+          Each dot is an athlete in your organization with this test; you are the blue dot.
+        </p>
+        {entries.map(([code, dist]) => {
+          const label = metricLabels[code] || code;
+          // Build ChartDataPoint[]: anonymous peers + the athlete (real id, highlighted).
+          const points = dist.values.map((v, i) => ({
+            athleteId: `peer-${i}`, athleteName: '', value: v, date: new Date(), metric: code,
+          }));
+          points.push({ athleteId, athleteName, value: dist.athleteValue, date: new Date(), metric: code });
+          return (
+            <div key={code} data-report-chart={`dist:${code}`} data-report-chart-title={`${label} — distribution`} className="h-[260px]">
+              <BoxPlotChart
+                data={points}
+                rawData={points}
+                highlightAthlete={athleteId}
+                showAllPoints
+                config={{ type: 'box_swarm_combo', title: label, showLegend: false, showTooltips: true, responsive: true }}
+                /* compact  // add if BoxPlotChart exposes it after the read above */
+              />
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+export default DistributionSection;
+```
+Adjust the props you pass to BoxPlotChart to match what the read in this task established (e.g. if it needs a `statistics` map, build one per metric from `dist.stats` filling the required `StatisticalSummary` fields: `count`, `mean`, `median`, `min`, `max`, `std`, `variance`, and `percentiles` with `p25=q1`, `p50=median`, `p75=q3`). If it derives the box from points, omit `statistics`.
+
+- [ ] **Step 2: Verify** `npm run check` → pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/web/src/components/reports/DistributionSection.tsx
+git commit -m "feat(reports): DistributionSection (box + dots, athlete highlighted)"
+```
+
+---
+
+## Task 6: wizard chart-selection step
+
+**Files:** Modify `packages/web/src/components/reports/ReportWizard.tsx`.
+
+- [ ] **Step 1: Form schema + defaults.** Replace the `showTrends: z.boolean().default(false)` field with a `charts` group:
+```typescript
+charts: z.object({
+  radar: z.boolean().default(true),
+  benchmarkStanding: z.boolean().default(true),
+  trends: z.boolean().default(true),
+  distribution: z.boolean().default(true),
+}).default({ radar: true, benchmarkStanding: true, trends: true, distribution: true }),
+```
+Update `defaultValues` accordingly (remove `showTrends: false`; add the `charts` default object). Update the `watch` (replace `const showTrends = watch('showTrends')` with `const charts = watch('charts')`).
+
+- [ ] **Step 2: Replace the checkbox UI.** Where the "Show progress over time" card is (individual step 8), render four described checkboxes, one per chart, mirroring the existing card style:
+```tsx
+{([
+  ['radar', 'All-around profile (radar)', 'Percentile shape across all metrics (needs ≥3 metrics)'],
+  ['benchmarkStanding', 'Benchmark standing', 'Where the athlete sits vs each benchmark'],
+  ['trends', 'Progress over time', 'Trend line per metric (needs ≥2 measurements)'],
+  ['distribution', 'Where you stand (distribution)', 'The group spread with the athlete marked'],
+] as const).map(([key, title, desc]) => (
+  <div key={key} className="flex items-start space-x-2">
+    <Checkbox id={`chart-${key}`} checked={charts?.[key] ?? true}
+      onCheckedChange={(v) => setValue(`charts.${key}` as const, v as boolean)} className="mt-1" />
+    <div>
+      <Label htmlFor={`chart-${key}`} className="cursor-pointer font-medium">{title}</Label>
+      <p className="text-sm text-muted-foreground">{desc}</p>
+    </div>
+  </div>
+))}
+```
+
+- [ ] **Step 3: Submit config.** In `onSubmit`, replace `config.showTrends = data.showTrends` with `config.charts = data.charts;`. Remove any `showTrends` from the submitted config.
+
+- [ ] **Step 4: Verify** `npm run check` → pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/src/components/reports/ReportWizard.tsx
+git commit -m "feat(reports): per-chart selection step in the report wizard (default all on)"
+```
+
+---
+
+## Task 7: render gating + distribution in report views
+
+**Files:** Modify `packages/web/src/components/reports/IndividualReportView.tsx`, `packages/web/src/pages/public-report.tsx`.
+
+- [ ] **Step 1: Live view.** Import `resolveChartSelection` from `@shared/report-charts` and `DistributionSection`. Compute `const sel = resolveChartSelection(reportData.reportConfig)` (confirm the generated data exposes `reportConfig`; the backend returns it). Gate each existing section by `sel.<chart> && <existing data guard>`:
+  - radar section: `sel.radar && athlete.percentiles && Object.keys(...).length >= 3`
+  - benchmark-standing: `sel.benchmarkStanding && <existing comparisons guard>`
+  - trends (`TrendSection`): `sel.trends && trends && Object.keys(trends).length > 0`
+  - distribution (new): `sel.distribution && distributions && Object.keys(distributions).length > 0` → render `<DistributionSection athleteId={athlete.userId} athleteName={athlete.userName} distributions={distributions} metricLabels={metricLabels} metricUnits={metricUnits} />` (destructure `distributions` from `reportData`).
+
+- [ ] **Step 2: Public page.** Same gating using `snapshotData` (config at `snapshotData.reportConfig`, distributions at top-level `snapshotData.distributions`, athlete at `snapshotData.athlete`). Render the same four gated sections.
+
+- [ ] **Step 3: Verify** `npm run check` → pass; manual: a report with all charts on shows radar/benchmark/trends/distribution; toggling distribution off removes it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/src/components/reports/IndividualReportView.tsx packages/web/src/pages/public-report.tsx
+git commit -m "feat(reports): gate report sections by chart selection; render distribution (live + public)"
+```
+
+---
+
+## Task 8: integration tests
+
+**Files:** Create `tests/integration/report-chart-selection.test.ts` (model harness on `tests/integration/report-trends.test.ts`).
+
+- [ ] **Step 1: Tests** (reuse the sibling harness: app build, login, seed org/team/athlete/measurements; seed a SECOND athlete so peers exist for the distribution):
+  - `generate` with `config.charts.distribution = true` returns `data.distributions[METRIC]` with `values`/`stats`/`athleteValue`; with distribution off (or legacy config), `data.distributions` is undefined.
+  - `config.charts.trends=false` → `data.trends` undefined; `charts.trends=true` → present.
+  - Back-compat: a report with NO `charts` and legacy `showTrends:true` → `data.trends` present, `data.distributions` undefined (matches `resolveChartSelection`).
+  - Distribution omits a metric with `<2` peers.
+
+- [ ] **Step 2: Run** `npx dotenv -e .env.local -- npx vitest run --config vitest.integration.config.ts tests/integration/report-chart-selection.test.ts` → PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/report-chart-selection.test.ts
+git commit -m "test(reports): integration coverage for chart selection + distribution payload"
+```
+
+---
+
+## Task 9: E2E + verification
+
+**Files:** Create `tests/e2e/report-chart-selection.spec.ts` (model on `tests/e2e/individual-report-charts.spec.ts`).
+
+- [ ] **Step 1: E2E** — seed an athlete (≥3 metrics, ≥2 measurements) PLUS a few peer athletes with the same metrics (so the distribution has a group). Create a report with `config.charts` all true. Assert: radar, `[data-testid="trend-section"]`, `[data-report-chart="distribution"]`, and a `[data-report-chart^="dist:"]` chart are visible. Create a second report with `charts.distribution=false` and assert `[data-report-chart="distribution"]` is NOT present. Verify the public link shows the distribution. Capture `screenshots/report-chart-selection-desktop.png` and `-mobile.png`.
+
+- [ ] **Step 2: Run** the E2E → PASS; screenshots generated. **View the desktop screenshot** to confirm the box+dots renders with the athlete marked and no overflowing analytics chrome (apply a `compact` prop to BoxPlotChart if chrome intrudes — same pattern as the radar fix).
+
+- [ ] **Step 3: Full verification**
+
+Run: `npm run check` → PASS.
+Run: `npm run test:unit` → PASS (new `report-charts`, `report-distributions` tests included; list any pre-existing unrelated failures separately).
+Run integration: `npx dotenv -e .env.local -- npx vitest run --config vitest.integration.config.ts tests/integration/report-chart-selection.test.ts tests/integration/report-trends.test.ts` → PASS (back-compat: report-trends still green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/report-chart-selection.spec.ts
+git commit -m "test(reports): E2E for chart selection + distribution (live + public) with screenshots"
+```
+
+---
+
+## Self-Review Notes (spec coverage)
+
+- Chart selection (all four toggleable, default on) → Tasks 1 (resolver), 4 (zod), 6 (wizard), 7 (gating).
+- Back-compat / no migration → Task 1 resolver + Tasks 3/7 using it; asserted in Task 8.
+- Distribution (org-wide peer reuse, box+dots, sampling) → Tasks 2 (stats/sampling), 3 (backend query), 5 (component), 7 (render).
+- Distribution data matches the percentile peer set → Task 3 mirrors `calculatePercentilesAndAverages`'s org-wide best-per-athlete query.
+- userDefined cleanup (individual only; team keeps it) → Task 4 (drop from individual frontend type; zod kept for team with comment).
+- PDF capture → DistributionSection carries `data-report-chart` hooks; the capture/embed path (generalized in the merged trends work) handles them; verified in Task 9.
+- Tests: unit (1,2), integration (8), E2E (9). Existing report behavior guarded (Task 8 back-compat, Task 9 report-trends).
+
+**Known implementation-time read (not a placeholder):** Task 5 requires reading `BoxPlotChart` to finalize how points/statistics are fed and whether a `compact` prop is needed — the data contract (`MetricDistribution`) is fully specified; only the analytics-component wiring is established at implementation time, with a screenshot-verification gate in Task 9.
+
+**Deferred (out of scope):** team-report chart selection; demographic/team peer sets for the distribution.

--- a/docs/superpowers/specs/2026-06-30-report-distribution-and-chart-selection-design.md
+++ b/docs/superpowers/specs/2026-06-30-report-distribution-and-chart-selection-design.md
@@ -1,0 +1,195 @@
+# Design: Report Chart Selection + "You Are Here" Distribution (+ userDefined cleanup)
+
+- **Date:** 2026-06-30
+- **Status:** Approved (design phase) — pending user review of this doc
+- **Author:** John Hull (with Claude Code)
+- **Builds on:** `2026-06-26-report-time-range-trends-design.md`, `2026-06-28-individual-report-charts-design.md` (both merged)
+
+## Problem
+
+The individual report now has several visual charts (radar, benchmark standing,
+trend lines), but the report creator has no control over which appear — only a
+single "Show progress over time" toggle. We want the creator to choose which
+charts to include. We also want the deferred **"you are here" distribution**
+chart (peer spread with the athlete marked), and to clean up a dead config path.
+
+## Scope
+
+**In scope (this increment, individual reports only):**
+- **Chart selection** in the report wizard: per-chart on/off toggles for Radar,
+  Benchmark standing, Trends, and Distribution, replacing the lone `showTrends`
+  checkbox. Default all-on for new reports.
+- **"You are here" distribution** chart (box + dots, athlete highlighted),
+  rendered in the live report, public page, and PDF.
+- **Cleanup:** remove the dead `userDefined` benchmark path from the individual
+  report config.
+
+**Out of scope (deferred / unchanged):**
+- Team reports (their sections are untouched; chart selection is individual-only).
+- Demographic-cohort or team-only peer sets for the distribution (org-wide only).
+- Per-chart styling options beyond the chosen distribution style.
+
+## Key Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Selectable charts | **All four visual charts** individually toggleable | Unified, consistent control; replaces the lone showTrends toggle |
+| New-report default | **All charts ON (opt-out)** | "Show everything, trim down"; each chart self-hides without data |
+| Existing reports | **Back-compat: absent config → today's behavior** | No data migration; saved reports look unchanged |
+| Distribution peer set | **Same org-wide set as the percentile** | The distribution visually matches the stated percentile |
+| Distribution style | **Box + dots combo** (`box_swarm_combo`) | Reuses the analytics component; crowd + stats; legible to parents and coaches |
+| userDefined path | **Remove** from individual config | Dead (nothing writes `reportBenchmarks`); site/custom benchmarks already cover single-value targets |
+| Report scope | **Individual only** | All four charts are individual-athlete visuals |
+
+## Architecture
+
+### 1. Chart selection model + resolver
+
+Add a `charts` object to the individual report config:
+```ts
+charts?: {
+  radar?: boolean;
+  benchmarkStanding?: boolean;
+  trends?: boolean;
+  distribution?: boolean;
+};
+```
+The legacy `showTrends?: boolean` stays in the type for reading old reports but the
+wizard no longer writes it (it writes `charts`).
+
+**Resolver** (pure, unit-tested) — the single source of truth for "is chart X on?":
+```ts
+function resolveChartSelection(config): {
+  radar: boolean; benchmarkStanding: boolean; trends: boolean; distribution: boolean;
+}
+```
+- If `config.charts` is present → use its booleans (missing keys default `false`).
+- If `config.charts` is absent (legacy report) → back-compat defaults:
+  `radar: true`, `benchmarkStanding: true`, `trends: config.showTrends ?? false`,
+  `distribution: false`.
+
+Lives in `packages/shared` (or a shared util) so backend + frontend resolve
+identically. Both `IndividualReportView` and `public-report` call it.
+
+**Render rule:** each section renders only when `resolveChartSelection(...)[chart]`
+is true **AND** the chart's data is present (radar: ≥3 percentiles;
+benchmarkStanding: any benchmark comparisons; trends: present `trends` payload;
+distribution: present `distributions` payload). Sections remain self-guarding, so
+a toggle never yields a broken/empty chart.
+
+### 2. Distribution data (backend)
+
+In `report-service.generateIndividualReport`, when `resolveChartSelection(config).distribution`
+is true, add a `distributions` field to `IndividualReportData`:
+```ts
+distributions?: Record<string /*metricCode*/, {
+  values: number[];          // peer best-performances (sampled for display; see below)
+  athleteValue: number;      // this athlete's best for the metric
+  stats: { min: number; q1: number; median: number; q3: number; max: number }; // from the FULL set
+}>;
+```
+- **Peer set:** the same org-wide peer best-performances already gathered by
+  `calculatePercentilesAndAverages` (which computes the report's percentiles). Capture
+  those values per metric rather than issuing a new query where possible; if the
+  existing helper discards them, extend it to return them (kept internal).
+- **Stats** (`min/q1/median/q3/max`) are computed from the **full** peer set.
+- **Sampling:** `values` for display is capped at `MAX_DISTRIBUTION_POINTS` (≈150).
+  When the peer count exceeds the cap, sample evenly (deterministic) down to the
+  cap; always include the athlete's own value position context via `athleteValue`.
+  The box/stats are unaffected (computed from the full set).
+- The field is **only** populated when the distribution chart is enabled (additive,
+  like `trends`).
+
+### 3. Distribution chart (frontend)
+
+- **New** `packages/web/src/components/reports/DistributionSection.tsx`: renders one
+  box-and-dots chart per metric from `distributions`, reusing the existing
+  `box_swarm_combo` rendering (`BoxPlotChart` with `rawData` = peer values +
+  `highlightAthlete`/marker for `athleteValue`, `statistics` from `stats`). Includes
+  a plain-language caption ("Each dot is an athlete in your group; you're the blue
+  one — farther right is better*" with the metric's direction) and a
+  `data-report-chart="dist:${metricCode}"` + `data-report-chart-title` capture hook
+  so it flows into the public page and PDF like the other report charts.
+- Rendered in `IndividualReportView` and `public-report` (from top-level
+  `snapshotData.distributions`), gated by the resolver + presence of `distributions`.
+
+### 4. Wizard chart-selection step
+
+In `ReportWizard`, for individual reports, replace the single `showTrends` checkbox
+with a **chart-selection** group: four labeled, described checkboxes (Radar,
+Benchmark standing, Trends, Distribution), defaulting all `true`. The submitted
+`config.charts` carries the four booleans. Remove the `showTrends` form field and
+the `userDefined` benchmark inputs (see §5). Mirror the existing checkbox pattern.
+
+### 5. userDefined cleanup
+
+Remove `userDefined` from the individual report path:
+- `IndividualReportConfig` (`report-types.ts`), backend `ReportConfig`
+  (`report-service.ts`), and the `insertReportSchema`/`updateReportSchema` config
+  zod (`schema-original.ts`) — drop the `userDefined` array from the individual
+  config shape. (If the same `benchmarks` shape is shared with team config, keep it
+  where team still uses it; only remove from the individual path. Confirm at
+  implementation time whether team uses `userDefined` — team's `getBenchmarksForReport`
+  DOES read `config.benchmarks.userDefined`, so if the shape is shared, leave the
+  type but remove it from the individual wizard + document it as team-only.)
+- Remove any `userDefined` inputs from the wizard's individual flow.
+- `getBenchmarkComparisons` already reads userDefined from the `reportBenchmarks`
+  table (empty), so removing the inert config input changes no runtime behavior for
+  individual reports.
+
+## Data contract changes
+
+- `IndividualReportConfig` / `ReportConfig`: add `charts?`, keep `showTrends?` (legacy
+  read-only), remove individual `benchmarks.userDefined` (or document team-only).
+- `IndividualReportData`: add `distributions?` (additive, only when enabled).
+- `insertReportSchema`/`updateReportSchema`: add `charts` object; remove/keep
+  `userDefined` per the team-shared determination above.
+
+## Edge cases
+
+- **Legacy report (no `charts`)** → resolver back-compat; appearance unchanged.
+- **Distribution enabled but metric has no peers / only the athlete** → omit that
+  metric's distribution (need ≥2 peers for a meaningful box); section hides if none.
+- **Large org (hundreds of peers)** → dots sampled to the cap; stats from full set.
+- **Chart toggled on but data absent** (e.g. radar with 2 metrics) → section hides.
+- **All charts toggled off** → report shows the Performance Summary table only (valid).
+- **PDF** → distribution carries a capture hook; charts already flow ~2/page.
+
+## Testing (TDD)
+
+**Unit:**
+- `resolveChartSelection`: new-config booleans; missing keys → false; legacy absent
+  config → back-compat defaults (incl. `showTrends` mapping).
+- Distribution stats helper: `min/q1/median/q3/max` correctness; even sampling caps
+  to `MAX_DISTRIBUTION_POINTS` and is deterministic; `<2` peers → omitted.
+
+**Integration:**
+- `generateIndividualReport` returns `distributions` only when the distribution chart
+  is enabled; values/stats correct against seeded peers; sampling applied past the cap.
+- Back-compat: a report with no `charts` (and/or legacy `showTrends`) generates the
+  same payload shape as today; existing report tests stay green.
+- Removing `userDefined` from individual config doesn't break generation.
+
+**E2E:**
+- Wizard: toggling each chart on/off controls whether its section appears in the
+  generated report. Distribution renders (box + dots + athlete marker) on the live
+  report and the public link; PDF download is non-empty and includes it.
+- Screenshots (desktop 1280×720, mobile 375×667) → `screenshots/`.
+
+## Success criteria
+
+1. Report creator can toggle Radar / Benchmark standing / Trends / Distribution per
+   individual report; defaults all-on for new reports.
+2. Each chart appears only when enabled AND its data exists; toggles never produce
+   empty/broken sections.
+3. The distribution chart shows the org-wide peer spread (box + dots) with the
+   athlete marked, consistent with the stated percentile — in live view, public link,
+   and PDF.
+4. Existing saved reports render exactly as before (no migration).
+5. The dead `userDefined` individual path is removed with no behavior change.
+6. All new logic covered by unit + integration + E2E tests.
+
+## Future direction (not built here)
+
+Team-report chart selection; demographic-cohort or team-only peer sets for the
+distribution (would also move the percentile to that cohort for consistency).

--- a/packages/api/routes/__tests__/pdf-chart-layout.test.ts
+++ b/packages/api/routes/__tests__/pdf-chart-layout.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { planChartPageBreaks } from '../pdf-chart-layout';
+
+describe('planChartPageBreaks', () => {
+  it('packs as many charts per page as fit by vertical space (more than two)', () => {
+    // Three 80-unit blocks fit in 250 of usable height (3 * 80 = 240 <= 250),
+    // so all three share the first page — the old fixed 2-per-page cap is gone.
+    const breaks = planChartPageBreaks([80, 80, 80], 250);
+    expect(breaks).toEqual([false, false, false]);
+  });
+
+  it('breaks to a new page when the next chart would overflow the page', () => {
+    // 100-unit blocks in 250 usable: two fit (200), the third overflows (300).
+    const breaks = planChartPageBreaks([100, 100, 100, 100, 100], 250);
+    expect(breaks).toEqual([false, false, true, false, true]);
+  });
+
+  it('never breaks before the first chart, even if it is oversized', () => {
+    expect(planChartPageBreaks([300], 250)).toEqual([false]);
+    // An oversized chart takes its own page; the next chart starts a fresh page.
+    expect(planChartPageBreaks([300, 50], 250)).toEqual([false, true]);
+  });
+
+  it('returns an empty array for no charts', () => {
+    expect(planChartPageBreaks([], 250)).toEqual([]);
+  });
+});

--- a/packages/api/routes/pdf-chart-layout.ts
+++ b/packages/api/routes/pdf-chart-layout.ts
@@ -1,0 +1,27 @@
+// packages/api/routes/pdf-chart-layout.ts
+
+/**
+ * Decide page breaks for charts flowed down PDF pages, packing as many as fit by
+ * available vertical space — no fixed per-page count.
+ *
+ * Given each chart's block height (label + image + gap) and the usable height of a
+ * page, returns, for each chart in order, whether a new page must start before it.
+ * The first chart never triggers a break, so an oversized chart still renders on
+ * its own page rather than being dropped.
+ */
+export function planChartPageBreaks(blockHeights: number[], usableHeight: number): boolean[] {
+  const breaks: boolean[] = [];
+  let used = 0; // height consumed on the current page
+
+  blockHeights.forEach((height, i) => {
+    if (i > 0 && used + height > usableHeight) {
+      breaks.push(true); // overflow → this chart starts a new page
+      used = height;
+    } else {
+      breaks.push(false);
+      used += height;
+    }
+  });
+
+  return breaks;
+}

--- a/packages/api/routes/report-routes.ts
+++ b/packages/api/routes/report-routes.ts
@@ -6,6 +6,7 @@
 import express, { type Express } from "express";
 import rateLimit from "express-rate-limit";
 import { ReportService } from "../services/report-service";
+import { planChartPageBreaks } from "./pdf-chart-layout";
 import { requireAuth, requireAIEnabled, type AuthenticatedRequest } from "../middleware";
 import { storage } from "../storage";
 import {
@@ -3702,10 +3703,6 @@ async function enforcePublicSnapshotAccess(
 // number of synchronous jsPDF getImageProperties/addImage calls per request.
 const MAX_CHART_IMAGES = 20;
 
-// Trend charts flowed per PDF page. 2 keeps each chart legible at roughly
-// half-height on A4 portrait; bumping it shrinks the charts.
-const MAX_CHARTS_PER_PDF_PAGE = 2;
-
 /**
  * Normalize the client-supplied chartImages payload into a safe, bounded array.
  * Destructuring defaults only guard `undefined`; a client sending `null`, a
@@ -3741,44 +3738,46 @@ function addTrendChartsToPdf(
   const pageHeight = doc.internal.pageSize.getHeight();
   const margin = 14;
   const imgWidth = pageWidth - margin * 2;
-  const bottomLimit = pageHeight - margin;
-  const maxPerPage = MAX_CHARTS_PER_PDF_PAGE;
+  const startY = 20;
+  const usableHeight = pageHeight - margin - startY;
 
-  // Start the trends section on a fresh page, then flow charts down it.
-  doc.addPage();
-  let yPos = 20;
-  let onPage = 0;
-
+  // Pass 1: measure each chart at full page width, skipping corrupt payloads. A
+  // payload that passes the data:image/png;base64, prefix check but has truncated
+  // bytes throws inside getImageProperties; isolating it here means one bad capture
+  // is dropped rather than aborting the whole PDF with a 500.
+  const measured: Array<{
+    img: { metricCode: string; dataUrl: string; title?: string };
+    imgHeight: number;
+    blockHeight: number;
+  }> = [];
   for (const img of chartImages) {
-    // Isolate each chart: a corrupt payload that passes the data:image/png;base64,
-    // prefix check but has truncated bytes will throw inside getImageProperties or
-    // addImage. Catching per-chart means one bad capture skips rather than aborting
-    // the entire PDF with a 500.
     try {
       const props = doc.getImageProperties(img.dataUrl);
       const imgHeight = (props.height / props.width) * imgWidth;
-      const blockHeight = 6 + imgHeight + 10; // label + image + gap
-
-      // Break to a new page when the page is full (max per page) or the next
-      // chart would overflow the bottom margin. Never break before the first
-      // chart on a page, so an oversized chart still renders.
-      if (onPage > 0 && (onPage >= maxPerPage || yPos + blockHeight > bottomLimit)) {
-        doc.addPage();
-        yPos = 20;
-        onPage = 0;
-      }
-
-      doc.setFontSize(14);
-      doc.setTextColor(40, 40, 40);
-      doc.text(img.title || metricLabels[img.metricCode] || img.metricCode, margin, yPos);
-      yPos += 6;
-      doc.addImage(img.dataUrl, 'PNG', margin, yPos, imgWidth, imgHeight);
-      yPos += imgHeight + 10;
-      onPage += 1;
+      measured.push({ img, imgHeight, blockHeight: 6 + imgHeight + 10 }); // label + image + gap
     } catch (err) {
       console.error('[pdf] skipping corrupt chart for', img.metricCode, err);
     }
   }
+  if (!measured.length) return;
+
+  // Pass 2: pack as many charts per page as fit by vertical space (no fixed
+  // per-page count), then flow them down the pages.
+  const breaks = planChartPageBreaks(measured.map((m) => m.blockHeight), usableHeight);
+  doc.addPage();
+  let yPos = startY;
+  measured.forEach(({ img, imgHeight }, i) => {
+    if (breaks[i]) {
+      doc.addPage();
+      yPos = startY;
+    }
+    doc.setFontSize(14);
+    doc.setTextColor(40, 40, 40);
+    doc.text(img.title || metricLabels[img.metricCode] || img.metricCode, margin, yPos);
+    yPos += 6;
+    doc.addImage(img.dataUrl, 'PNG', margin, yPos, imgWidth, imgHeight);
+    yPos += imgHeight + 10;
+  });
 }
 
 async function generatePDF(report: any, reportData: any, format: 'visual' | 'simplified' = 'simplified', org?: ReportOrg, chartImages: Array<{ metricCode: string; dataUrl: string; title?: string }> = []): Promise<jsPDF> {

--- a/packages/api/services/__tests__/cohort-label.test.ts
+++ b/packages/api/services/__tests__/cohort-label.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { buildCohortLabel } from '../cohort-label';
+
+describe('buildCohortLabel', () => {
+  it('combines team names with a parenthesized demographic qualifier', () => {
+    expect(buildCohortLabel(['Varsity'], 'Male', ['WR'])).toBe('Varsity (Male, WR)');
+  });
+
+  it('joins multiple teams and multiple positions', () => {
+    expect(buildCohortLabel(['Varsity', 'JV'], undefined, ['WR', 'CB'])).toBe(
+      'Varsity, JV (WR, CB)',
+    );
+  });
+
+  it('returns just the teams when there is no demographic filter', () => {
+    expect(buildCohortLabel(['Varsity', 'JV'], undefined, [])).toBe('Varsity, JV');
+  });
+
+  it('returns just the demographic qualifier when there are no teams', () => {
+    expect(buildCohortLabel([], 'Female', ['GK'])).toBe('Female, GK');
+  });
+
+  it('returns undefined when there is no filter at all (org-wide)', () => {
+    expect(buildCohortLabel([], undefined, [])).toBeUndefined();
+    expect(buildCohortLabel([], undefined, undefined)).toBeUndefined();
+  });
+});

--- a/packages/api/services/__tests__/report-distributions.test.ts
+++ b/packages/api/services/__tests__/report-distributions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeDistribution, MAX_DISTRIBUTION_POINTS } from '../report-distributions';
+import { computeDistribution } from '../report-distributions';
 
 describe('computeDistribution', () => {
   it('computes five-number stats from the full set', () => {

--- a/packages/api/services/__tests__/report-distributions.test.ts
+++ b/packages/api/services/__tests__/report-distributions.test.ts
@@ -2,44 +2,41 @@ import { describe, it, expect } from 'vitest';
 import { computeDistribution } from '../report-distributions';
 
 describe('computeDistribution', () => {
-  it('computes five-number stats from the full set; values exclude the athlete', () => {
-    const d = computeDistribution([10, 20, 30, 40, 50], 30, 100)!;
+  it('computes five-number stats from the full population (peers + athlete); values are the peers', () => {
+    // peers already exclude the focal athlete (removed by id upstream)
+    const d = computeDistribution([10, 20, 40, 50], 30)!;
+    // stats population = peers + athlete = [10,20,30,40,50]
     expect(d.stats.min).toBe(10);
     expect(d.stats.max).toBe(50);
     expect(d.stats.median).toBe(30);
     expect(d.stats.q1).toBeCloseTo(20, 5);
     expect(d.stats.q3).toBeCloseTo(40, 5);
     expect(d.athleteValue).toBe(30);
-    // One occurrence of the athlete's own value (30) is removed from the dots.
+    // values are the peers only (athlete is added back by the consumer as the marker)
     expect(d.values).toEqual([10, 20, 40, 50]);
-    expect(d.values).toHaveLength(4);
   });
 
   it('returns null for fewer than 2 peers', () => {
-    expect(computeDistribution([42], 42, 100)).toBeNull();
-    expect(computeDistribution([], 1, 100)).toBeNull();
+    expect(computeDistribution([42], 42)).toBeNull();
+    expect(computeDistribution([], 1)).toBeNull();
   });
 
-  it('samples values deterministically down to the cap; stats use the full set; athlete excluded', () => {
-    const full = Array.from({ length: 1000 }, (_, i) => i + 1); // 1..1000
-    const d = computeDistribution(full, 500, 150)!;
-    expect(d.values.length).toBeLessThanOrEqual(150);
+  it('does not sample — returns every peer so counts are exact for large orgs', () => {
+    const peers = Array.from({ length: 1000 }, (_, i) => i + 1); // 1..1000
+    const d = computeDistribution(peers, 500)!;
+    expect(d.values).toHaveLength(1000);
     expect(d.stats.min).toBe(1);
     expect(d.stats.max).toBe(1000);
-    expect(computeDistribution(full, 500, 150)!.values).toEqual(d.values);
-    // The athlete's own value is removed before sampling, so it never appears as a dot.
-    expect(d.values).not.toContain(500);
+    // a peer legitimately sharing the athlete's value is kept (exclusion is by id upstream)
+    expect(d.values).toContain(500);
   });
 
-  it('does not sample when under the cap; excludes one occurrence of the athlete value', () => {
-    const d = computeDistribution([1, 2, 3, 4], 3, 150)!;
-    expect(d.values).toEqual([1, 2, 4]);
-  });
-
-  it('returns sorted values for unsorted input under the cap; nothing removed when athlete absent', () => {
-    const d = computeDistribution([40, 10, 30, 20], 25, 150)!;
+  it('returns sorted values for unsorted peer input', () => {
+    const d = computeDistribution([40, 10, 30, 20], 25)!;
     expect(d.values).toEqual([10, 20, 30, 40]);
+    // stats population includes the athlete (25)
     expect(d.stats.min).toBe(10);
+    expect(d.stats.median).toBe(25);
     expect(d.stats.max).toBe(40);
   });
 });

--- a/packages/api/services/__tests__/report-distributions.test.ts
+++ b/packages/api/services/__tests__/report-distributions.test.ts
@@ -31,4 +31,11 @@ describe('computeDistribution', () => {
     const d = computeDistribution([1, 2, 3, 4], 3, 150)!;
     expect(d.values).toEqual([1, 2, 3, 4]);
   });
+
+  it('returns sorted values for unsorted input under the cap', () => {
+    const d = computeDistribution([40, 10, 30, 20], 25, 150)!;
+    expect(d.values).toEqual([10, 20, 30, 40]);
+    expect(d.stats.min).toBe(10);
+    expect(d.stats.max).toBe(40);
+  });
 });

--- a/packages/api/services/__tests__/report-distributions.test.ts
+++ b/packages/api/services/__tests__/report-distributions.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { computeDistribution, MAX_DISTRIBUTION_POINTS } from '../report-distributions';
+
+describe('computeDistribution', () => {
+  it('computes five-number stats from the full set', () => {
+    const d = computeDistribution([10, 20, 30, 40, 50], 30, 100)!;
+    expect(d.stats.min).toBe(10);
+    expect(d.stats.max).toBe(50);
+    expect(d.stats.median).toBe(30);
+    expect(d.stats.q1).toBeCloseTo(20, 5);
+    expect(d.stats.q3).toBeCloseTo(40, 5);
+    expect(d.athleteValue).toBe(30);
+    expect(d.values).toHaveLength(5);
+  });
+
+  it('returns null for fewer than 2 peers', () => {
+    expect(computeDistribution([42], 42, 100)).toBeNull();
+    expect(computeDistribution([], 1, 100)).toBeNull();
+  });
+
+  it('samples values deterministically down to the cap; stats use the full set', () => {
+    const full = Array.from({ length: 1000 }, (_, i) => i + 1); // 1..1000
+    const d = computeDistribution(full, 500, 150)!;
+    expect(d.values.length).toBeLessThanOrEqual(150);
+    expect(d.stats.min).toBe(1);
+    expect(d.stats.max).toBe(1000);
+    expect(computeDistribution(full, 500, 150)!.values).toEqual(d.values);
+  });
+
+  it('does not sample when under the cap', () => {
+    const d = computeDistribution([1, 2, 3, 4], 3, 150)!;
+    expect(d.values).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/packages/api/services/__tests__/report-distributions.test.ts
+++ b/packages/api/services/__tests__/report-distributions.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { computeDistribution } from '../report-distributions';
 
 describe('computeDistribution', () => {
-  it('computes five-number stats from the full set', () => {
+  it('computes five-number stats from the full set; values exclude the athlete', () => {
     const d = computeDistribution([10, 20, 30, 40, 50], 30, 100)!;
     expect(d.stats.min).toBe(10);
     expect(d.stats.max).toBe(50);
@@ -10,7 +10,9 @@ describe('computeDistribution', () => {
     expect(d.stats.q1).toBeCloseTo(20, 5);
     expect(d.stats.q3).toBeCloseTo(40, 5);
     expect(d.athleteValue).toBe(30);
-    expect(d.values).toHaveLength(5);
+    // One occurrence of the athlete's own value (30) is removed from the dots.
+    expect(d.values).toEqual([10, 20, 40, 50]);
+    expect(d.values).toHaveLength(4);
   });
 
   it('returns null for fewer than 2 peers', () => {
@@ -18,21 +20,23 @@ describe('computeDistribution', () => {
     expect(computeDistribution([], 1, 100)).toBeNull();
   });
 
-  it('samples values deterministically down to the cap; stats use the full set', () => {
+  it('samples values deterministically down to the cap; stats use the full set; athlete excluded', () => {
     const full = Array.from({ length: 1000 }, (_, i) => i + 1); // 1..1000
     const d = computeDistribution(full, 500, 150)!;
     expect(d.values.length).toBeLessThanOrEqual(150);
     expect(d.stats.min).toBe(1);
     expect(d.stats.max).toBe(1000);
     expect(computeDistribution(full, 500, 150)!.values).toEqual(d.values);
+    // The athlete's own value is removed before sampling, so it never appears as a dot.
+    expect(d.values).not.toContain(500);
   });
 
-  it('does not sample when under the cap', () => {
+  it('does not sample when under the cap; excludes one occurrence of the athlete value', () => {
     const d = computeDistribution([1, 2, 3, 4], 3, 150)!;
-    expect(d.values).toEqual([1, 2, 3, 4]);
+    expect(d.values).toEqual([1, 2, 4]);
   });
 
-  it('returns sorted values for unsorted input under the cap', () => {
+  it('returns sorted values for unsorted input under the cap; nothing removed when athlete absent', () => {
     const d = computeDistribution([40, 10, 30, 20], 25, 150)!;
     expect(d.values).toEqual([10, 20, 30, 40]);
     expect(d.stats.min).toBe(10);

--- a/packages/api/services/cohort-label.ts
+++ b/packages/api/services/cohort-label.ts
@@ -1,0 +1,22 @@
+// packages/api/services/cohort-label.ts
+
+/**
+ * Build a human-readable label for the peer cohort an individual report compares
+ * against, from the report's filters. Used by the "Where You Stand" caption so a
+ * viewer knows who "the group" is (e.g. "Varsity (Male, WR)").
+ *
+ * Returns undefined when no filter narrows the cohort (org-wide) — callers then
+ * fall back to a generic phrase like "your group".
+ */
+export function buildCohortLabel(
+  teamNames: string[],
+  gender?: string,
+  positions?: string[],
+): string | undefined {
+  const teamPart = teamNames.filter(Boolean).join(', ');
+  const demoPart = [gender, ...(positions ?? [])].filter(Boolean).join(', ');
+
+  if (!teamPart && !demoPart) return undefined;
+  if (teamPart && demoPart) return `${teamPart} (${demoPart})`;
+  return teamPart || demoPart;
+}

--- a/packages/api/services/report-distributions.ts
+++ b/packages/api/services/report-distributions.ts
@@ -5,6 +5,13 @@ import type { MetricDistribution } from '@shared/report-trends-types';
 export const MAX_DISTRIBUTION_POINTS = 150;
 
 /**
+ * The direction-agnostic core of a distribution. The caller attaches `direction`
+ * (metric metadata) to form the full {@link MetricDistribution}; this keeps the
+ * math pure and independent of higher/lower-is-better.
+ */
+type DistributionCore = Omit<MetricDistribution, 'direction'>;
+
+/**
  * Build a peer distribution for one metric. Stats are computed from the FULL
  * peer set; `values` is evenly sampled down to `maxPoints` for display.
  * Returns null when there are fewer than 2 peers (no meaningful box).
@@ -13,7 +20,7 @@ export function computeDistribution(
   peerValues: number[],
   athleteValue: number,
   maxPoints: number = MAX_DISTRIBUTION_POINTS,
-): MetricDistribution | null {
+): DistributionCore | null {
   if (!peerValues || peerValues.length < 2) return null;
 
   const sorted = [...peerValues].sort((a, b) => a - b);

--- a/packages/api/services/report-distributions.ts
+++ b/packages/api/services/report-distributions.ts
@@ -25,7 +25,7 @@ export function computeDistribution(
     max: sorted[sorted.length - 1],
   };
 
-  let values = peerValues;
+  let values = sorted;
   if (peerValues.length > maxPoints) {
     // Even, deterministic down-sampling of the sorted set.
     const step = peerValues.length / maxPoints;

--- a/packages/api/services/report-distributions.ts
+++ b/packages/api/services/report-distributions.ts
@@ -2,8 +2,6 @@
 import { quantile } from 'simple-statistics';
 import type { MetricDistribution } from '@shared/report-trends-types';
 
-export const MAX_DISTRIBUTION_POINTS = 150;
-
 /**
  * The direction-agnostic core of a distribution. The caller attaches `direction`
  * (metric metadata) to form the full {@link MetricDistribution}; this keeps the
@@ -12,40 +10,33 @@ export const MAX_DISTRIBUTION_POINTS = 150;
 type DistributionCore = Omit<MetricDistribution, 'direction'>;
 
 /**
- * Build a peer distribution for one metric. Stats are computed from the FULL
- * peer set; `values` is evenly sampled down to `maxPoints` for display.
- * Returns null when there are fewer than 2 peers (no meaningful box).
+ * Build a peer distribution for one metric.
+ *
+ * `peers` are the org-wide best-per-athlete values with the focal athlete already
+ * removed BY ID (upstream), so the athlete is never counted among their own peers.
+ * `values` (the histogram/dot inputs) are the peers, sorted; the consumer adds the
+ * athlete back as the highlighted marker. `stats` (five-number summary) are taken
+ * from the full population — the peers plus the athlete — matching the percentile.
+ *
+ * Values are NOT sampled: the histogram derives exact per-range counts from them.
+ * Returns null when there are fewer than 2 peers (no meaningful distribution).
  */
 export function computeDistribution(
-  peerValues: number[],
+  peers: number[],
   athleteValue: number,
-  maxPoints: number = MAX_DISTRIBUTION_POINTS,
 ): DistributionCore | null {
-  if (!peerValues || peerValues.length < 2) return null;
+  if (!peers || peers.length < 2) return null;
 
-  const sorted = [...peerValues].sort((a, b) => a - b);
+  const population = [...peers, athleteValue].sort((a, b) => a - b);
   const stats = {
-    min: sorted[0],
-    q1: quantile(sorted, 0.25),
-    median: quantile(sorted, 0.5),
-    q3: quantile(sorted, 0.75),
-    max: sorted[sorted.length - 1],
+    min: population[0],
+    q1: quantile(population, 0.25),
+    median: quantile(population, 0.5),
+    q3: quantile(population, 0.75),
+    max: population[population.length - 1],
   };
 
-  // Peers shown as dots exclude the athlete's own value (drawn separately as the
-  // marker). Remove one occurrence BEFORE sampling so exclusion is deterministic
-  // at any size. Stats above still reflect the full population (matching the
-  // percentile, which includes the athlete).
-  const peers = [...sorted];
-  const selfIdx = peers.indexOf(athleteValue);
-  if (selfIdx !== -1) peers.splice(selfIdx, 1);
-
-  let values = peers;
-  if (peers.length > maxPoints) {
-    // Even, deterministic down-sampling of the athlete-excluded peers.
-    const step = peers.length / maxPoints;
-    values = Array.from({ length: maxPoints }, (_, i) => peers[Math.floor(i * step)]);
-  }
+  const values = [...peers].sort((a, b) => a - b);
 
   return { values, athleteValue, stats };
 }

--- a/packages/api/services/report-distributions.ts
+++ b/packages/api/services/report-distributions.ts
@@ -25,11 +25,19 @@ export function computeDistribution(
     max: sorted[sorted.length - 1],
   };
 
-  let values = sorted;
-  if (peerValues.length > maxPoints) {
-    // Even, deterministic down-sampling of the sorted set.
-    const step = peerValues.length / maxPoints;
-    values = Array.from({ length: maxPoints }, (_, i) => sorted[Math.floor(i * step)]);
+  // Peers shown as dots exclude the athlete's own value (drawn separately as the
+  // marker). Remove one occurrence BEFORE sampling so exclusion is deterministic
+  // at any size. Stats above still reflect the full population (matching the
+  // percentile, which includes the athlete).
+  const peers = [...sorted];
+  const selfIdx = peers.indexOf(athleteValue);
+  if (selfIdx !== -1) peers.splice(selfIdx, 1);
+
+  let values = peers;
+  if (peers.length > maxPoints) {
+    // Even, deterministic down-sampling of the athlete-excluded peers.
+    const step = peers.length / maxPoints;
+    values = Array.from({ length: maxPoints }, (_, i) => peers[Math.floor(i * step)]);
   }
 
   return { values, athleteValue, stats };

--- a/packages/api/services/report-distributions.ts
+++ b/packages/api/services/report-distributions.ts
@@ -1,0 +1,36 @@
+// packages/api/services/report-distributions.ts
+import { quantile } from 'simple-statistics';
+import type { MetricDistribution } from '@shared/report-trends-types';
+
+export const MAX_DISTRIBUTION_POINTS = 150;
+
+/**
+ * Build a peer distribution for one metric. Stats are computed from the FULL
+ * peer set; `values` is evenly sampled down to `maxPoints` for display.
+ * Returns null when there are fewer than 2 peers (no meaningful box).
+ */
+export function computeDistribution(
+  peerValues: number[],
+  athleteValue: number,
+  maxPoints: number = MAX_DISTRIBUTION_POINTS,
+): MetricDistribution | null {
+  if (!peerValues || peerValues.length < 2) return null;
+
+  const sorted = [...peerValues].sort((a, b) => a - b);
+  const stats = {
+    min: sorted[0],
+    q1: quantile(sorted, 0.25),
+    median: quantile(sorted, 0.5),
+    q3: quantile(sorted, 0.75),
+    max: sorted[sorted.length - 1],
+  };
+
+  let values = peerValues;
+  if (peerValues.length > maxPoints) {
+    // Even, deterministic down-sampling of the sorted set.
+    const step = peerValues.length / maxPoints;
+    values = Array.from({ length: maxPoints }, (_, i) => sorted[Math.floor(i * step)]);
+  }
+
+  return { values, athleteValue, stats };
+}

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -31,6 +31,7 @@ import { type MetricExplanation } from '@shared/metric-explanations';
 import { getMetricExplanationsMap } from './metric-explanation-service';
 import { assembleTrends } from './report-trends';
 import { computeDistribution } from './report-distributions';
+import { buildCohortLabel } from './cohort-label';
 import { resolveChartSelection, type ChartSelection } from '@shared/report-charts';
 import type { ReportTrends, ReportDistributions } from '@shared/report-trends-types';
 import type { BenchmarkComparison } from '@shared/benchmark-types';
@@ -147,6 +148,7 @@ interface IndividualReportData {
   orgBranding?: OrgBranding;
   trends?: ReportTrends; // present only when reportConfig.showTrends is true
   distributions?: ReportDistributions;
+  comparisonLabel?: string; // cohort name for the "Where You Stand" caption (undefined = org-wide)
 }
 
 export class ReportService extends BaseService {
@@ -400,16 +402,19 @@ export class ReportService extends BaseService {
       }
     }
 
-    // Calculate org-wide percentiles and team averages (always org-wide, not filtered by event)
-    // Note: Don't pass eventId here - org-wide percentiles should compare against all org athletes
+    // Calculate percentiles and team averages against the report's peer cohort
+    // (narrowed by config.filters — team/gender/positions — or the whole org when
+    // no filters are set). eventId is intentionally NOT passed: the cohort spans
+    // all events so the athlete is ranked against every comparable performance.
     const { percentiles, teamAverages, peerValues } = await this.calculatePercentilesAndAverages(
       athleteId,
       report.organizationId,
       config.metrics,
       bestPerformances,
       startDate,
-      endDate
-      // eventId intentionally not passed - org percentiles should be org-wide
+      endDate,
+      undefined, // eventId intentionally not passed - cohort spans all events
+      config.filters
     );
 
     // Calculate event percentiles if requested
@@ -475,6 +480,22 @@ export class ReportService extends BaseService {
       if (Object.keys(distributions).length === 0) distributions = undefined;
     }
 
+    // Human label for the peer cohort (names the group in the "Where You Stand"
+    // caption). Undefined when no filter narrows the cohort → frontend says "your group".
+    let comparisonLabel: string | undefined;
+    const f = config.filters;
+    if (f && (f.teamIds?.length || f.gender || f.positions?.length)) {
+      let filterTeamNames: string[] = [];
+      if (f.teamIds?.length) {
+        const rows = await db
+          .select({ name: teams.name })
+          .from(teams)
+          .where(inArray(teams.id, f.teamIds));
+        filterTeamNames = rows.map((r) => r.name);
+      }
+      comparisonLabel = buildCohortLabel(filterTeamNames, f.gender, f.positions);
+    }
+
     const athletePerformance: AthletePerformance = {
       userId: athlete.id,
       userName: athlete.fullName,
@@ -537,6 +558,7 @@ export class ReportService extends BaseService {
       eventContext,
       trends,
       distributions,
+      comparisonLabel,
     };
   }
 
@@ -571,52 +593,48 @@ export class ReportService extends BaseService {
     athletePerformances: Record<string, number>,
     startDate: string,
     endDate: string,
-    eventId?: string
+    eventId?: string,
+    filters?: ReportFilters
   ): Promise<{ percentiles: Record<string, number>; teamAverages: Record<string, number>; peerValues: Record<string, number[]> }> {
     const percentiles: Record<string, number> = {};
     const teamAverages: Record<string, number> = {};
     const peerValues: Record<string, number[]> = {};
+
+    // Peer cohort = org athletes narrowed by the report's filters (team / gender /
+    // positions). With no filters this is the whole org (unchanged behavior). One
+    // query for all metrics; grouped per metric below. This peer set feeds the
+    // percentile, team average, AND the distribution, so they stay consistent.
+    const cohortMeasurements = await this.getFilteredMeasurements(
+      organizationId,
+      metrics,
+      filters,
+      startDate,
+      endDate,
+      eventId
+    );
 
     for (const metric of metrics) {
       if (athletePerformances[metric] === undefined) {
         continue;
       }
 
-      // Get all measurements for this metric in the organization (optionally filtered by event)
-      const measurementConditions = [
-        eq(measurements.organizationId, organizationId),
-        eq(measurements.metric, metric),
-        gte(measurements.date, startDate),
-        lte(measurements.date, endDate),
-      ];
-
-      if (eventId) {
-        measurementConditions.push(eq(measurements.eventId, eventId));
-      }
-
-      const allMeasurements = await db
-        .select({
-          value: measurements.value,
-          userId: measurements.userId,
-        })
-        .from(measurements)
-        .where(and(...measurementConditions));
-
-      // Get best performance per athlete
+      // Get best performance per athlete within the cohort
       const athleteBestMap = new Map<string, number>();
       const metricInfo = await this.getMetricInfo(metric);
 
-      for (const m of allMeasurements) {
-        const value = parseFloat(m.value);
-        const current = athleteBestMap.get(m.userId);
+      for (const r of cohortMeasurements) {
+        if (r.measurement.metric !== metric) continue;
+        const value = parseFloat(r.measurement.value);
+        const userId = r.measurement.userId;
+        const current = athleteBestMap.get(userId);
 
         if (current === undefined) {
-          athleteBestMap.set(m.userId, value);
+          athleteBestMap.set(userId, value);
         } else {
           if (metricInfo.lowerIsBetter) {
-            if (value < current) athleteBestMap.set(m.userId, value);
+            if (value < current) athleteBestMap.set(userId, value);
           } else {
-            if (value > current) athleteBestMap.set(m.userId, value);
+            if (value > current) athleteBestMap.set(userId, value);
           }
         }
       }

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -490,7 +490,9 @@ export class ReportService extends BaseService {
         const rows = await db
           .select({ name: teams.name })
           .from(teams)
-          .where(inArray(teams.id, f.teamIds))
+          // Scope to this report's org so a crafted cross-org teamId can't leak
+          // another org's team name into the caption.
+          .where(and(eq(teams.organizationId, report.organizationId), inArray(teams.id, f.teamIds)))
           .orderBy(teams.name); // deterministic label order for multi-team cohorts
         filterTeamNames = rows.map((r) => r.name);
       }

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -465,7 +465,12 @@ export class ReportService extends BaseService {
         const athleteValue = bestPerformances[metric];
         if (athleteValue === undefined) continue;
         const dist = computeDistribution(peerValues[metric] ?? [], athleteValue);
-        if (dist) distributions[metric] = dist;
+        if (dist) {
+          // getMetricInfo memoizes (warmed by the bestPerformances loop), so this
+          // is a cache hit; direction lets the histogram annotate the "better" side.
+          const info = await this.getMetricInfo(metric);
+          distributions[metric] = { ...dist, direction: info.lowerIsBetter ? 'lower' : 'higher' };
+        }
       }
       if (Object.keys(distributions).length === 0) distributions = undefined;
     }

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -490,7 +490,8 @@ export class ReportService extends BaseService {
         const rows = await db
           .select({ name: teams.name })
           .from(teams)
-          .where(inArray(teams.id, f.teamIds));
+          .where(inArray(teams.id, f.teamIds))
+          .orderBy(teams.name); // deterministic label order for multi-team cohorts
         filterTeamNames = rows.map((r) => r.name);
       }
       comparisonLabel = buildCohortLabel(filterTeamNames, f.gender, f.positions);

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -31,7 +31,7 @@ import { type MetricExplanation } from '@shared/metric-explanations';
 import { getMetricExplanationsMap } from './metric-explanation-service';
 import { assembleTrends } from './report-trends';
 import { computeDistribution } from './report-distributions';
-import { resolveChartSelection } from '@shared/report-charts';
+import { resolveChartSelection, type ChartSelection } from '@shared/report-charts';
 import type { ReportTrends, ReportDistributions } from '@shared/report-trends-types';
 import type { BenchmarkComparison } from '@shared/benchmark-types';
 
@@ -70,7 +70,7 @@ interface ReportConfig {
   compositeIndex?: CompositeIndexConfig;
   filters?: ReportFilters;
   showTrends?: boolean; // when true, individual reports include time-series trends
-  charts?: { radar?: boolean; benchmarkStanding?: boolean; trends?: boolean; distribution?: boolean };
+  charts?: Partial<ChartSelection>;
 }
 
 interface AthletePerformance {

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -30,7 +30,9 @@ import { evaluateTierBenchmark as evaluateTierBenchmarkPure } from './benchmark-
 import { type MetricExplanation } from '@shared/metric-explanations';
 import { getMetricExplanationsMap } from './metric-explanation-service';
 import { assembleTrends } from './report-trends';
-import type { ReportTrends } from '@shared/report-trends-types';
+import { computeDistribution } from './report-distributions';
+import { resolveChartSelection } from '@shared/report-charts';
+import type { ReportTrends, ReportDistributions } from '@shared/report-trends-types';
 import type { BenchmarkComparison } from '@shared/benchmark-types';
 
 interface TimeframeConfig {
@@ -68,6 +70,7 @@ interface ReportConfig {
   compositeIndex?: CompositeIndexConfig;
   filters?: ReportFilters;
   showTrends?: boolean; // when true, individual reports include time-series trends
+  charts?: { radar?: boolean; benchmarkStanding?: boolean; trends?: boolean; distribution?: boolean };
 }
 
 interface AthletePerformance {
@@ -143,6 +146,7 @@ interface IndividualReportData {
   eventContext?: EventContext; // Present when eventId filter is used
   orgBranding?: OrgBranding;
   trends?: ReportTrends; // present only when reportConfig.showTrends is true
+  distributions?: ReportDistributions;
 }
 
 export class ReportService extends BaseService {
@@ -429,9 +433,11 @@ export class ReportService extends BaseService {
       config
     );
 
+    const chartSelection = resolveChartSelection(config);
+
     // Build time-series trends when the report opts in (additive; off by default)
     let trends: ReportTrends | undefined;
-    if (config.showTrends) {
+    if (chartSelection.trends) {
       const directions: Record<string, 'higher' | 'lower'> = {};
       // getMetricInfo memoizes, but a selected metric with no measurements in
       // range was not pre-warmed by the bestPerformances loop above — resolve
@@ -449,6 +455,13 @@ export class ReportService extends BaseService {
         config.metrics,
         directions,
         benchmarkComparisons,
+      );
+    }
+
+    let distributions: ReportDistributions | undefined;
+    if (chartSelection.distribution) {
+      distributions = await this.calculateDistributions(
+        report.organizationId, config.metrics, bestPerformances, startDate, endDate,
       );
     }
 
@@ -513,6 +526,7 @@ export class ReportService extends BaseService {
       metricExplanations,
       eventContext,
       trends,
+      distributions,
     };
   }
 
@@ -612,6 +626,44 @@ export class ReportService extends BaseService {
     }
 
     return { percentiles, teamAverages };
+  }
+
+  /** Org-wide peer distribution per metric (same peer set as the percentile). */
+  async calculateDistributions(
+    organizationId: string,
+    metrics: string[],
+    athletePerformances: Record<string, number>,
+    startDate: string,
+    endDate: string,
+  ): Promise<ReportDistributions> {
+    const distributions: ReportDistributions = {};
+    for (const metric of metrics) {
+      const athleteValue = athletePerformances[metric];
+      if (athleteValue === undefined) continue;
+
+      const rows = await db
+        .select({ value: measurements.value, userId: measurements.userId })
+        .from(measurements)
+        .where(and(
+          eq(measurements.organizationId, organizationId),
+          eq(measurements.metric, metric),
+          gte(measurements.date, startDate),
+          lte(measurements.date, endDate),
+        ));
+
+      const info = await this.getMetricInfo(metric);
+      const bestMap = new Map<string, number>();
+      for (const r of rows) {
+        const v = parseFloat(r.value);
+        const cur = bestMap.get(r.userId);
+        if (cur === undefined) bestMap.set(r.userId, v);
+        else if (info.lowerIsBetter ? v < cur : v > cur) bestMap.set(r.userId, v);
+      }
+
+      const dist = computeDistribution(Array.from(bestMap.values()), athleteValue);
+      if (dist) distributions[metric] = dist;
+    }
+    return distributions;
   }
 
   /**

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -634,9 +634,14 @@ export class ReportService extends BaseService {
         // Calculate team average (using best performance per athlete, same as team reports)
         teamAverages[metric] = mean(allValues);
 
-        // Expose the per-metric peer best-values so callers (e.g. distributions)
-        // can reuse this peer set instead of re-running the same query.
-        peerValues[metric] = allValues;
+        // Expose the per-metric peer best-values (EXCLUDING the focal athlete by
+        // id) so callers (e.g. distributions) reuse this peer set without a second
+        // query, and the athlete is never counted among their own peers — correct
+        // even when an event filter makes the athlete's shown value differ from
+        // their org-wide best.
+        peerValues[metric] = Array.from(athleteBestMap.entries())
+          .filter(([userId]) => userId !== athleteId)
+          .map(([, value]) => value);
       }
     }
 

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -402,7 +402,7 @@ export class ReportService extends BaseService {
 
     // Calculate org-wide percentiles and team averages (always org-wide, not filtered by event)
     // Note: Don't pass eventId here - org-wide percentiles should compare against all org athletes
-    const { percentiles, teamAverages } = await this.calculatePercentilesAndAverages(
+    const { percentiles, teamAverages, peerValues } = await this.calculatePercentilesAndAverages(
       athleteId,
       report.organizationId,
       config.metrics,
@@ -460,9 +460,14 @@ export class ReportService extends BaseService {
 
     let distributions: ReportDistributions | undefined;
     if (chartSelection.distribution) {
-      distributions = await this.calculateDistributions(
-        report.organizationId, config.metrics, bestPerformances, startDate, endDate,
-      );
+      distributions = {};
+      for (const metric of config.metrics) {
+        const athleteValue = bestPerformances[metric];
+        if (athleteValue === undefined) continue;
+        const dist = computeDistribution(peerValues[metric] ?? [], athleteValue);
+        if (dist) distributions[metric] = dist;
+      }
+      if (Object.keys(distributions).length === 0) distributions = undefined;
     }
 
     const athletePerformance: AthletePerformance = {
@@ -562,9 +567,10 @@ export class ReportService extends BaseService {
     startDate: string,
     endDate: string,
     eventId?: string
-  ): Promise<{ percentiles: Record<string, number>; teamAverages: Record<string, number> }> {
+  ): Promise<{ percentiles: Record<string, number>; teamAverages: Record<string, number>; peerValues: Record<string, number[]> }> {
     const percentiles: Record<string, number> = {};
     const teamAverages: Record<string, number> = {};
+    const peerValues: Record<string, number[]> = {};
 
     for (const metric of metrics) {
       if (athletePerformances[metric] === undefined) {
@@ -622,48 +628,14 @@ export class ReportService extends BaseService {
 
         // Calculate team average (using best performance per athlete, same as team reports)
         teamAverages[metric] = mean(allValues);
+
+        // Expose the per-metric peer best-values so callers (e.g. distributions)
+        // can reuse this peer set instead of re-running the same query.
+        peerValues[metric] = allValues;
       }
     }
 
-    return { percentiles, teamAverages };
-  }
-
-  /** Org-wide peer distribution per metric (same peer set as the percentile). */
-  async calculateDistributions(
-    organizationId: string,
-    metrics: string[],
-    athletePerformances: Record<string, number>,
-    startDate: string,
-    endDate: string,
-  ): Promise<ReportDistributions> {
-    const distributions: ReportDistributions = {};
-    for (const metric of metrics) {
-      const athleteValue = athletePerformances[metric];
-      if (athleteValue === undefined) continue;
-
-      const rows = await db
-        .select({ value: measurements.value, userId: measurements.userId })
-        .from(measurements)
-        .where(and(
-          eq(measurements.organizationId, organizationId),
-          eq(measurements.metric, metric),
-          gte(measurements.date, startDate),
-          lte(measurements.date, endDate),
-        ));
-
-      const info = await this.getMetricInfo(metric);
-      const bestMap = new Map<string, number>();
-      for (const r of rows) {
-        const v = parseFloat(r.value);
-        const cur = bestMap.get(r.userId);
-        if (cur === undefined) bestMap.set(r.userId, v);
-        else if (info.lowerIsBetter ? v < cur : v > cur) bestMap.set(r.userId, v);
-      }
-
-      const dist = computeDistribution(Array.from(bestMap.values()), athleteValue);
-      if (dist) distributions[metric] = dist;
-    }
-    return distributions;
+    return { percentiles, teamAverages, peerValues };
   }
 
   /**

--- a/packages/shared/__tests__/report-charts.test.ts
+++ b/packages/shared/__tests__/report-charts.test.ts
@@ -20,4 +20,10 @@ describe('resolveChartSelection', () => {
   it('explicit charts overrides legacy showTrends', () => {
     expect(resolveChartSelection({ showTrends: true, charts: { trends: false } }).trends).toBe(false);
   });
+
+  it('treats a present-but-empty charts object as all-off (explicit selection)', () => {
+    expect(resolveChartSelection({ charts: {} })).toEqual({
+      radar: false, benchmarkStanding: false, trends: false, distribution: false,
+    });
+  });
 });

--- a/packages/shared/__tests__/report-charts.test.ts
+++ b/packages/shared/__tests__/report-charts.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { resolveChartSelection } from '../report-charts';
+
+describe('resolveChartSelection', () => {
+  it('uses explicit charts config when present (missing keys -> false)', () => {
+    expect(resolveChartSelection({ charts: { radar: true, distribution: true } })).toEqual({
+      radar: true, benchmarkStanding: false, trends: false, distribution: true,
+    });
+  });
+
+  it('back-compat: absent charts -> radar+benchmark on, trends from showTrends, distribution off', () => {
+    expect(resolveChartSelection({ showTrends: true })).toEqual({
+      radar: true, benchmarkStanding: true, trends: true, distribution: false,
+    });
+    expect(resolveChartSelection({})).toEqual({
+      radar: true, benchmarkStanding: true, trends: false, distribution: false,
+    });
+  });
+
+  it('explicit charts overrides legacy showTrends', () => {
+    expect(resolveChartSelection({ showTrends: true, charts: { trends: false } }).trends).toBe(false);
+  });
+});

--- a/packages/shared/report-charts.ts
+++ b/packages/shared/report-charts.ts
@@ -1,0 +1,37 @@
+// packages/shared/report-charts.ts
+
+export interface ChartSelection {
+  radar: boolean;
+  benchmarkStanding: boolean;
+  trends: boolean;
+  distribution: boolean;
+}
+
+/** Config subset this resolver reads. */
+interface ChartConfigInput {
+  charts?: Partial<ChartSelection>;
+  showTrends?: boolean;
+}
+
+/**
+ * Resolve which report charts are enabled. New reports carry `charts`; legacy
+ * reports (no `charts`) fall back to historical behavior: radar + benchmark
+ * standing on, trends driven by the old `showTrends` flag, distribution off.
+ */
+export function resolveChartSelection(config: ChartConfigInput | undefined | null): ChartSelection {
+  const c = config?.charts;
+  if (c) {
+    return {
+      radar: c.radar ?? false,
+      benchmarkStanding: c.benchmarkStanding ?? false,
+      trends: c.trends ?? false,
+      distribution: c.distribution ?? false,
+    };
+  }
+  return {
+    radar: true,
+    benchmarkStanding: true,
+    trends: config?.showTrends ?? false,
+    distribution: false,
+  };
+}

--- a/packages/shared/report-charts.ts
+++ b/packages/shared/report-charts.ts
@@ -7,6 +7,11 @@ export interface ChartSelection {
   distribution: boolean;
 }
 
+/** Default chart selection for new reports — all charts on. */
+export const DEFAULT_CHART_SELECTION: ChartSelection = {
+  radar: true, benchmarkStanding: true, trends: true, distribution: true,
+};
+
 /** Config subset this resolver reads. */
 interface ChartConfigInput {
   charts?: Partial<ChartSelection>;

--- a/packages/shared/report-charts.ts
+++ b/packages/shared/report-charts.ts
@@ -20,6 +20,8 @@ interface ChartConfigInput {
  */
 export function resolveChartSelection(config: ChartConfigInput | undefined | null): ChartSelection {
   const c = config?.charts;
+  // A present `charts` object is the explicit selection — an empty object means
+  // all charts off (only legacy reports, which have no `charts`, get the defaults).
   if (c) {
     return {
       radar: c.radar ?? false,

--- a/packages/shared/report-trends-types.ts
+++ b/packages/shared/report-trends-types.ts
@@ -40,7 +40,7 @@ export type ReportTrends = Record<string, MetricTrend>;
 
 /** Peer distribution for one metric (org-wide), with the athlete's own value. */
 export interface MetricDistribution {
-  values: number[];   // peer best-performances, sampled for display (<= cap)
+  values: number[];   // peer best-performances (sorted; all peers, not sampled)
   athleteValue: number;
   stats: { min: number; q1: number; median: number; q3: number; max: number }; // from the FULL set
   direction: 'higher' | 'lower';  // higher-is-better vs lower-is-better (for the "better" axis annotation)

--- a/packages/shared/report-trends-types.ts
+++ b/packages/shared/report-trends-types.ts
@@ -37,3 +37,13 @@ export interface MetricTrend {
 
 /** Map of metric code -> trend. Present on a report only when showTrends is on. */
 export type ReportTrends = Record<string, MetricTrend>;
+
+/** Peer distribution for one metric (org-wide), with the athlete's own value. */
+export interface MetricDistribution {
+  values: number[];   // peer best-performances, sampled for display (<= cap)
+  athleteValue: number;
+  stats: { min: number; q1: number; median: number; q3: number; max: number }; // from the FULL set
+}
+
+/** Map of metric code -> distribution. Present only when the distribution chart is enabled. */
+export type ReportDistributions = Record<string, MetricDistribution>;

--- a/packages/shared/report-trends-types.ts
+++ b/packages/shared/report-trends-types.ts
@@ -43,6 +43,7 @@ export interface MetricDistribution {
   values: number[];   // peer best-performances, sampled for display (<= cap)
   athleteValue: number;
   stats: { min: number; q1: number; median: number; q3: number; max: number }; // from the FULL set
+  direction: 'higher' | 'lower';  // higher-is-better vs lower-is-better (for the "better" axis annotation)
 }
 
 /** Map of metric code -> distribution. Present only when the distribution chart is enabled. */

--- a/packages/shared/schema-original.ts
+++ b/packages/shared/schema-original.ts
@@ -2194,11 +2194,18 @@ export const insertReportSchema = createInsertSchema(reports).omit({
     benchmarks: z.object({
       site: z.array(z.string()).optional(), // Site benchmark IDs
       custom: z.array(z.string()).optional(), // Custom benchmark IDs
+      // userDefined applies to team reports only (individual reads benchmarks from site/custom)
       userDefined: z.array(z.object({
         metricCode: z.string(),
         value: z.number().positive(),
         label: z.string().max(100),
       })).optional(),
+    }).optional(),
+    charts: z.object({
+      radar: z.boolean().optional(),
+      benchmarkStanding: z.boolean().optional(),
+      trends: z.boolean().optional(),
+      distribution: z.boolean().optional(),
     }).optional(),
     compositeIndex: z.object({
       enabled: z.boolean(),
@@ -2233,11 +2240,18 @@ export const updateReportSchema = z.object({
     benchmarks: z.object({
       site: z.array(z.string()).optional(),
       custom: z.array(z.string()).optional(),
+      // userDefined applies to team reports only (individual reads benchmarks from site/custom)
       userDefined: z.array(z.object({
         metricCode: z.string(),
         value: z.number().positive(),
         label: z.string().max(100),
       })).optional(),
+    }).optional(),
+    charts: z.object({
+      radar: z.boolean().optional(),
+      benchmarkStanding: z.boolean().optional(),
+      trends: z.boolean().optional(),
+      distribution: z.boolean().optional(),
     }).optional(),
     compositeIndex: z.object({
       enabled: z.boolean(),

--- a/packages/web/src/components/charts/BoxPlotChart.tsx
+++ b/packages/web/src/components/charts/BoxPlotChart.tsx
@@ -48,7 +48,6 @@ interface BoxPlotChartProps {
   selectedGroups?: GroupDefinition[]; // For multi-group analysis
   benchmarks?: BenchmarkLine[]; // Benchmark lines/ranges to display
   showBenchmarks?: boolean; // Whether to show benchmarks
-  compact?: boolean; // Suppress analytics-only chrome (toggle) for embedded/report use
 }
 
 export const BoxPlotChart = React.memo(function BoxPlotChart({
@@ -61,8 +60,7 @@ export const BoxPlotChart = React.memo(function BoxPlotChart({
   showAthleteNames = false,
   selectedGroups,
   benchmarks,
-  showBenchmarks = true,
-  compact = false
+  showBenchmarks = true
 }: BoxPlotChartProps) {
   const { getMetricConfig } = useMetricConfig();
   const chartRef = useRef<ChartJS<'scatter'> | null>(null);
@@ -1529,8 +1527,8 @@ export const BoxPlotChart = React.memo(function BoxPlotChart({
   // Add error boundary wrapper for chart rendering
   return (
     <div className="w-full h-full flex flex-col overflow-hidden">
-      {/* Toggle control for athlete names - only show when swarm mode is enabled (hidden in compact/report mode) */}
-      {showAllPoints && !compact && (
+      {/* Toggle control for athlete names - only show when swarm mode is enabled */}
+      {showAllPoints && (
         <div className="flex items-center space-x-2 mb-4 px-2 flex-shrink-0">
           <Switch
             id="show-names"
@@ -1543,8 +1541,8 @@ export const BoxPlotChart = React.memo(function BoxPlotChart({
         </div>
       )}
 
-      <div className={compact ? 'flex-1 min-h-0' : 'flex-1 overflow-y-auto'}>
-        <div style={{ position: 'relative', minHeight: compact ? '100%' : '400px', height: compact ? '100%' : undefined, width: '100%' }}>
+      <div className="flex-1 overflow-y-auto">
+        <div style={{ position: 'relative', minHeight: '400px', width: '100%' }}>
           {(() => {
             try {
               // Render chart only if there's data and options

--- a/packages/web/src/components/charts/BoxPlotChart.tsx
+++ b/packages/web/src/components/charts/BoxPlotChart.tsx
@@ -48,6 +48,7 @@ interface BoxPlotChartProps {
   selectedGroups?: GroupDefinition[]; // For multi-group analysis
   benchmarks?: BenchmarkLine[]; // Benchmark lines/ranges to display
   showBenchmarks?: boolean; // Whether to show benchmarks
+  compact?: boolean; // Suppress analytics-only chrome (toggle) for embedded/report use
 }
 
 export const BoxPlotChart = React.memo(function BoxPlotChart({
@@ -60,7 +61,8 @@ export const BoxPlotChart = React.memo(function BoxPlotChart({
   showAthleteNames = false,
   selectedGroups,
   benchmarks,
-  showBenchmarks = true
+  showBenchmarks = true,
+  compact = false
 }: BoxPlotChartProps) {
   const { getMetricConfig } = useMetricConfig();
   const chartRef = useRef<ChartJS<'scatter'> | null>(null);
@@ -1527,8 +1529,8 @@ export const BoxPlotChart = React.memo(function BoxPlotChart({
   // Add error boundary wrapper for chart rendering
   return (
     <div className="w-full h-full flex flex-col overflow-hidden">
-      {/* Toggle control for athlete names - only show when swarm mode is enabled */}
-      {showAllPoints && (
+      {/* Toggle control for athlete names - only show when swarm mode is enabled (hidden in compact/report mode) */}
+      {showAllPoints && !compact && (
         <div className="flex items-center space-x-2 mb-4 px-2 flex-shrink-0">
           <Switch
             id="show-names"
@@ -1541,8 +1543,8 @@ export const BoxPlotChart = React.memo(function BoxPlotChart({
         </div>
       )}
 
-      <div className="flex-1 overflow-y-auto">
-        <div style={{ position: 'relative', minHeight: '400px', width: '100%' }}>
+      <div className={compact ? 'flex-1 min-h-0' : 'flex-1 overflow-y-auto'}>
+        <div style={{ position: 'relative', minHeight: compact ? '100%' : '400px', height: compact ? '100%' : undefined, width: '100%' }}>
           {(() => {
             try {
               // Render chart only if there's data and options

--- a/packages/web/src/components/reports/AthleteReportView.tsx
+++ b/packages/web/src/components/reports/AthleteReportView.tsx
@@ -212,7 +212,7 @@ function AthleteIndividualReportView({ report }: { report: Report }) {
                 <TableRow>
                   <TableHead>Metric</TableHead>
                   <TableHead>Best Result</TableHead>
-                  <TableHead>Team Average</TableHead>
+                  <TableHead>Group Average</TableHead>
                   <TableHead>Percentile</TableHead>
                   <TableHead>Benchmark Comparisons</TableHead>
                 </TableRow>

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { BoxPlotChart } from '@/components/charts/BoxPlotChart';
 import type { ReportDistributions } from '@shared/report-trends-types';
+import type { StatisticalSummary } from '@shared/analytics-types';
 
 interface Props {
   athleteId: string;
@@ -29,13 +30,10 @@ export function DistributionSection({
         </p>
         {entries.map(([code, dist]) => {
           const label = metricLabels[code] || code;
-          // Drop one occurrence of the athlete's own value from the peer dots — the
-          // athlete is shown separately as the highlighted star (the box stats still
-          // reflect the full population, computed on the backend).
-          const peerVals = [...dist.values];
-          const selfIdx = peerVals.indexOf(dist.athleteValue);
-          if (selfIdx !== -1) peerVals.splice(selfIdx, 1);
-          const points = peerVals.map((v, i) => ({
+          // dist.values are the peer dots — the backend already excludes one
+          // occurrence of the athlete's own value (before sampling), so the athlete
+          // is not double-plotted. The athlete is added below as the highlighted star.
+          const points = dist.values.map((v, i) => ({
             athleteId: `peer-${i}`,
             athleteName: '',
             value: v,
@@ -49,6 +47,36 @@ export function DistributionSection({
             date: new Date(),
             metric: code,
           });
+          // Pass the backend's full-population five-number summary so the box reflects
+          // the true distribution rather than the sampled dots. Percentiles not carried
+          // by dist.stats are filled monotonically from min/q1/median/q3/max.
+          const s = dist.stats;
+          const statistics: Record<string, StatisticalSummary> = {
+            [code]: {
+              count: dist.values.length + 1,
+              mean: s.median,
+              median: s.median,
+              min: s.min,
+              max: s.max,
+              std: 0,
+              variance: 0,
+              percentiles: {
+                p5: s.min,
+                p10: s.min,
+                p20: s.min,
+                p25: s.q1,
+                p30: s.q1,
+                p40: s.median,
+                p50: s.median,
+                p60: s.median,
+                p70: s.q3,
+                p75: s.q3,
+                p80: s.q3,
+                p90: s.max,
+                p95: s.max,
+              },
+            },
+          };
           return (
             <div
               key={code}
@@ -59,6 +87,7 @@ export function DistributionSection({
               <BoxPlotChart
                 data={points}
                 rawData={points}
+                statistics={statistics}
                 highlightAthlete={athleteId}
                 showAllPoints
                 compact

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -123,7 +123,7 @@ export function DistributionSection({
   const groupLabel = comparisonLabel ?? 'your group';
 
   return (
-    <Card>
+    <Card data-report-chart="distribution" data-report-chart-title="Where You Stand">
       <CardHeader>
         <CardTitle>Where You Stand (vs {groupLabel})</CardTitle>
       </CardHeader>

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -125,7 +125,7 @@ export function DistributionSection({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Where You Stand (vs your group)</CardTitle>
+        <CardTitle>Where You Stand (vs {groupLabel})</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
         {entries.map(([code, dist]) => {

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -1,105 +1,135 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { BoxPlotChart } from '@/components/charts/BoxPlotChart';
-import type { ReportDistributions } from '@shared/report-trends-types';
-import type { StatisticalSummary } from '@shared/analytics-types';
+import type { ReportDistributions, MetricDistribution } from '@shared/report-trends-types';
+import { computeHistogram, percentBetterThanPeers } from './histogram-utils';
 
 interface Props {
-  athleteId: string;
   athleteName: string;
   distributions: ReportDistributions;
   metricLabels?: Record<string, string>;
+  metricUnits?: Record<string, string>;
+  /** Direction-normalized "better than X%" per metric, from the report (preferred). */
+  percentiles?: Record<string, number>;
+}
+
+/** Compact number: integers as-is, otherwise one decimal. */
+function fmt(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}
+
+/**
+ * "Where you stand" histogram for one metric. Bars = how many athletes scored in
+ * each value range; the athlete's bar is highlighted with a "You" tag. A plain
+ * sentence states the percentile so the takeaway lands without reading the chart.
+ */
+function MetricHistogram({
+  dist,
+  label,
+  unit,
+  percentile,
+  captureCode,
+  captureTitle,
+}: {
+  dist: MetricDistribution;
+  label: string;
+  unit?: string;
+  percentile?: number;
+  captureCode: string;
+  captureTitle: string;
+}) {
+  const bins = computeHistogram(dist.values, dist.athleteValue);
+  const maxCount = Math.max(...bins.map((b) => b.count), 1);
+
+  const pct =
+    percentile !== undefined
+      ? Math.max(0, Math.min(100, Math.round(percentile)))
+      : percentBetterThanPeers(dist.values, dist.athleteValue, dist.direction);
+
+  const betterSide = dist.direction === 'higher' ? 'farther right = better' : 'farther left = better';
+  const yourValue = `${fmt(dist.athleteValue)}${unit ? ` ${unit}` : ''}`;
+
+  // SVG layout (viewBox units).
+  const W = 600;
+  const plotLeft = 40;
+  const plotRight = 585;
+  const plotWidth = plotRight - plotLeft;
+  const baseline = 195;
+  const maxBarH = 150;
+  const n = bins.length;
+  const bw = plotWidth / n;
+  const gap = Math.min(8, bw * 0.2);
+  const barW = bw - gap;
+
+  return (
+    <div data-report-chart={`dist:${captureCode}`} data-report-chart-title={captureTitle} className="space-y-1">
+      <p className="text-sm text-foreground">
+        <span className="font-medium">{label}.</span> You scored better than{' '}
+        <span className="font-semibold text-green-600">{pct}% of your group</span> ({yourValue}).
+      </p>
+      <p className="text-xs text-muted-foreground">
+        Each bar shows how many athletes scored in that range · you are the green bar ★
+      </p>
+      <svg viewBox={`0 0 ${W} 240`} className="w-full" role="img" aria-label={`${label} distribution histogram`}>
+        <line x1={plotLeft} y1={baseline} x2={plotRight} y2={baseline} stroke="#cbd5e1" />
+        {bins.map((b, i) => {
+          const h = (b.count / maxCount) * maxBarH;
+          const x = plotLeft + i * bw + gap / 2;
+          const y = baseline - h;
+          const cx = x + barW / 2;
+          return (
+            <g key={i}>
+              <rect x={x} y={y} width={barW} height={h} fill={b.isAthlete ? '#16a34a' : '#cbd5e1'} rx={2} />
+              {b.count > 0 && (
+                <text x={cx} y={y - 4} textAnchor="middle" fontSize={10} fill="#94a3b8">
+                  {b.count}
+                </text>
+              )}
+              {b.isAthlete && (
+                <text x={cx} y={Math.max(12, y - 16)} textAnchor="middle" fontSize={11} fontWeight={700} fill="#16a34a">
+                  ★ You
+                </text>
+              )}
+              <text x={cx} y={210} textAnchor="middle" fontSize={9} fill="#64748b">
+                {`${fmt(b.start)}–${fmt(b.end)}`}
+              </text>
+            </g>
+          );
+        })}
+        <text x={W / 2} y={232} textAnchor="middle" fontSize={11} fill="#64748b">
+          {`${label}${unit ? ` (${unit})` : ''} — ${betterSide}`}
+        </text>
+      </svg>
+    </div>
+  );
 }
 
 export function DistributionSection({
-  athleteId,
   athleteName,
   distributions,
   metricLabels = {},
+  metricUnits = {},
+  percentiles = {},
 }: Props) {
   const entries = Object.entries(distributions);
   if (entries.length === 0) return null;
 
   return (
-    <Card data-report-chart="distribution" data-report-chart-title="Distribution vs peers">
+    <Card data-report-chart="distribution" data-report-chart-title="Where you stand">
       <CardHeader>
         <CardTitle>Where You Stand (vs your group)</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-2">
-        <p className="text-sm text-muted-foreground">
-          Each blue dot is an athlete in your organization with this test; you are the highlighted green star.
-        </p>
+      <CardContent className="space-y-6">
         {entries.map(([code, dist]) => {
           const label = metricLabels[code] || code;
-          // dist.values are the peer dots — the backend already excludes one
-          // occurrence of the athlete's own value (before sampling), so the athlete
-          // is not double-plotted. The athlete is added below as the highlighted star.
-          const points = dist.values.map((v, i) => ({
-            athleteId: `peer-${i}`,
-            athleteName: '',
-            value: v,
-            date: new Date(),
-            metric: code,
-          }));
-          points.push({
-            athleteId,
-            athleteName,
-            value: dist.athleteValue,
-            date: new Date(),
-            metric: code,
-          });
-          // Pass the backend's full-population five-number summary so the box reflects
-          // the true distribution rather than the sampled dots. Percentiles not carried
-          // by dist.stats are filled monotonically from min/q1/median/q3/max.
-          const s = dist.stats;
-          const statistics: Record<string, StatisticalSummary> = {
-            [code]: {
-              count: dist.values.length + 1,
-              mean: s.median,
-              median: s.median,
-              min: s.min,
-              max: s.max,
-              std: 0,
-              variance: 0,
-              percentiles: {
-                p5: s.min,
-                p10: s.min,
-                p20: s.min,
-                p25: s.q1,
-                p30: s.q1,
-                p40: s.median,
-                p50: s.median,
-                p60: s.median,
-                p70: s.q3,
-                p75: s.q3,
-                p80: s.q3,
-                p90: s.max,
-                p95: s.max,
-              },
-            },
-          };
           return (
-            <div
+            <MetricHistogram
               key={code}
-              data-report-chart={`dist:${code}`}
-              data-report-chart-title={`${label} — distribution`}
-              className="h-[260px]"
-            >
-              <BoxPlotChart
-                data={points}
-                rawData={points}
-                statistics={statistics}
-                highlightAthlete={athleteId}
-                showAllPoints
-                compact
-                config={{
-                  type: 'box_swarm_combo',
-                  title: label,
-                  showLegend: false,
-                  showTooltips: true,
-                  responsive: true,
-                }}
-              />
-            </div>
+              dist={dist}
+              label={label}
+              unit={metricUnits[code]}
+              percentile={percentiles[code]}
+              captureCode={code}
+              captureTitle={`${label} — where ${athleteName} stands`}
+            />
           );
         })}
       </CardContent>

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -27,7 +27,7 @@ export function DistributionSection({
       </CardHeader>
       <CardContent className="space-y-2">
         <p className="text-sm text-muted-foreground">
-          Each dot is an athlete in your organization with this test; you are the blue dot.
+          Each blue dot is an athlete in your organization with this test; you are the highlighted green star.
         </p>
         {entries.map(([code, dist]) => {
           const label = metricLabels[code] || code;

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -7,7 +7,6 @@ interface Props {
   athleteName: string;
   distributions: ReportDistributions;
   metricLabels?: Record<string, string>;
-  metricUnits?: Record<string, string>;
 }
 
 export function DistributionSection({
@@ -15,7 +14,6 @@ export function DistributionSection({
   athleteName,
   distributions,
   metricLabels = {},
-  metricUnits = {},
 }: Props) {
   const entries = Object.entries(distributions);
   if (entries.length === 0) return null;
@@ -31,7 +29,13 @@ export function DistributionSection({
         </p>
         {entries.map(([code, dist]) => {
           const label = metricLabels[code] || code;
-          const points = dist.values.map((v, i) => ({
+          // Drop one occurrence of the athlete's own value from the peer dots — the
+          // athlete is shown separately as the highlighted star (the box stats still
+          // reflect the full population, computed on the backend).
+          const peerVals = [...dist.values];
+          const selfIdx = peerVals.indexOf(dist.athleteValue);
+          if (selfIdx !== -1) peerVals.splice(selfIdx, 1);
+          const points = peerVals.map((v, i) => ({
             athleteId: `peer-${i}`,
             athleteName: '',
             value: v,

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -9,6 +9,8 @@ interface Props {
   metricUnits?: Record<string, string>;
   /** Direction-normalized "better than X%" per metric, from the report (preferred). */
   percentiles?: Record<string, number>;
+  /** Name of the peer cohort (e.g. "Varsity (Male, WR)"); falls back to "your group". */
+  comparisonLabel?: string;
 }
 
 /** Compact number: integers as-is, otherwise one decimal. */
@@ -26,6 +28,7 @@ function MetricHistogram({
   label,
   unit,
   percentile,
+  groupLabel,
   captureCode,
   captureTitle,
 }: {
@@ -33,6 +36,7 @@ function MetricHistogram({
   label: string;
   unit?: string;
   percentile?: number;
+  groupLabel: string;
   captureCode: string;
   captureTitle: string;
 }) {
@@ -63,10 +67,13 @@ function MetricHistogram({
     <div data-report-chart={`dist:${captureCode}`} data-report-chart-title={captureTitle} className="space-y-1">
       <p className="text-sm text-foreground">
         <span className="font-medium">{label}.</span> You scored better than{' '}
-        <span className="font-semibold text-green-600">{pct}% of your group</span> ({yourValue}).
+        <span className="font-semibold text-green-600">
+          {pct}% of {groupLabel}
+        </span>{' '}
+        ({yourValue}).
       </p>
       <p className="text-xs text-muted-foreground">
-        Each bar shows how many athletes scored in that range · you are the green bar ★
+        Each bar shows how many athletes in {groupLabel} scored in that range · you are the green bar ★
       </p>
       <svg viewBox={`0 0 ${W} 240`} className="w-full" role="img" aria-label={`${label} distribution histogram`}>
         <line x1={plotLeft} y1={baseline} x2={plotRight} y2={baseline} stroke="#cbd5e1" />
@@ -108,9 +115,12 @@ export function DistributionSection({
   metricLabels = {},
   metricUnits = {},
   percentiles = {},
+  comparisonLabel,
 }: Props) {
   const entries = Object.entries(distributions);
   if (entries.length === 0) return null;
+
+  const groupLabel = comparisonLabel ?? 'your group';
 
   return (
     <Card>
@@ -127,6 +137,7 @@ export function DistributionSection({
               label={label}
               unit={metricUnits[code]}
               percentile={percentiles[code]}
+              groupLabel={groupLabel}
               captureCode={code}
               captureTitle={`${label} — where ${athleteName} stands`}
             />

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -1,0 +1,77 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BoxPlotChart } from '@/components/charts/BoxPlotChart';
+import type { ReportDistributions } from '@shared/report-trends-types';
+
+interface Props {
+  athleteId: string;
+  athleteName: string;
+  distributions: ReportDistributions;
+  metricLabels?: Record<string, string>;
+  metricUnits?: Record<string, string>;
+}
+
+export function DistributionSection({
+  athleteId,
+  athleteName,
+  distributions,
+  metricLabels = {},
+  metricUnits = {},
+}: Props) {
+  const entries = Object.entries(distributions);
+  if (entries.length === 0) return null;
+
+  return (
+    <Card data-report-chart="distribution" data-report-chart-title="Distribution vs peers">
+      <CardHeader>
+        <CardTitle>Where You Stand (vs your group)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-muted-foreground">
+          Each dot is an athlete in your organization with this test; you are the blue dot.
+        </p>
+        {entries.map(([code, dist]) => {
+          const label = metricLabels[code] || code;
+          const points = dist.values.map((v, i) => ({
+            athleteId: `peer-${i}`,
+            athleteName: '',
+            value: v,
+            date: new Date(),
+            metric: code,
+          }));
+          points.push({
+            athleteId,
+            athleteName,
+            value: dist.athleteValue,
+            date: new Date(),
+            metric: code,
+          });
+          return (
+            <div
+              key={code}
+              data-report-chart={`dist:${code}`}
+              data-report-chart-title={`${label} — distribution`}
+              className="h-[260px]"
+            >
+              <BoxPlotChart
+                data={points}
+                rawData={points}
+                highlightAthlete={athleteId}
+                showAllPoints
+                compact
+                config={{
+                  type: 'box_swarm_combo',
+                  title: label,
+                  showLegend: false,
+                  showTooltips: true,
+                  responsive: true,
+                }}
+              />
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default DistributionSection;

--- a/packages/web/src/components/reports/DistributionSection.tsx
+++ b/packages/web/src/components/reports/DistributionSection.tsx
@@ -113,7 +113,7 @@ export function DistributionSection({
   if (entries.length === 0) return null;
 
   return (
-    <Card data-report-chart="distribution" data-report-chart-title="Where you stand">
+    <Card>
       <CardHeader>
         <CardTitle>Where You Stand (vs your group)</CardTitle>
       </CardHeader>

--- a/packages/web/src/components/reports/IndividualReportView.tsx
+++ b/packages/web/src/components/reports/IndividualReportView.tsx
@@ -352,10 +352,11 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
 
       {sel.distribution && distributions && Object.keys(distributions).length > 0 && (
         <DistributionSection
-          athleteId={athlete.userId}
           athleteName={athlete.userName}
           distributions={distributions}
           metricLabels={metricLabels}
+          metricUnits={metricUnits}
+          percentiles={athlete.percentiles}
         />
       )}
 

--- a/packages/web/src/components/reports/IndividualReportView.tsx
+++ b/packages/web/src/components/reports/IndividualReportView.tsx
@@ -27,6 +27,8 @@ import { MetricExplanation } from "./MetricExplanation";
 import { ReportMetricsGlossary } from "./ReportMetricsGlossary";
 import { TrendSection } from "@/components/reports/TrendSection";
 import { PercentileRadarSection } from "@/components/reports/PercentileRadarSection";
+import { DistributionSection } from "@/components/reports/DistributionSection";
+import { resolveChartSelection } from "@shared/report-charts";
 import { TierProgressChart } from "@/components/charts/TierProgressChart";
 import { BenchmarkStandingBar } from "@/components/charts/BenchmarkStandingBar";
 import { format } from "date-fns";
@@ -112,8 +114,9 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
     );
   }
 
-  const { athlete, metricLabels, metricUnits, metricExplanations, trends } = reportData;
+  const { athlete, metricLabels, metricUnits, metricExplanations, trends, distributions } = reportData;
   const measurementCodes = athlete?.measurements ? Object.keys(athlete.measurements) : [];
+  const sel = resolveChartSelection(reportData.reportConfig);
 
   return (
     <div className="space-y-6">
@@ -299,7 +302,7 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
         </Card>
       )}
 
-      {athlete?.percentiles && Object.keys(athlete.percentiles).length >= 3 && (
+      {sel.radar && athlete?.percentiles && Object.keys(athlete.percentiles).length >= 3 && (
         <PercentileRadarSection
           athleteId={athlete.userId}
           athleteName={athlete.userName}
@@ -308,7 +311,7 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
         />
       )}
 
-      {athlete?.benchmarkComparisons &&
+      {sel.benchmarkStanding && athlete?.benchmarkComparisons &&
         Object.values(athlete.benchmarkComparisons).some((cs: any) =>
           cs && cs.length > 0
         ) && (
@@ -343,8 +346,18 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
         </Card>
       )}
 
-      {trends && Object.keys(trends).length > 0 && (
+      {sel.trends && trends && Object.keys(trends).length > 0 && (
         <TrendSection trends={trends} metricLabels={metricLabels} metricUnits={metricUnits} />
+      )}
+
+      {sel.distribution && distributions && Object.keys(distributions).length > 0 && (
+        <DistributionSection
+          athleteId={athlete.userId}
+          athleteName={athlete.userName}
+          distributions={distributions}
+          metricLabels={metricLabels}
+          metricUnits={metricUnits}
+        />
       )}
 
       {metricExplanations && (

--- a/packages/web/src/components/reports/IndividualReportView.tsx
+++ b/packages/web/src/components/reports/IndividualReportView.tsx
@@ -356,7 +356,6 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
           athleteName={athlete.userName}
           distributions={distributions}
           metricLabels={metricLabels}
-          metricUnits={metricUnits}
         />
       )}
 

--- a/packages/web/src/components/reports/IndividualReportView.tsx
+++ b/packages/web/src/components/reports/IndividualReportView.tsx
@@ -205,7 +205,7 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
                 <TableRow>
                   <TableHead>Metric</TableHead>
                   <TableHead>Best Result</TableHead>
-                  <TableHead>Team Average</TableHead>
+                  <TableHead>Group Average</TableHead>
                   <TableHead>Percentile</TableHead>
                   <TableHead>Benchmark Comparisons</TableHead>
                 </TableRow>
@@ -357,6 +357,7 @@ export function IndividualReportView({ report }: IndividualReportViewProps) {
           metricLabels={metricLabels}
           metricUnits={metricUnits}
           percentiles={athlete.percentiles}
+          comparisonLabel={reportData.comparisonLabel}
         />
       )}
 

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -38,6 +38,7 @@ import { TeamAthleteSelector } from "@/components/ui/team-athlete-selector";
 import type { OrganizationBenchmarkWithDetails } from "@shared/schema";
 import { deriveTierGroupName } from "./report-utils";
 import { useContextualLabels } from "@/hooks/useContextualLabels";
+import { DEFAULT_CHART_SELECTION } from "@shared/report-charts";
 
 const reportConfigSchema = z.object({
   reportType: z.enum(["team", "individual"]),
@@ -61,7 +62,7 @@ const reportConfigSchema = z.object({
     benchmarkStanding: z.boolean().default(true),
     trends: z.boolean().default(true),
     distribution: z.boolean().default(true),
-  }).default({ radar: true, benchmarkStanding: true, trends: true, distribution: true }),
+  }).default(DEFAULT_CHART_SELECTION),
   compositeWeights: z.record(z.string(), z.number()).optional(),
 }).superRefine((data, ctx) => {
   if (data.reportType === "individual" && (!data.athleteIds || data.athleteIds.length === 0)) {
@@ -111,7 +112,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
       teamIds: [],
       positions: [],
       enableCompositeIndex: false,
-      charts: { radar: true, benchmarkStanding: true, trends: true, distribution: true },
+      charts: DEFAULT_CHART_SELECTION,
     },
   });
 

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -56,7 +56,12 @@ const reportConfigSchema = z.object({
   positions: z.array(z.string()).optional(),
   audience: z.enum(["coach", "athlete", "parent"]).default("coach"),
   enableCompositeIndex: z.boolean().default(false),
-  showTrends: z.boolean().default(false),
+  charts: z.object({
+    radar: z.boolean().default(true),
+    benchmarkStanding: z.boolean().default(true),
+    trends: z.boolean().default(true),
+    distribution: z.boolean().default(true),
+  }).default({ radar: true, benchmarkStanding: true, trends: true, distribution: true }),
   compositeWeights: z.record(z.string(), z.number()).optional(),
 }).superRefine((data, ctx) => {
   if (data.reportType === "individual" && (!data.athleteIds || data.athleteIds.length === 0)) {
@@ -106,7 +111,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
       teamIds: [],
       positions: [],
       enableCompositeIndex: false,
-      showTrends: false,
+      charts: { radar: true, benchmarkStanding: true, trends: true, distribution: true },
     },
   });
 
@@ -128,7 +133,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
   const timeframeType = watch("timeframeType");
   const selectedMetrics = watch("metrics");
   const enableCompositeIndex = watch("enableCompositeIndex");
-  const showTrends = watch("showTrends");
+  const charts = watch("charts");
 
   // Fetch organization's enabled metrics using standardized hook
   const { data: metrics, isLoading: metricsLoading, error: metricsError } = useOrganizationMetrics(
@@ -329,12 +334,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
       };
     }
 
-    // showTrends only applies to individual reports. Gate the assignment (not
-    // just the checkbox render) so a stale form value can't persist
-    // showTrends: true onto a team report after switching report type.
-    if (data.reportType === "individual") {
-      config.showTrends = data.showTrends;
-    }
+    config.charts = data.charts;
 
     if (data.teamIds?.length || data.gender || data.positions?.length) {
       config.filters = {
@@ -919,25 +919,23 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
                   Click "Create Report" to finish
                 </p>
               </div>
-              <div className="border rounded-lg p-4 bg-muted/30">
-                <div className="flex items-start space-x-3">
-                  <Checkbox
-                    id="showTrends"
-                    checked={showTrends}
-                    onCheckedChange={(checked) => setValue("showTrends", checked as boolean)}
-                    className="mt-1"
-                  />
-                  <div className="space-y-1">
-                    <Label htmlFor="showTrends" className="cursor-pointer font-medium">
-                      Show progress over time
-                    </Label>
-                    <p className="text-sm text-muted-foreground">
-                      Add trend charts plotting each metric's measurements across the
-                      report's timeframe, with benchmarks overlaid. Needs at least 2
-                      measurements per metric in the selected date range.
-                    </p>
+              <div className="border rounded-lg p-4 bg-muted/30 space-y-4">
+                <Label className="font-medium">Charts to include</Label>
+                {([
+                  ['radar', 'All-around profile (radar)', 'Percentile shape across all metrics (needs ≥3 metrics)'],
+                  ['benchmarkStanding', 'Benchmark standing', 'Where the athlete sits vs each benchmark'],
+                  ['trends', 'Progress over time', 'Trend line per metric (needs ≥2 measurements)'],
+                  ['distribution', 'Where you stand (distribution)', 'The group spread with the athlete marked'],
+                ] as const).map(([key, title, desc]) => (
+                  <div key={key} className="flex items-start space-x-2">
+                    <Checkbox id={`chart-${key}`} checked={charts?.[key] ?? true}
+                      onCheckedChange={(v) => setValue(`charts.${key}` as const, v as boolean)} className="mt-1" />
+                    <div>
+                      <Label htmlFor={`chart-${key}`} className="cursor-pointer font-medium">{title}</Label>
+                      <p className="text-sm text-muted-foreground">{desc}</p>
+                    </div>
                   </div>
-                </div>
+                ))}
               </div>
             </div>
           )}

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -335,7 +335,10 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
       };
     }
 
-    config.charts = data.charts;
+    // Chart selection is an individual-report feature; don't pollute team configs.
+    if (data.reportType === "individual") {
+      config.charts = data.charts;
+    }
 
     if (data.teamIds?.length || data.gender || data.positions?.length) {
       config.filters = {

--- a/packages/web/src/components/reports/__tests__/histogram-utils.test.ts
+++ b/packages/web/src/components/reports/__tests__/histogram-utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { computeHistogram, percentBetterThanPeers } from '../histogram-utils';
+
+describe('computeHistogram', () => {
+  it('counts the whole org population (peers + the athlete) across the bins', () => {
+    const peers = [10, 12, 14, 16, 18, 20];
+    const bins = computeHistogram(peers, 15, 4);
+    const total = bins.reduce((sum, b) => sum + b.count, 0);
+    // 6 peers + the athlete = 7 people distributed across the bins
+    expect(total).toBe(7);
+  });
+
+  it('flags exactly one bin as the athlete bin, and it contains the athlete value', () => {
+    const bins = computeHistogram([10, 12, 14, 16, 18, 20], 15, 4);
+    const athleteBins = bins.filter((b) => b.isAthlete);
+    expect(athleteBins).toHaveLength(1);
+    const b = athleteBins[0];
+    expect(15).toBeGreaterThanOrEqual(b.start);
+    expect(15).toBeLessThanOrEqual(b.end);
+  });
+
+  it('places the athlete at the population maximum into the last bin', () => {
+    const bins = computeHistogram([10, 12, 14, 16, 18], 20, 5);
+    expect(bins[bins.length - 1].isAthlete).toBe(true);
+    // the max value must be counted, not dropped past the final edge
+    const total = bins.reduce((sum, b) => sum + b.count, 0);
+    expect(total).toBe(6);
+  });
+
+  it('produces a single bin when every value is identical', () => {
+    const bins = computeHistogram([12, 12, 12], 12, 8);
+    expect(bins).toHaveLength(1);
+    expect(bins[0].count).toBe(4); // 3 peers + athlete
+    expect(bins[0].isAthlete).toBe(true);
+  });
+
+  it('never creates more bins than there are people', () => {
+    const bins = computeHistogram([10, 20], 30, 8); // 3 people, asked for 8 bins
+    expect(bins.length).toBeLessThanOrEqual(3);
+  });
+
+  it('computes correct per-bin counts for a known dataset', () => {
+    // population = peers [0,1,2,3] + athlete 4 = [0,1,2,3,4], range 0..4, 4 bins width 1
+    // bin0 [0,1): {0}=1  bin1 [1,2): {1}=1  bin2 [2,3): {2}=1  bin3 [3,4]: {3,4}=2
+    const bins = computeHistogram([0, 1, 2, 3], 4, 4);
+    expect(bins.map((b) => b.count)).toEqual([1, 1, 1, 2]);
+    expect(bins[3].isAthlete).toBe(true);
+  });
+});
+
+describe('percentBetterThanPeers', () => {
+  it('higher-is-better: counts peers with a lower value', () => {
+    // athlete 15 beats [10,12,14] but not [16,18] → 3/5 = 60%
+    expect(percentBetterThanPeers([10, 12, 14, 16, 18], 15, 'higher')).toBe(60);
+  });
+
+  it('lower-is-better: counts peers with a higher (worse) value', () => {
+    // athlete 4.5s beats slower peers [5,6] but not [4,3] → 2/4 = 50%
+    expect(percentBetterThanPeers([3, 4, 5, 6], 4.5, 'lower')).toBe(50);
+  });
+
+  it('returns 0 when there are no peers', () => {
+    expect(percentBetterThanPeers([], 10, 'higher')).toBe(0);
+  });
+});

--- a/packages/web/src/components/reports/histogram-utils.ts
+++ b/packages/web/src/components/reports/histogram-utils.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure binning helpers for the "Where you stand" distribution histogram.
+ *
+ * The histogram shows the whole org population (peer best-values PLUS the athlete)
+ * bucketed into a few equal-width value ranges, so a parent or athlete can read
+ * "most people are in the middle bars; I'm on the highlighted one" without any
+ * statistics vocabulary. The athlete is counted in their own bar (the bar reflects
+ * everyone, including them) and that bar is flagged for the "You" highlight.
+ */
+
+export interface HistogramBin {
+  /** Inclusive lower edge of the value range. */
+  start: number;
+  /** Upper edge of the value range (inclusive on the final bin). */
+  end: number;
+  /** Number of athletes (peers + the athlete) whose value falls in this bin. */
+  count: number;
+  /** True for the single bin that contains the athlete's own value. */
+  isAthlete: boolean;
+}
+
+/**
+ * Bucket `peerValues` plus `athleteValue` into up to `binCount` equal-width bins.
+ *
+ * - The athlete is included in the population, so bar heights reflect everyone.
+ * - The bin containing `athleteValue` is flagged `isAthlete` for the highlight.
+ * - Bins never outnumber the people (avoids a comb of empty bars on small groups).
+ * - All-equal values collapse to a single bin.
+ */
+export function computeHistogram(
+  peerValues: number[],
+  athleteValue: number,
+  binCount = 8,
+): HistogramBin[] {
+  const population = [...peerValues, athleteValue];
+  const min = Math.min(...population);
+  const max = Math.max(...population);
+
+  // Degenerate range: everyone scored the same → one bar.
+  if (max === min) {
+    return [{ start: min, end: max, count: population.length, isAthlete: true }];
+  }
+
+  const effectiveBins = Math.max(1, Math.min(binCount, population.length));
+  const width = (max - min) / effectiveBins;
+
+  const bins: HistogramBin[] = Array.from({ length: effectiveBins }, (_, i) => ({
+    start: min + i * width,
+    end: min + (i + 1) * width,
+    count: 0,
+    isAthlete: false,
+  }));
+
+  // Values at the maximum edge land in the last bin (clamp), not past it.
+  const indexOf = (v: number) =>
+    Math.min(effectiveBins - 1, Math.max(0, Math.floor((v - min) / width)));
+
+  for (const v of population) {
+    bins[indexOf(v)].count += 1;
+  }
+  bins[indexOf(athleteValue)].isAthlete = true;
+
+  return bins;
+}
+
+/**
+ * Fallback "better than X%" when the report's direction-normalized percentile is
+ * unavailable. Counts the share of peer dots the athlete beats, respecting metric
+ * direction (for lower-is-better, a smaller value is better). Returns 0..100.
+ *
+ * Prefer the report's `percentiles[metric]` (full-population, consistent with the
+ * radar/benchmark charts) over this; it exists only as a self-contained backstop.
+ */
+export function percentBetterThanPeers(
+  peerValues: number[],
+  athleteValue: number,
+  direction: 'higher' | 'lower',
+): number {
+  if (peerValues.length === 0) return 0;
+  const beaten = peerValues.filter((v) =>
+    direction === 'lower' ? v > athleteValue : v < athleteValue,
+  ).length;
+  return Math.round((beaten / peerValues.length) * 100);
+}

--- a/packages/web/src/hooks/use-reports.ts
+++ b/packages/web/src/hooks/use-reports.ts
@@ -3,6 +3,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import type { ReportFilters } from "./use-report-filters";
 import type { Report } from "@/types/report-types";
+import type { ChartSelection } from "@shared/report-charts";
 
 interface CreateReportData {
   name: string;
@@ -34,7 +35,7 @@ interface CreateReportData {
       gender?: string;
       positions?: string[];
     };
-    charts?: { radar?: boolean; benchmarkStanding?: boolean; trends?: boolean; distribution?: boolean };
+    charts?: Partial<ChartSelection>;
   };
 }
 

--- a/packages/web/src/hooks/use-reports.ts
+++ b/packages/web/src/hooks/use-reports.ts
@@ -34,6 +34,7 @@ interface CreateReportData {
       gender?: string;
       positions?: string[];
     };
+    charts?: { radar?: boolean; benchmarkStanding?: boolean; trends?: boolean; distribution?: boolean };
   };
 }
 

--- a/packages/web/src/lib/chartExport.ts
+++ b/packages/web/src/lib/chartExport.ts
@@ -209,7 +209,13 @@ export async function getChartPngDataUrl(containerElement: HTMLElement): Promise
  * Report charts carry data-report-chart={metricCode} with optional data-report-chart-title={title}.
  */
 export async function captureTrendCharts(): Promise<Array<{ metricCode: string; dataUrl: string; title?: string }>> {
-  const nodes = Array.from(document.querySelectorAll<HTMLElement>('[data-chart-metric], [data-report-chart]'));
+  const all = Array.from(document.querySelectorAll<HTMLElement>('[data-chart-metric], [data-report-chart]'));
+
+  // Keep only leaf-most capture targets: skip any element that CONTAINS another
+  // matched element. This lets a section wrapper (e.g. the distribution Card) carry
+  // data-report-chart as a grouping/E2E anchor without being captured as a giant
+  // duplicate of the per-metric charts nested inside it.
+  const nodes = all.filter((node) => !all.some((other) => other !== node && node.contains(other)));
 
   // Capture charts concurrently for speed, but isolate per-chart failures: a
   // single html2canvas error must not reject the whole capture and silently

--- a/packages/web/src/pages/public-report.tsx
+++ b/packages/web/src/pages/public-report.tsx
@@ -467,13 +467,21 @@ export default function PublicReport() {
               </Card>
             )}
 
+            {sel.trends && trends && Object.keys(trends).length > 0 && (
+              <TrendSection
+                trends={trends}
+                metricLabels={metricLabels}
+                metricUnits={metricUnits}
+              />
+            )}
+
             {sel.distribution && snapshotData.distributions && Object.keys(snapshotData.distributions).length > 0 && (
               <DistributionSection
-                athleteName={snapshotData.athlete.userName}
+                athleteName={snapshotData.athlete?.userName ?? ''}
                 distributions={snapshotData.distributions}
                 metricLabels={metricLabels}
                 metricUnits={metricUnits}
-                percentiles={snapshotData.athlete.percentiles}
+                percentiles={snapshotData.athlete?.percentiles}
                 comparisonLabel={snapshotData.comparisonLabel}
               />
             )}
@@ -486,15 +494,6 @@ export default function PublicReport() {
               />
             )}
           </>
-        )}
-
-        {/* Time-series trends — gated on the real top-level snapshot reportType */}
-        {reportType === "individual" && sel.trends && trends && Object.keys(trends).length > 0 && (
-          <TrendSection
-            trends={trends}
-            metricLabels={metricLabels}
-            metricUnits={metricUnits}
-          />
         )}
       </div>
     </div>

--- a/packages/web/src/pages/public-report.tsx
+++ b/packages/web/src/pages/public-report.tsx
@@ -469,10 +469,11 @@ export default function PublicReport() {
 
             {sel.distribution && snapshotData.distributions && Object.keys(snapshotData.distributions).length > 0 && (
               <DistributionSection
-                athleteId={snapshotData.athlete.userId}
                 athleteName={snapshotData.athlete.userName}
                 distributions={snapshotData.distributions}
                 metricLabels={metricLabels}
+                metricUnits={metricUnits}
+                percentiles={snapshotData.athlete.percentiles}
               />
             )}
 

--- a/packages/web/src/pages/public-report.tsx
+++ b/packages/web/src/pages/public-report.tsx
@@ -24,6 +24,8 @@ import { MetricExplanation } from "@/components/reports/MetricExplanation";
 import { ReportMetricsGlossary } from "@/components/reports/ReportMetricsGlossary";
 import { TrendSection } from "@/components/reports/TrendSection";
 import { PercentileRadarSection } from "@/components/reports/PercentileRadarSection";
+import { DistributionSection } from "@/components/reports/DistributionSection";
+import { resolveChartSelection } from "@shared/report-charts";
 import { TierProgressChart } from "@/components/charts/TierProgressChart";
 import { BenchmarkStandingBar } from "@/components/charts/BenchmarkStandingBar";
 import type { MetricExplanation as MetricExplanationData } from "@shared/metric-explanations";
@@ -75,6 +77,7 @@ export default function PublicReport() {
   const metricLabels = (snapshotData.metricLabels ?? {}) as Record<string, string>;
   const metricUnits = (snapshotData.metricUnits ?? {}) as Record<string, string>;
   const trends = snapshotData.trends as ReportTrends | undefined;
+  const sel = resolveChartSelection(snapshotData.reportConfig);
 
   // Real produced shapes (mirror IndividualReportView / TeamReportView).
   const athlete = snapshotData.athlete as any;
@@ -420,7 +423,7 @@ export default function PublicReport() {
               </Card>
             )}
 
-            {athlete?.percentiles && Object.keys(athlete.percentiles).length >= 3 && (
+            {sel.radar && athlete?.percentiles && Object.keys(athlete.percentiles).length >= 3 && (
               <PercentileRadarSection
                 athleteId={athlete.userId}
                 athleteName={athlete.userName}
@@ -429,7 +432,7 @@ export default function PublicReport() {
               />
             )}
 
-            {athlete?.benchmarkComparisons &&
+            {sel.benchmarkStanding && athlete?.benchmarkComparisons &&
               Object.values(athlete.benchmarkComparisons).some((cs: any) =>
                 cs && cs.length > 0
               ) && (
@@ -464,6 +467,16 @@ export default function PublicReport() {
               </Card>
             )}
 
+            {sel.distribution && snapshotData.distributions && Object.keys(snapshotData.distributions).length > 0 && (
+              <DistributionSection
+                athleteId={snapshotData.athlete.userId}
+                athleteName={snapshotData.athlete.userName}
+                distributions={snapshotData.distributions}
+                metricLabels={metricLabels}
+                metricUnits={metricUnits}
+              />
+            )}
+
             {/* Glossary of metrics (Individual) */}
             {Object.keys(metricExplanations).length > 0 && (
               <ReportMetricsGlossary
@@ -475,7 +488,7 @@ export default function PublicReport() {
         )}
 
         {/* Time-series trends — gated on the real top-level snapshot reportType */}
-        {reportType === "individual" && trends && Object.keys(trends).length > 0 && (
+        {reportType === "individual" && sel.trends && trends && Object.keys(trends).length > 0 && (
           <TrendSection
             trends={trends}
             metricLabels={metricLabels}

--- a/packages/web/src/pages/public-report.tsx
+++ b/packages/web/src/pages/public-report.tsx
@@ -474,6 +474,7 @@ export default function PublicReport() {
                 metricLabels={metricLabels}
                 metricUnits={metricUnits}
                 percentiles={snapshotData.athlete.percentiles}
+                comparisonLabel={snapshotData.comparisonLabel}
               />
             )}
 

--- a/packages/web/src/pages/public-report.tsx
+++ b/packages/web/src/pages/public-report.tsx
@@ -473,7 +473,6 @@ export default function PublicReport() {
                 athleteName={snapshotData.athlete.userName}
                 distributions={snapshotData.distributions}
                 metricLabels={metricLabels}
-                metricUnits={metricUnits}
               />
             )}
 

--- a/packages/web/src/types/report-types.ts
+++ b/packages/web/src/types/report-types.ts
@@ -132,6 +132,7 @@ export interface IndividualReportData {
   orgBranding?: OrgBranding;
   trends?: ReportTrends;
   distributions?: ReportDistributions;
+  comparisonLabel?: string; // cohort name for the "Where You Stand" caption (undefined = org-wide)
 }
 
 export type PdfFormat = 'visual' | 'simplified';

--- a/packages/web/src/types/report-types.ts
+++ b/packages/web/src/types/report-types.ts
@@ -1,6 +1,7 @@
 import type { MetricExplanation } from '@shared/metric-explanations';
 import type { ReportTrends, ReportDistributions } from '@shared/report-trends-types';
 import type { BenchmarkComparison } from '@shared/benchmark-types';
+import type { ChartSelection } from '@shared/report-charts';
 
 export interface Benchmark {
   name: string;
@@ -87,7 +88,7 @@ export interface IndividualReportConfig {
     custom?: string[]; // Custom benchmark IDs
   };
   showTrends?: boolean;
-  charts?: { radar?: boolean; benchmarkStanding?: boolean; trends?: boolean; distribution?: boolean };
+  charts?: Partial<ChartSelection>;
 }
 
 export interface OrgBranding {

--- a/packages/web/src/types/report-types.ts
+++ b/packages/web/src/types/report-types.ts
@@ -1,5 +1,5 @@
 import type { MetricExplanation } from '@shared/metric-explanations';
-import type { ReportTrends } from '@shared/report-trends-types';
+import type { ReportTrends, ReportDistributions } from '@shared/report-trends-types';
 import type { BenchmarkComparison } from '@shared/benchmark-types';
 
 export interface Benchmark {
@@ -85,13 +85,9 @@ export interface IndividualReportConfig {
   benchmarks?: {
     site?: string[]; // Site benchmark IDs
     custom?: string[]; // Custom benchmark IDs
-    userDefined?: Array<{
-      metricCode: string;
-      value: number;
-      label: string;
-    }>;
   };
   showTrends?: boolean;
+  charts?: { radar?: boolean; benchmarkStanding?: boolean; trends?: boolean; distribution?: boolean };
 }
 
 export interface OrgBranding {
@@ -134,6 +130,7 @@ export interface IndividualReportData {
   metricExplanations?: Record<string, MetricExplanation>;
   orgBranding?: OrgBranding;
   trends?: ReportTrends;
+  distributions?: ReportDistributions;
 }
 
 export type PdfFormat = 'visual' | 'simplified';

--- a/tests/e2e/report-chart-selection.spec.ts
+++ b/tests/e2e/report-chart-selection.spec.ts
@@ -1,0 +1,329 @@
+import { test, expect } from '@playwright/test';
+import { loginAsDefaultUser } from './helpers/auth';
+
+/**
+ * REPORT CHART SELECTION + DISTRIBUTION: End-to-End Tests
+ *
+ * Verifies the per-report chart-selection toggles end-to-end, with emphasis on
+ * the new peer-distribution section:
+ *  1. With config.charts = { radar, benchmarkStanding, trends, distribution } all
+ *     true, the live report renders the radar ([data-report-chart="radar"]), the
+ *     trend section ([data-testid="trend-section"]), the distribution card
+ *     ([data-report-chart="distribution"]) and at least one per-metric
+ *     distribution chart ([data-report-chart^="dist:"]).
+ *  2. A second report with charts.distribution = false (others true) renders the
+ *     trend section but NOT the distribution card — proving the toggle gates the
+ *     section.
+ *  3. The public shared snapshot of the first report renders the distribution
+ *     card unauthenticated.
+ *
+ * Modeled closely on tests/e2e/individual-report-charts.spec.ts (same harness):
+ *  - loginAsDefaultUser + localStorage organizationContext resolution
+ *  - inline API data setup: team + athlete + measurements
+ *  - public snapshot creation + unauthenticated render
+ *
+ * A team is created and athletes are added to it because a measurement's
+ * organizationId is derived from the athlete's team — the report athlete AND the
+ * peers must share the report's organization for the peer distribution to find
+ * them. Peers are seeded with a VERTICAL_JUMP measurement each so that metric has
+ * >= 2 athletes and computeDistribution renders a box + dots.
+ *
+ * Screenshots (per the project UI screenshot convention) are written to
+ * screenshots/report-chart-selection-desktop.png and
+ * screenshots/report-chart-selection-mobile.png.
+ */
+
+const STAGING_URL = process.env.STAGING_URL || 'http://localhost:5000';
+
+// >=3 metrics so the radar (which requires >=3 percentiles) renders; each gets
+// >=2 measurements on distinct dates so trends have a series.
+const METRICS: Array<{ code: string; earlier: number; latest: number }> = [
+  { code: 'VERTICAL_JUMP', earlier: 24, latest: 28 },
+  { code: 'FLY10_TIME', earlier: 1.35, latest: 1.22 },
+  { code: 'AGILITY_505', earlier: 2.6, latest: 2.45 },
+];
+
+const METRIC_CODES = METRICS.map((m) => m.code);
+
+// >=2 peers, each with a VERTICAL_JUMP measurement, so the distribution for that
+// metric has >= 2 peers (plus the report athlete) and renders a box + dots.
+const PEER_VERTICALS = [21, 31];
+
+function uid(): string {
+  return Date.now().toString(36) + Math.random().toString(36).substring(2);
+}
+
+/**
+ * Resolve the organization to operate in.
+ * Mirrors individual-report-charts.spec.ts (localStorage organizationContext);
+ * falls back to the first organization for org-less site-admin sessions.
+ */
+async function resolveOrgId(page: any): Promise<string | null> {
+  const lsOrg = await page.evaluate(() => {
+    const auth = localStorage.getItem('auth');
+    return auth ? JSON.parse(auth).organizationContext || null : null;
+  });
+  if (lsOrg) return lsOrg;
+
+  const res = await page.request.get(`${STAGING_URL}/api/organizations`);
+  if (!res.ok()) return null;
+  const body = await res.json();
+  const orgs = Array.isArray(body) ? body : body?.organizations;
+  return orgs?.[0]?.id || null;
+}
+
+test.describe('Report Chart Selection + Distribution (live + public)', () => {
+  let orgId: string | null;
+  let teamId: string;
+  let athleteId: string;
+  let athleteFirstName: string;
+  let peerIds: string[] = [];
+  let createdReportIds: string[] = [];
+  let createdSnapshots: Array<{ reportId: string; snapshotId: string }> = [];
+
+  /**
+   * Create an individual report with an explicit chart selection. The create
+   * endpoint returns { id } or { reports: [...] } (one report per athlete).
+   */
+  async function createReport(
+    page: any,
+    charts: { radar: boolean; benchmarkStanding: boolean; trends: boolean; distribution: boolean }
+  ): Promise<string> {
+    const createRes = await page.request.post(`${STAGING_URL}/api/reports`, {
+      data: {
+        name: `ChartSel Report ${uid()}`,
+        reportType: 'individual',
+        organizationId: orgId,
+        config: {
+          athleteId, // backend generate() reads config.athleteId (singular)
+          athleteIds: [athleteId],
+          timeframe: { type: 'preset', preset: 'all_time' },
+          metrics: METRIC_CODES,
+          charts,
+        },
+      },
+    });
+    expect(createRes.ok(), 'report was created').toBeTruthy();
+    const created = await createRes.json();
+    const reportId = created.id || created.reports?.[0]?.id;
+    expect(reportId, 'report id returned').toBeTruthy();
+    createdReportIds.push(reportId);
+    return reportId;
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsDefaultUser(page);
+    peerIds = [];
+    createdReportIds = [];
+    createdSnapshots = [];
+
+    orgId = await resolveOrgId(page);
+    expect(orgId, 'an organization is required to create a report').toBeTruthy();
+
+    const suffix = uid();
+
+    // Team in the target org (gives created measurements an organization context)
+    const teamRes = await page.request.post(`${STAGING_URL}/api/teams`, {
+      data: { name: `DistTeam_${suffix}`, organizationId: orgId, level: 'Club' },
+    });
+    teamId = (await teamRes.json()).id;
+
+    // Adult athlete (adult avoids COPPA public-link restriction)
+    athleteFirstName = `DistAthlete_${suffix}`;
+    const athleteRes = await page.request.post(`${STAGING_URL}/api/athletes`, {
+      data: {
+        firstName: athleteFirstName,
+        lastName: 'Charts',
+        birthDate: '2000-01-01',
+        emails: [],
+      },
+    });
+    athleteId = (await athleteRes.json()).id;
+
+    await page.request.post(`${STAGING_URL}/api/teams/${teamId}/members`, {
+      data: { userId: athleteId },
+    });
+
+    // Seed >=2 measurements for each of >=3 metrics on distinct dates so that
+    // percentiles (radar) and trends both have data.
+    const today = new Date();
+    const earlier = new Date(today.getTime() - 60 * 24 * 60 * 60 * 1000);
+    const earlierDate = earlier.toISOString().split('T')[0];
+    const todayDate = today.toISOString().split('T')[0];
+
+    for (const { code, earlier: earlyValue, latest: latestValue } of METRICS) {
+      for (const [date, value] of [
+        [earlierDate, earlyValue],
+        [todayDate, latestValue],
+      ] as Array<[string, number]>) {
+        await page.request.post(`${STAGING_URL}/api/measurements`, {
+          data: { userId: athleteId, metric: code, value, date, teamId },
+        });
+      }
+    }
+
+    // Seed >=2 PEER athletes in the SAME org/team, each with a VERTICAL_JUMP
+    // measurement. The peer distribution is "best value per athlete in the org
+    // for the metric" — report athlete + these peers gives >= 2 peers so the
+    // VERTICAL_JUMP distribution box + dots renders.
+    for (const peerVertical of PEER_VERTICALS) {
+      const peerRes = await page.request.post(`${STAGING_URL}/api/athletes`, {
+        data: {
+          firstName: `DistPeer_${uid()}`,
+          lastName: 'Charts',
+          birthDate: '2000-01-01',
+          emails: [],
+        },
+      });
+      const peerId = (await peerRes.json()).id;
+      peerIds.push(peerId);
+
+      await page.request.post(`${STAGING_URL}/api/teams/${teamId}/members`, {
+        data: { userId: peerId },
+      });
+
+      await page.request.post(`${STAGING_URL}/api/measurements`, {
+        data: { userId: peerId, metric: 'VERTICAL_JUMP', value: peerVertical, date: todayDate, teamId },
+      });
+    }
+  });
+
+  test.afterEach(async ({ page }) => {
+    for (const { reportId, snapshotId } of createdSnapshots) {
+      try {
+        await page.request.delete(`${STAGING_URL}/api/reports/${reportId}/snapshots/${snapshotId}`);
+      } catch (error) {
+        console.warn(`Failed to cleanup snapshot ${snapshotId}:`, error);
+      }
+    }
+    for (const reportId of createdReportIds) {
+      try {
+        await page.request.delete(`${STAGING_URL}/api/reports/${reportId}`);
+      } catch (error) {
+        console.warn(`Failed to cleanup report ${reportId}:`, error);
+      }
+    }
+    for (const peerId of peerIds) {
+      try {
+        await page.request.delete(`${STAGING_URL}/api/athletes/${peerId}`);
+      } catch (error) {
+        console.warn(`Failed to cleanup peer ${peerId}:`, error);
+      }
+    }
+    try {
+      if (athleteId) await page.request.delete(`${STAGING_URL}/api/athletes/${athleteId}`);
+    } catch (error) {
+      console.warn('Failed to cleanup athlete:', error);
+    }
+    try {
+      if (teamId) await page.request.delete(`${STAGING_URL}/api/teams/${teamId}`);
+    } catch (error) {
+      console.warn('Failed to cleanup team:', error);
+    }
+  });
+
+  test('renders the radar, trend section and peer distribution on the live report', async ({ page }) => {
+    const reportId = await createReport(page, {
+      radar: true,
+      benchmarkStanding: true,
+      trends: true,
+      distribution: true,
+    });
+
+    // IndividualReportView auto-generates on mount (no Generate button needed)
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+
+    // --- Radar (all-around percentile profile) ---
+    const radar = page.locator('[data-report-chart="radar"]');
+    await expect(radar).toBeVisible({ timeout: 15000 });
+
+    // --- Trend section ---
+    const trendSection = page.getByTestId('trend-section');
+    await expect(trendSection).toBeVisible({ timeout: 15000 });
+
+    // --- Distribution card + at least one per-metric distribution chart ---
+    const distribution = page.locator('[data-report-chart="distribution"]');
+    await expect(distribution).toBeVisible({ timeout: 15000 });
+    const distMetricCharts = page.locator('[data-report-chart^="dist:"]');
+    await expect(distMetricCharts.first()).toBeVisible({ timeout: 15000 });
+    expect(await distMetricCharts.count()).toBeGreaterThanOrEqual(1);
+    await expect(page.locator('[data-report-chart="dist:VERTICAL_JUMP"]')).toBeVisible();
+
+    // Screenshot capture (UI screenshot convention) - desktop then mobile
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await distribution.scrollIntoViewIfNeeded();
+    await page.screenshot({ path: 'screenshots/report-chart-selection-desktop.png', fullPage: true });
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    await expect(distribution).toBeVisible({ timeout: 15000 });
+    await distribution.scrollIntoViewIfNeeded();
+    await page.screenshot({ path: 'screenshots/report-chart-selection-mobile.png', fullPage: true });
+  });
+
+  test('omits the distribution card when charts.distribution is false (trend section still shows)', async ({ page }) => {
+    const reportId = await createReport(page, {
+      radar: true,
+      benchmarkStanding: true,
+      trends: true,
+      distribution: false,
+    });
+
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+
+    // Trend section is the proof that the report generated and the toggle is the
+    // only thing gating the distribution section.
+    await expect(page.getByTestId('trend-section')).toBeVisible({ timeout: 15000 });
+
+    // Distribution is gated off — the card must not be present at all.
+    await expect(page.locator('[data-report-chart="distribution"]')).toHaveCount(0);
+    await expect(page.locator('[data-report-chart^="dist:"]')).toHaveCount(0);
+  });
+
+  test('renders the peer distribution on the public shared link', async ({ page, context }) => {
+    const reportId = await createReport(page, {
+      radar: true,
+      benchmarkStanding: true,
+      trends: true,
+      distribution: true,
+    });
+
+    // Open the live report once so it generates and the snapshot freezes real data.
+    await page.goto(`${STAGING_URL}/reports/${reportId}`);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[data-report-chart="distribution"]')).toBeVisible({ timeout: 15000 });
+
+    // Create a public snapshot via API (freezes the generated chart data)
+    const snapshotRes = await page.request.post(`${STAGING_URL}/api/reports/${reportId}/snapshots`, {
+      data: { expirationDays: 7 },
+    });
+    const snapshot = await snapshotRes.json();
+    createdSnapshots.push({ reportId, snapshotId: snapshot.id });
+
+    const publicUrl = `${STAGING_URL}/public/reports/${snapshot.publicToken}`;
+
+    // Open the public link in a fresh, unauthenticated context
+    const incognitoContext = await context.browser()!.newContext();
+    const incognitoPage = await incognitoContext.newPage();
+
+    try {
+      await incognitoPage.goto(publicUrl);
+      await incognitoPage.waitForLoadState('networkidle');
+
+      // Distribution card renders on the public snapshot
+      await expect(incognitoPage.locator('[data-report-chart="distribution"]')).toBeVisible({ timeout: 15000 });
+      await expect(
+        incognitoPage.locator('[data-report-chart="dist:VERTICAL_JUMP"]')
+      ).toBeVisible({ timeout: 15000 });
+
+      // Regression guard: the real performance content (athlete name) must render.
+      await expect(
+        incognitoPage.getByText(athleteFirstName, { exact: false }).first()
+      ).toBeVisible({ timeout: 15000 });
+    } finally {
+      await incognitoPage.close();
+      await incognitoContext.close();
+    }
+  });
+});

--- a/tests/integration/report-chart-selection.test.ts
+++ b/tests/integration/report-chart-selection.test.ts
@@ -293,6 +293,10 @@ describe('POST /api/reports/:id/generate — distribution payload', () => {
     for (const key of ['min', 'q1', 'median', 'q3', 'max']) {
       expect(typeof dist.stats[key]).toBe('number');
     }
+
+    // direction: VERTICAL_JUMP is higher-is-better (drives the histogram's
+    // "better" axis annotation on the frontend).
+    expect(dist.direction).toBe('higher');
   });
 
   it('omits distributions when charts.distribution is false', async () => {

--- a/tests/integration/report-chart-selection.test.ts
+++ b/tests/integration/report-chart-selection.test.ts
@@ -299,6 +299,24 @@ describe('POST /api/reports/:id/generate — distribution payload', () => {
     expect(dist.direction).toBe('higher');
   });
 
+  it('excludes the athlete by id, not by value: a peer tying the athlete stays', async () => {
+    // A peer whose best equals the athlete's best (27.5). The athlete is removed
+    // from the peer set by id, so this tying peer must remain — the old
+    // value-equality removal would have wrongly dropped it.
+    await seedPeerAthlete('VERTICAL_JUMP', '27.500');
+    await seedPeerAthlete('VERTICAL_JUMP', '20.000');
+    const report = await createIndividualReport({ charts: { distribution: true } });
+
+    const response = await generate(report.id);
+    expect(response.status).toBe(200);
+
+    const dist = response.body.distributions.VERTICAL_JUMP;
+    expect(dist.athleteValue).toBe(27.5);
+    // The tying peer is kept exactly once; the athlete's own 27.5 is not among the peers.
+    expect(dist.values.filter((v: number) => v === 27.5)).toHaveLength(1);
+    expect(dist.values).toContain(20);
+  });
+
   it('omits distributions when charts.distribution is false', async () => {
     await seedPeerAthlete('VERTICAL_JUMP', '20.000');
     const report = await createIndividualReport({ charts: { distribution: false } });

--- a/tests/integration/report-chart-selection.test.ts
+++ b/tests/integration/report-chart-selection.test.ts
@@ -334,6 +334,21 @@ describe('POST /api/reports/:id/generate — trends gate via charts', () => {
   });
 });
 
+describe('POST /api/reports/:id/generate — explicit empty charts (all-off)', () => {
+  it('treats a present-but-empty charts object as all-off: no distributions, no trends', async () => {
+    // A peer exists (distribution could resolve) but an explicit empty `charts`
+    // selects nothing — distinguishing it from legacy "no charts" defaults.
+    await seedPeerAthlete('VERTICAL_JUMP', '20.000');
+    const report = await createIndividualReport({ charts: {} });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.distributions).toBeUndefined();
+    expect(response.body.trends).toBeUndefined();
+  });
+});
+
 describe('POST /api/reports/:id/generate — back-compat (no charts field)', () => {
   it('falls back to legacy defaults: showTrends drives trends, distribution off', async () => {
     // A peer exists, but with no `charts` field distribution stays off by default.

--- a/tests/integration/report-chart-selection.test.ts
+++ b/tests/integration/report-chart-selection.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Integration Tests for Report Chart Selection + Distribution Payload
+ *
+ * Verifies the chart-selection resolver and peer-distribution payload produced
+ * by generateIndividualReport (via POST /api/reports/:id/generate) against a
+ * real test database:
+ *   1. config.charts.distribution=true seeds `distributions[METRIC]` (with
+ *      values/athleteValue/stats) when there are >= 2 athletes for the metric.
+ *   2. config.charts.distribution=false omits `distributions`.
+ *   3. config.charts.trends gates the `trends` field on/off.
+ *   4. Back-compat: a config with NO `charts` field falls back to
+ *      resolveChartSelection defaults (trends from legacy showTrends,
+ *      distribution off).
+ *   5. distribution enabled but < 2 peers for the metric -> metric omitted
+ *      (distributions undefined when it was the only metric).
+ *
+ * Modeled on tests/integration/report-trends.test.ts (same harness/bootstrap).
+ */
+
+// Set environment variables BEFORE any imports
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET = 'test-secret-key-for-integration-tests-only-at-least-32-characters-long';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+process.env.BYPASS_GENERAL_RATE_LIMIT = 'true'; // Bypass rate limits for these tests
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { type Express } from 'express';
+import { db } from '../../packages/api/db';
+import { organizations, users, userOrganizations, reports, measurements } from '@shared/schema';
+import { eq, and } from 'drizzle-orm';
+import bcrypt from 'bcrypt';
+import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
+
+// Mock vite module before importing registerRoutes
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn()
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+// Helper function for password hashing
+async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, BCRYPT_SALT_ROUNDS);
+}
+
+// Test data
+let app: Express;
+let testOrg: any;
+let testCoach: any;
+let testAthlete: any;
+let coachAuthCookie: string;
+let createdReportIds: string[] = [];
+let createdPeerIds: string[] = [];
+
+beforeAll(async () => {
+  // Create Express app and register routes (mirrors the sibling report-trends harness).
+  app = express();
+  const defaultJsonParser = express.json();
+  const isLargePdfUpload = (req: express.Request) =>
+    req.method === 'POST' &&
+    req.path.endsWith('/pdf') &&
+    (req.path.startsWith('/api/reports/') || req.path.startsWith('/api/public/reports/'));
+  app.use((req, res, next) =>
+    isLargePdfUpload(req) ? next() : defaultJsonParser(req, res, next),
+  );
+  app.use(express.urlencoded({ extended: false }));
+  await registerRoutes(app);
+});
+
+afterAll(async () => {
+  if (testCoach) {
+    await db.delete(users).where(eq(users.id, testCoach.id));
+  }
+});
+
+beforeEach(async () => {
+  // Create fresh test organization
+  [testOrg] = await db.insert(organizations).values({
+    name: `ChartSel Org ${Date.now()}`,
+    description: 'Test organization for report chart-selection integration tests',
+    isActive: true,
+  }).returning();
+
+  // Create test coach user
+  const coachPassword = await hashPassword('TestCoach123!');
+  [testCoach] = await db.insert(users).values({
+    username: `chartselcoach_${Date.now()}`,
+    emails: [`chartselcoach_${Date.now()}@test.com`],
+    password: coachPassword,
+    firstName: 'ChartSel',
+    lastName: 'Coach',
+    fullName: 'ChartSel Coach',
+  }).returning();
+
+  await db.insert(userOrganizations).values({
+    userId: testCoach.id,
+    organizationId: testOrg.id,
+    role: 'coach',
+  });
+
+  // Create test athlete user (the report subject)
+  const athletePassword = await hashPassword('AthletePass123!');
+  [testAthlete] = await db.insert(users).values({
+    username: `chartselathlete_${Date.now()}`,
+    emails: [`chartselathlete_${Date.now()}@test.com`],
+    password: athletePassword,
+    firstName: 'ChartSel',
+    lastName: 'Athlete',
+    fullName: 'ChartSel Athlete',
+  }).returning();
+
+  await db.insert(userOrganizations).values({
+    userId: testAthlete.id,
+    organizationId: testOrg.id,
+    role: 'athlete',
+  });
+
+  // Seed two VERTICAL_JUMP measurements on different dates within an all_time window.
+  // Two dates so trends has a >= 2 point series; best (27.5) is the athleteValue.
+  await db.insert(measurements).values({
+    userId: testAthlete.id,
+    submittedBy: testCoach.id,
+    date: '2024-01-15',
+    age: 17,
+    metric: 'VERTICAL_JUMP',
+    value: '24.000',
+    units: 'in',
+    organizationId: testOrg.id,
+    isVerified: true,
+  });
+  await db.insert(measurements).values({
+    userId: testAthlete.id,
+    submittedBy: testCoach.id,
+    date: '2024-03-15',
+    age: 17,
+    metric: 'VERTICAL_JUMP',
+    value: '27.500',
+    units: 'in',
+    organizationId: testOrg.id,
+    isVerified: true,
+  });
+
+  // Login as coach and get session cookie
+  const coachLogin = await request(app)
+    .post('/api/auth/login')
+    .send({
+      username: testCoach.username,
+      password: 'TestCoach123!',
+    });
+
+  coachAuthCookie = coachLogin.headers['set-cookie'][0];
+});
+
+afterEach(async () => {
+  // Cleanup any peer athletes seeded for the distribution tests. Must run before
+  // the organization is deleted below, since peer measurements/memberships FK it.
+  for (const peerId of createdPeerIds) {
+    await db.delete(measurements).where(eq(measurements.userId, peerId));
+    await db.delete(userOrganizations).where(eq(userOrganizations.userId, peerId));
+    await db.delete(users).where(eq(users.id, peerId));
+  }
+  createdPeerIds = [];
+
+  // Cleanup in reverse dependency order
+  for (const reportId of createdReportIds) {
+    await db.delete(reports).where(eq(reports.id, reportId));
+  }
+  createdReportIds = [];
+
+  if (testAthlete) {
+    await db.delete(measurements).where(eq(measurements.userId, testAthlete.id));
+    await db.delete(userOrganizations).where(eq(userOrganizations.userId, testAthlete.id));
+    await db.delete(users).where(eq(users.id, testAthlete.id));
+    testAthlete = null;
+  }
+  if (testCoach && testOrg) {
+    await db.delete(userOrganizations).where(
+      and(
+        eq(userOrganizations.userId, testCoach.id),
+        eq(userOrganizations.organizationId, testOrg.id)
+      )
+    );
+  }
+  if (testCoach) {
+    await db.delete(users).where(eq(users.id, testCoach.id));
+    testCoach = null;
+  }
+  if (testOrg) {
+    await db.delete(organizations).where(eq(organizations.id, testOrg.id));
+  }
+});
+
+/**
+ * Seed a peer athlete in the same org with one measurement for `metric`.
+ * The distribution peer set is "best value per athlete in the org for the
+ * metric" — so the report athlete plus one peer gives the >= 2 values that
+ * computeDistribution requires.
+ */
+async function seedPeerAthlete(metric: string, value: string, date = '2024-02-15') {
+  const stamp = `${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const [peer] = await db.insert(users).values({
+    username: `chartselpeer_${stamp}`,
+    emails: [`chartselpeer_${stamp}@test.com`],
+    password: await hashPassword('PeerPass123!'),
+    firstName: 'ChartSel',
+    lastName: 'Peer',
+    fullName: 'ChartSel Peer',
+  }).returning();
+  createdPeerIds.push(peer.id);
+
+  await db.insert(userOrganizations).values({
+    userId: peer.id,
+    organizationId: testOrg.id,
+    role: 'athlete',
+  });
+
+  await db.insert(measurements).values({
+    userId: peer.id,
+    submittedBy: testCoach.id,
+    date,
+    age: 17,
+    metric,
+    value,
+    units: 'in',
+    organizationId: testOrg.id,
+    isVerified: true,
+  });
+
+  return peer;
+}
+
+/**
+ * Create an individual report over VERTICAL_JUMP with an arbitrary config
+ * fragment (e.g. { charts: { distribution: true } } or { showTrends: true }).
+ */
+async function createIndividualReport(extraConfig: Record<string, any>) {
+  const [report] = await db.insert(reports).values({
+    name: 'Individual Chart-Selection Report',
+    organizationId: testOrg.id,
+    reportType: 'individual',
+    config: {
+      timeframe: { type: 'preset', preset: 'all_time' },
+      metrics: ['VERTICAL_JUMP'],
+      ...extraConfig,
+    },
+    createdBy: testCoach.id,
+  }).returning();
+  createdReportIds.push(report.id);
+  return report;
+}
+
+async function generate(reportId: string) {
+  return request(app)
+    .post(`/api/reports/${reportId}/generate`)
+    .set('Cookie', coachAuthCookie)
+    .send({ athleteId: testAthlete.id });
+}
+
+describe('POST /api/reports/:id/generate — distribution payload', () => {
+  it('includes distributions[METRIC] when charts.distribution is true and a peer exists', async () => {
+    await seedPeerAthlete('VERTICAL_JUMP', '20.000');
+    const report = await createIndividualReport({ charts: { distribution: true } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('reportType', 'individual');
+
+    expect(response.body.distributions).toBeDefined();
+    const dist = response.body.distributions.VERTICAL_JUMP;
+    expect(dist).toBeDefined();
+
+    // values: sampled peer set, >= 2 (report athlete best + peer)
+    expect(Array.isArray(dist.values)).toBe(true);
+    expect(dist.values.length).toBeGreaterThanOrEqual(2);
+
+    // athleteValue: the report athlete's best (27.5)
+    expect(typeof dist.athleteValue).toBe('number');
+
+    // stats: five-number summary
+    expect(dist.stats).toBeDefined();
+    for (const key of ['min', 'q1', 'median', 'q3', 'max']) {
+      expect(typeof dist.stats[key]).toBe('number');
+    }
+  });
+
+  it('omits distributions when charts.distribution is false', async () => {
+    await seedPeerAthlete('VERTICAL_JUMP', '20.000');
+    const report = await createIndividualReport({ charts: { distribution: false } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.distributions).toBeUndefined();
+  });
+
+  it('omits the metric when distribution is enabled but there are < 2 peers', async () => {
+    // No peer seeded — only the report athlete has VERTICAL_JUMP, so the peer
+    // set has a single value and computeDistribution returns null. With it being
+    // the only metric, `distributions` collapses to undefined.
+    const report = await createIndividualReport({ charts: { distribution: true } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.distributions).toBeUndefined();
+  });
+});
+
+describe('POST /api/reports/:id/generate — trends gate via charts', () => {
+  it('omits trends when charts.trends is false', async () => {
+    const report = await createIndividualReport({ charts: { trends: false } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.trends).toBeUndefined();
+  });
+
+  it('includes trends[METRIC] when charts.trends is true', async () => {
+    const report = await createIndividualReport({ charts: { trends: true } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.trends).toBeDefined();
+    expect(response.body.trends).toHaveProperty('VERTICAL_JUMP');
+    expect(Array.isArray(response.body.trends.VERTICAL_JUMP.series)).toBe(true);
+    expect(response.body.trends.VERTICAL_JUMP.series.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('POST /api/reports/:id/generate — back-compat (no charts field)', () => {
+  it('falls back to legacy defaults: showTrends drives trends, distribution off', async () => {
+    // A peer exists, but with no `charts` field distribution stays off by default.
+    await seedPeerAthlete('VERTICAL_JUMP', '20.000');
+    const report = await createIndividualReport({ showTrends: true });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+
+    // Legacy showTrends -> trends present
+    expect(response.body.trends).toBeDefined();
+    expect(response.body.trends).toHaveProperty('VERTICAL_JUMP');
+
+    // Distribution defaults off for legacy reports
+    expect(response.body.distributions).toBeUndefined();
+  });
+});

--- a/tests/integration/report-chart-selection.test.ts
+++ b/tests/integration/report-chart-selection.test.ts
@@ -261,8 +261,12 @@ async function generate(reportId: string) {
 }
 
 describe('POST /api/reports/:id/generate — distribution payload', () => {
-  it('includes distributions[METRIC] when charts.distribution is true and a peer exists', async () => {
+  it('includes distributions[METRIC] when charts.distribution is true and peers exist', async () => {
+    // Two peers (distinct from the report athlete's 27.5) so the peers-only
+    // `values` array has >= 2 entries. The org population for the box is the
+    // athlete + these two peers = 3.
     await seedPeerAthlete('VERTICAL_JUMP', '20.000');
+    await seedPeerAthlete('VERTICAL_JUMP', '24.000');
     const report = await createIndividualReport({ charts: { distribution: true } });
 
     const response = await generate(report.id);
@@ -274,12 +278,15 @@ describe('POST /api/reports/:id/generate — distribution payload', () => {
     const dist = response.body.distributions.VERTICAL_JUMP;
     expect(dist).toBeDefined();
 
-    // values: sampled peer set, >= 2 (report athlete best + peer)
+    // values: peer dots only — the backend excludes the athlete before sampling
+    // so the athlete is not double-plotted (once as a peer dot, once as the star).
     expect(Array.isArray(dist.values)).toBe(true);
     expect(dist.values.length).toBeGreaterThanOrEqual(2);
 
-    // athleteValue: the report athlete's best (27.5)
+    // athleteValue: the report athlete's best (27.5), and NOT present among the
+    // peer dots (proves the exclusion-before-sampling contract).
     expect(typeof dist.athleteValue).toBe('number');
+    expect(dist.values).not.toContain(dist.athleteValue);
 
     // stats: five-number summary
     expect(dist.stats).toBeDefined();

--- a/tests/integration/report-chart-selection.test.ts
+++ b/tests/integration/report-chart-selection.test.ts
@@ -25,7 +25,7 @@ process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
 process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
 process.env.BYPASS_GENERAL_RATE_LIMIT = 'true'; // Bypass rate limits for these tests
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import express, { type Express } from 'express';
 import { db } from '../../packages/api/db';
@@ -70,12 +70,6 @@ beforeAll(async () => {
   );
   app.use(express.urlencoded({ extended: false }));
   await registerRoutes(app);
-});
-
-afterAll(async () => {
-  if (testCoach) {
-    await db.delete(users).where(eq(users.id, testCoach.id));
-  }
 });
 
 beforeEach(async () => {

--- a/tests/integration/report-chart-selection.test.ts
+++ b/tests/integration/report-chart-selection.test.ts
@@ -400,11 +400,13 @@ describe('POST /api/reports/:id/generate — trends gate via charts', () => {
 });
 
 describe('POST /api/reports/:id/generate — explicit empty charts (all-off)', () => {
-  it('treats a present-but-empty charts object as all-off: no distributions, no trends', async () => {
-    // A peer exists (distribution could resolve) but an explicit empty `charts`
-    // selects nothing — distinguishing it from legacy "no charts" defaults.
+  it('overrides legacy showTrends: empty charts means all-off even with showTrends true', async () => {
+    // A peer exists (distribution could resolve) and legacy showTrends is set —
+    // but an explicit empty `charts` selects nothing and must WIN over showTrends.
+    // If the resolver wrongly fell back to legacy defaults, trends would appear;
+    // seeding showTrends: true is what makes those two behaviors diverge here.
     await seedPeerAthlete('VERTICAL_JUMP', '20.000');
-    const report = await createIndividualReport({ charts: {} });
+    const report = await createIndividualReport({ charts: {}, showTrends: true });
 
     const response = await generate(report.id);
 

--- a/tests/integration/report-chart-selection.test.ts
+++ b/tests/integration/report-chart-selection.test.ts
@@ -29,7 +29,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } 
 import request from 'supertest';
 import express, { type Express } from 'express';
 import { db } from '../../packages/api/db';
-import { organizations, users, userOrganizations, reports, measurements } from '@shared/schema';
+import { organizations, users, userOrganizations, reports, measurements, teams } from '@shared/schema';
 import { eq, and } from 'drizzle-orm';
 import bcrypt from 'bcrypt';
 import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
@@ -55,6 +55,7 @@ let testAthlete: any;
 let coachAuthCookie: string;
 let createdReportIds: string[] = [];
 let createdPeerIds: string[] = [];
+let createdTeamIds: string[] = [];
 
 beforeAll(async () => {
   // Create Express app and register routes (mirrors the sibling report-trends harness).
@@ -171,6 +172,11 @@ afterEach(async () => {
   }
   createdReportIds = [];
 
+  for (const teamId of createdTeamIds) {
+    await db.delete(teams).where(eq(teams.id, teamId));
+  }
+  createdTeamIds = [];
+
   if (testAthlete) {
     await db.delete(measurements).where(eq(measurements.userId, testAthlete.id));
     await db.delete(userOrganizations).where(eq(userOrganizations.userId, testAthlete.id));
@@ -200,7 +206,7 @@ afterEach(async () => {
  * metric" — so the report athlete plus one peer gives the >= 2 values that
  * computeDistribution requires.
  */
-async function seedPeerAthlete(metric: string, value: string, date = '2024-02-15') {
+async function seedPeerAthlete(metric: string, value: string, date = '2024-02-15', teamId?: string) {
   const stamp = `${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
   const [peer] = await db.insert(users).values({
     username: `chartselpeer_${stamp}`,
@@ -227,10 +233,21 @@ async function seedPeerAthlete(metric: string, value: string, date = '2024-02-15
     value,
     units: 'in',
     organizationId: testOrg.id,
+    teamId,
     isVerified: true,
   });
 
   return peer;
+}
+
+/** Seed a team in the test org and track it for cleanup. Returns its id. */
+async function seedTeam(name: string): Promise<string> {
+  const [team] = await db.insert(teams).values({
+    organizationId: testOrg.id,
+    name,
+  }).returning();
+  createdTeamIds.push(team.id);
+  return team.id;
 }
 
 /**
@@ -315,6 +332,31 @@ describe('POST /api/reports/:id/generate — distribution payload', () => {
     // The tying peer is kept exactly once; the athlete's own 27.5 is not among the peers.
     expect(dist.values.filter((v: number) => v === 27.5)).toHaveLength(1);
     expect(dist.values).toContain(20);
+  });
+
+  it('scopes the peer cohort to the report filter teams and names the group', async () => {
+    // Two peers ON the filtered team, one peer OFF it. The distribution must
+    // reflect only the on-team peers, and comparisonLabel must name the team.
+    const teamId = await seedTeam('Alpha Squad');
+    await seedPeerAthlete('VERTICAL_JUMP', '22.000', '2024-02-15', teamId);
+    await seedPeerAthlete('VERTICAL_JUMP', '25.000', '2024-02-15', teamId);
+    await seedPeerAthlete('VERTICAL_JUMP', '30.000', '2024-02-15'); // off-team, must be excluded
+    const report = await createIndividualReport({
+      charts: { distribution: true },
+      filters: { teamIds: [teamId] },
+    });
+
+    const response = await generate(report.id);
+    expect(response.status).toBe(200);
+
+    const dist = response.body.distributions.VERTICAL_JUMP;
+    expect(dist).toBeDefined();
+    // Only the two on-team peers are in the cohort; the off-team 30 is excluded.
+    expect(dist.values).toContain(22);
+    expect(dist.values).toContain(25);
+    expect(dist.values).not.toContain(30);
+    // The caption names the cohort.
+    expect(response.body.comparisonLabel).toBe('Alpha Squad');
   });
 
   it('omits distributions when charts.distribution is false', async () => {


### PR DESCRIPTION
## Summary

Lets the creator choose which charts an **individual** report includes, adds the deferred **"you are here" distribution** chart, and removes a dead config path. Builds on the merged trends/radar/tier work.

- **Chart selection** — the report wizard replaces the lone "Show progress over time" checkbox with four toggles (**Radar / Benchmark standing / Trends / Distribution**), default all-on. A shared `resolveChartSelection(config)` decides which sections render, with **no-migration back-compat**: reports saved before this (no `charts`) resolve to their old appearance (radar+benchmark on, trends from legacy `showTrends`, distribution off). Each section still self-gates on data availability, so a toggle can only remove a section, never force an empty one.
- **"You are here" distribution** — a box-and-dots chart per metric (`box_swarm_combo`) showing the org-wide peer spread with the athlete as a green star (peers are blue dots). Uses the **same org-wide peer set the percentile is computed from** (so it lines up with the stated percentile), built by **reusing** those peer values (no extra query). The athlete's own value is excluded from the peer dots and shown only as the star; stats reflect the full population; dots are sampled to ≤150 for large orgs. Renders in the live view, public link, and PDF (`compact` mode on `BoxPlotChart` suppresses analytics chrome).
- **Cleanup** — removed the dead `userDefined` field from the *individual* report config type (nothing writes the `reportBenchmarks` table it read). Team reports still use it, so the shared/team type is unchanged.

Individual reports only. Design docs: `docs/superpowers/specs/2026-06-30-report-distribution-and-chart-selection-design.md`, `docs/superpowers/plans/2026-06-30-report-distribution-and-chart-selection.md`.

## Worth a reviewer's eye
- **Back-compat**: `resolveChartSelection` is the single gate; nothing reads `config.showTrends` directly anymore. Legacy reports/snapshots render unchanged (verified by an integration test).
- **`BoxPlotChart` `compact` prop**: defaults false; analytics callers are byte-identical when unset.
- **Default change**: new reports default all four charts on (previously trends were opt-in) — intended per the design.

## Test plan
- [x] Unit: `resolveChartSelection` (explicit + back-compat + override); `computeDistribution` (five-number stats, deterministic sampling, <2-peer null, sorted output)
- [x] Integration (vs Postgres): distribution present only when enabled; trends gate via `charts`; legacy `showTrends` back-compat; <2-peer omission
- [x] E2E: all charts render; toggling distribution off omits its section; public link renders distribution; desktop+mobile screenshots
- [x] `npm run check` clean; back-compat `report-trends` integration still green
- [ ] Reviewer: create an individual report toggling charts on/off; confirm the distribution box+dots (blue peers, green-star athlete) in live view, public link, and PDF, and that a metric with <2 peers is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add per-chart selection for individual reports and introduce a new peer distribution chart while cleaning up obsolete individual benchmark config.

New Features:
- Allow individual report creators to toggle inclusion of radar, benchmark standing, trends, and distribution charts via a unified charts config and wizard UI.
- Add an org-wide peer distribution payload and DistributionSection that render a box-and-dots "you are here" chart in live individual reports and public report snapshots.

Enhancements:
- Gate all individual report chart sections in live and public views through a shared resolveChartSelection helper to preserve legacy behavior without migrations.
- Extend the BoxPlotChart with a compact mode to better embed box-and-dots visuals in reports without analytics-only UI chrome.

Documentation:
- Add design and implementation-plan documents for report chart selection, distribution charts, and userDefined cleanup.

Tests:
- Add unit tests for chart selection resolution and distribution computation, plus integration and end-to-end tests to verify chart gating, distribution payloads, and public report rendering.

Chores:
- Remove the dead userDefined benchmark config field from individual report types while retaining it for team reports.