### PR TITLE
fix(ci): seed default metrics and apply cascade triggers in staging-deploy

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -51,6 +51,16 @@ jobs:
         env:
           DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}
 
+      - name: Seed default metrics
+        run: npx tsx scripts/seed-default-metrics.ts
+        env:
+          DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}
+
+      - name: Apply cascade delete triggers
+        run: ./scripts/apply-cascade-triggers.sh
+        env:
+          DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}
+
       - name: Run integration tests
         run: npm run test:integration
         env:


### PR DESCRIPTION
## Summary
- `staging-deploy.yml` was missing two steps that `pr-checks.yml` already has between database setup and running integration tests: seeding `site_metrics` and applying cascade delete triggers.
- Without seeded `site_metrics`, two staging integration test failures occur that do NOT reflect real product bugs:
  - `tests/integration/analytics-benchmark-tiers.test.ts` — hard FK violation (`custom_benchmarks.metric_code` references `site_metrics.code`), all 5 tests fail in `beforeEach`.
  - `tests/integration/report-chart-selection.test.ts` — 2 tests get a silently wrong answer because `report-service.ts`'s `getMetricInfo()` falls back to `{ lowerIsBetter: true }` when a metric isn't in `site_metrics`, causing VERTICAL_JUMP (higher-is-better) to pick `Math.min` instead of `Math.max`.
- Both test files pass in `pr-checks.yml` for the same commits, confirming the gap is specific to `staging-deploy.yml`'s missing seeding step, not a real regression.

## Change
Inserted the same two steps `pr-checks.yml` already runs, matching `staging-deploy.yml`'s own `DATABASE_URL` secret-reference style (no `|| 'postgres'` fallback, since this workflow always has secrets available):

```yaml
- name: Seed default metrics
  run: npx tsx scripts/seed-default-metrics.ts
  env:
    DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}

- name: Apply cascade delete triggers
  run: ./scripts/apply-cascade-triggers.sh
  env:
    DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}
```

Placed between the existing "Setup test database schema" step and "Run integration tests" step.

## Test plan
- [x] YAML validated locally (`yaml.safe_load`)
- [ ] Merge to `develop` and confirm the next "Deploy to Staging" GitHub Actions run passes `analytics-benchmark-tiers.test.ts` and `report-chart-selection.test.ts`

Note: this is CI infra only — no application/test source files were touched. Independent of PR #446 (develop -> main release), will ride along in the next develop -> main sync once merged.

## Summary by Sourcery

CI:
- Update staging-deploy GitHub Actions workflow to seed default metrics and apply cascade delete triggers prior to integration tests.