### PR TITLE
fix(ci): seed default metrics in production-deploy.yml before running integration tests

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -56,6 +56,11 @@ jobs:
         env:
           DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}
 
+      - name: Seed default metrics
+        run: npx tsx scripts/seed-default-metrics.ts
+        env:
+          DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}
+
       - name: Run integration tests
         run: npm run test:integration
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ E2E_*.md
 
 # Superpowers brainstorm mockups
 .superpowers/
+
+# Git worktrees (local dev isolation, not repo content)
+.worktrees/


### PR DESCRIPTION
## Summary
- `production-deploy.yml` ran `npm run db:push` (schema only) for its test-database setup but, unlike `staging-deploy.yml`, never ran `scripts/seed-default-metrics.ts` — so `site_metrics` was empty for every production-release CI run.
- With `site_metrics` empty, `ReportService.getMetricInfo()` (`packages/api/services/report-service.ts:1906`) silently fell back to `lowerIsBetter: true` for every metric, including `VERTICAL_JUMP` (which is higher-is-better). That flipped `bestPerformances` to `Math.min` instead of `Math.max`, breaking the distribution-payload assertions in `tests/integration/report-chart-selection.test.ts`.
- The same missing seed also caused `custom_benchmarks` inserts to violate `custom_benchmarks_metric_code_site_metrics_code_fk` in `tests/integration/analytics-benchmark-tiers.test.ts`, since there were no `site_metrics` rows for the referenced codes.
- This is what caused [run #76](https://github.com/johnahull/AthleteMetrics/actions/runs/28563749029) (`v0.23.0` production deploy) to fail at "Run integration tests" and block the deploy.

## Fix
Add the same "Seed default metrics" step `staging-deploy.yml` already has, between "Setup test database schema" and "Run integration tests" in `production-deploy.yml`. Also added `.worktrees/` to `.gitignore` (used to isolate this fix from in-progress work on another branch).

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Step mirrors the existing, working `staging-deploy.yml` step exactly
- [ ] Confirm the next `develop → main` release run passes "Run integration tests" (this workflow only triggers on `release: published`, so it can't be exercised in this PR directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align production deploy CI workflow test database setup with staging by seeding default metrics before running integration tests.

CI:
- Add a 'Seed default metrics' step to the production-deploy workflow to populate site metrics in the test database before integration tests run.

Chores:
- Ignore Git worktree directories by adding .worktrees/ to .gitignore.