### PR TITLE
release: v0.23.1 — CI pipeline fix + test flakiness fix

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -56,6 +56,11 @@ jobs:
         env:
           DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}
 
+      - name: Seed default metrics
+        run: npx tsx scripts/seed-default-metrics.ts
+        env:
+          DATABASE_URL: postgresql://${{ secrets.CI_POSTGRES_USER }}:${{ secrets.CI_POSTGRES_PASSWORD }}@localhost:5432/${{ secrets.CI_POSTGRES_DB }}
+
       - name: Run integration tests
         run: npm run test:integration
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ E2E_*.md
 
 # Superpowers brainstorm mockups
 .superpowers/
+
+# Git worktrees (local dev isolation, not repo content)
+.worktrees/

--- a/packages/api/__tests__/auth-service.test.ts
+++ b/packages/api/__tests__/auth-service.test.ts
@@ -522,9 +522,20 @@ describe("AuthService", () => {
       });
       const successTime = Date.now() - startTime2;
 
-      // Both should take similar time due to bcrypt (>50ms typically)
-      expect(failTime).toBeGreaterThan(50);
-      expect(successTime).toBeGreaterThan(50);
+      // Sanity floor: confirm bcrypt.compare genuinely ran (not short-circuited)
+      // rather than asserting an absolute wall-clock threshold, which is flaky
+      // under variable CI runner speed.
+      expect(failTime).toBeGreaterThan(0);
+      expect(successTime).toBeGreaterThan(0);
+
+      // The actual timing-safety property: a failed login and a successful
+      // login should take comparable time, so a timing side-channel can't be
+      // used to distinguish valid vs invalid passwords. Compare the two
+      // durations directly instead of each against a fixed floor.
+      const [slower, faster] = failTime >= successTime
+        ? [failTime, successTime]
+        : [successTime, failTime];
+      expect(slower / faster).toBeLessThan(3);
     });
   });
 


### PR DESCRIPTION
## Release Readiness: v0.23.1

**Proposed version**: 0.23.1 (PATCH — both changes are bug fixes; no schema, API, or breaking changes)
**Changes**: 3 files changed, 22 insertions(+), 3 deletions(-)
(`git diff main develop --stat`, not `git log main..develop`, per this repo's squash-merge caveat)

### Why this release

The last production deploy (GitHub Actions run [#76](https://github.com/johnahull/AthleteMetrics/actions/runs/28563749029), for `v0.23.0`) failed at the "Run integration tests" step. `production-deploy.yml` ran schema-only `db:push` but never seeded `site_metrics`, so `ReportService.getMetricInfo()` silently fell back to `lowerIsBetter: true` for every metric (including higher-is-better ones like `VERTICAL_JUMP`), and `custom_benchmarks` inserts violated their FK constraint on `site_metrics`. This release ships the fix so the next production deploy can complete.

### Checklist Status

- [x] Both PRs individually passed CI (Unit Tests, integration checks) before merge to `develop`
- [x] No TypeScript errors — no application/production source touched (test file, workflow YAML, `.gitignore` only)
- [x] No schema/migration changes
- [x] No new dependencies / `package-lock.json` unchanged
- [x] No breaking changes
- [x] Changelog drafted (below)

### Verdict: GO

**Blockers**: None

---

## Changelog: v0.23.0 → v0.23.1

Breaking Changes: 0
Features: 0
Bug Fixes: 2
Security: 0
Maintenance: 0

### Bug Fixes
- **CI**: Production deploy workflow now seeds `site_metrics` before running integration tests, matching `staging-deploy.yml`. Previously the missing seed caused silent `lowerIsBetter: true` fallback in `ReportService.getMetricInfo()` for all metrics and FK violations on `custom_benchmarks` inserts, failing the last production deploy (run #76). — [#449](https://github.com/johnahull/AthleteMetrics/pull/449)
- **Tests**: `auth-service.test.ts`'s bcrypt timing test no longer asserts an absolute 50ms wall-clock floor per call (flaky under variable CI runner speed). It now asserts a near-zero sanity floor plus a direct ratio comparison between fail/success durations, which is the actual timing-safety property being verified. Test-only change; no auth source modified. — [#448](https://github.com/johnahull/AthleteMetrics/pull/448)

---

## What's New in v0.23.1

Maintenance release: fixes the CI pipeline bug that blocked the `v0.23.0` production deploy, plus a flaky test fix picked up along the way.

### Highlights
- Production deploy CI now seeds default metrics before integration tests run, unblocking production deploys.
- Bcrypt timing-safety test de-flaked (compares fail/success durations directly instead of a fixed threshold).

### Full Changelog

#### Bug Fixes
- CI: seed default metrics in `production-deploy.yml` before running integration tests (#449)
- Tests: stop asserting absolute bcrypt timing floor in `auth-service.test.ts` (#448)

---
**Full diff**: `v0.23.0...v0.23.1`

## Summary by Sourcery

Fix CI production deploy pipeline and stabilize a flaky auth timing test.

Bug Fixes:
- Update the production deploy workflow to seed default metrics before running integration tests so production deployments no longer fail on missing data.
- Adjust the auth service bcrypt timing test to assert relative timing behavior instead of a fixed duration threshold to eliminate test flakiness in CI.