### PR TITLE
feat(reports): team report chart data + selection (stage 1 of 3)

### DIFF
--- a/packages/api/services/__tests__/report-team-charts.test.ts
+++ b/packages/api/services/__tests__/report-team-charts.test.ts
@@ -85,6 +85,46 @@ describe('assembleTeamTrends', () => {
     const trends = assembleTeamTrends([], ['VJ'], { VJ: 'higher' }, { VJ: [] });
     expect(trends.VJ).toBeUndefined();
   });
+
+  it('collapses same-day retests to the best value instead of double-weighting that athlete in the team average (regression: a second same-date row used to be averaged in as if it were a second athlete)', () => {
+    const rows = [
+      // Alice retested VJ twice on the same day — best (higher-is-better) is 26.
+      row('a1', 'Alice', 'VJ', '2025-09-01', 20),
+      row('a1', 'Alice', 'VJ', '2025-09-01', 26),
+      row('a2', 'Bob', 'VJ', '2025-09-01', 24),
+      row('a1', 'Alice', 'VJ', '2026-02-01', 30),
+      row('a2', 'Bob', 'VJ', '2026-02-01', 32),
+    ];
+    const trends = assembleTeamTrends(rows, ['VJ'], { VJ: 'higher' }, { VJ: [] });
+
+    // Team average must be (26 + 24) / 2 = 25, not (20 + 26 + 24) / 3.
+    expect(trends.VJ.teamSeries).toEqual([
+      { date: '2025-09-01', value: 25 },
+      { date: '2026-02-01', value: 31 },
+    ]);
+
+    // Alice's own series must also collapse to one point for that date.
+    const alice = trends.VJ.athleteSeries.find(s => s.athleteId === 'a1')!;
+    expect(alice.series).toEqual([
+      { date: '2025-09-01', value: 26 },
+      { date: '2026-02-01', value: 30 },
+    ]);
+  });
+
+  it('collapses same-day retests to the lowest value for a lower-is-better metric', () => {
+    const rows = [
+      row('a1', 'Alice', 'DASH', '2025-09-01', 5.6),
+      row('a1', 'Alice', 'DASH', '2025-09-01', 4.9), // faster (better) retest
+      row('a2', 'Bob', 'DASH', '2025-09-01', 5.2),
+      row('a1', 'Alice', 'DASH', '2026-02-01', 4.7),
+      row('a2', 'Bob', 'DASH', '2026-02-01', 5.0),
+    ];
+    const trends = assembleTeamTrends(rows, ['DASH'], { DASH: 'lower' }, { DASH: [] });
+
+    expect(trends.DASH.teamSeries[0]).toEqual({ date: '2025-09-01', value: (4.9 + 5.2) / 2 });
+    const alice = trends.DASH.athleteSeries.find(s => s.athleteId === 'a1')!;
+    expect(alice.series[0]).toEqual({ date: '2025-09-01', value: 4.9 });
+  });
 });
 
 describe('computeTeamDistribution', () => {

--- a/packages/api/services/__tests__/report-team-charts.test.ts
+++ b/packages/api/services/__tests__/report-team-charts.test.ts
@@ -1,0 +1,130 @@
+// packages/api/services/__tests__/report-team-charts.test.ts
+import { describe, it, expect } from 'vitest';
+import { assembleTeamTrends, computeTeamDistribution } from '../report-team-charts';
+
+// Minimal shape of a per-athlete measurement row used by assembleTeamTrends.
+const row = (athleteId: string, athleteName: string, metric: string, date: string, value: number) => ({
+  athleteId, athleteName, metric, date, value: String(value),
+});
+
+describe('assembleTeamTrends', () => {
+  it('computes the team-average per date and preserves per-athlete series', () => {
+    const rows = [
+      row('a1', 'Alice', 'VJ', '2025-09-01', 20),
+      row('a2', 'Bob', 'VJ', '2025-09-01', 24),
+      row('a1', 'Alice', 'VJ', '2026-02-01', 26),
+      row('a2', 'Bob', 'VJ', '2026-02-01', 30),
+    ];
+    const trends = assembleTeamTrends(rows, ['VJ'], { VJ: 'higher' }, { VJ: [] });
+
+    expect(trends.VJ.teamSeries).toEqual([
+      { date: '2025-09-01', value: 22 },
+      { date: '2026-02-01', value: 28 },
+    ]);
+
+    expect(trends.VJ.athleteSeries).toHaveLength(2);
+    const alice = trends.VJ.athleteSeries.find(s => s.athleteId === 'a1')!;
+    expect(alice.athleteName).toBe('Alice');
+    expect(alice.series).toEqual([
+      { date: '2025-09-01', value: 20 },
+      { date: '2026-02-01', value: 26 },
+    ]);
+    const bob = trends.VJ.athleteSeries.find(s => s.athleteId === 'a2')!;
+    expect(bob.series.map(p => p.value)).toEqual([24, 30]);
+  });
+
+  it('computes positive improvement pct for a higher-is-better metric', () => {
+    const rows = [
+      row('a1', 'Alice', 'VJ', '2025-09-01', 20),
+      row('a1', 'Alice', 'VJ', '2026-02-01', 25),
+    ];
+    const trends = assembleTeamTrends(rows, ['VJ'], { VJ: 'higher' }, { VJ: [] });
+    expect(trends.VJ.direction).toBe('higher');
+    expect(trends.VJ.delta.from).toBe(20);
+    expect(trends.VJ.delta.to).toBe(25);
+    expect(Math.round(trends.VJ.delta.pct)).toBe(25); // (25-20)/20*100
+  });
+
+  it('computes positive improvement pct for a lower-is-better metric', () => {
+    const rows = [
+      row('a1', 'Alice', 'DASH', '2025-09-01', 5.6),
+      row('a1', 'Alice', 'DASH', '2026-02-01', 4.92),
+    ];
+    const trends = assembleTeamTrends(rows, ['DASH'], { DASH: 'lower' }, { DASH: [] });
+    expect(trends.DASH.direction).toBe('lower');
+    expect(trends.DASH.delta.from).toBe(5.6);
+    expect(trends.DASH.delta.to).toBe(4.92);
+    expect(Math.round(trends.DASH.delta.pct)).toBe(12); // (5.6-4.92)/5.6*100
+  });
+
+  it('derives the benchmark overlay from the metric comparisons via deriveOverlay', () => {
+    const rows = [
+      row('a1', 'Alice', 'VJ', '2025-09-01', 20),
+      row('a1', 'Alice', 'VJ', '2026-02-01', 25),
+    ];
+    const trends = assembleTeamTrends(rows, ['VJ'], { VJ: 'higher' }, {
+      VJ: [{ benchmarkName: 'Target', benchmarkValue: 24 }],
+    });
+    expect(trends.VJ.benchmark).toEqual({
+      kind: 'thresholds',
+      lines: [{ name: 'Target', value: 24, color: '#ef4444' }],
+    });
+  });
+
+  it('drops a metric whose teamSeries has fewer than 2 distinct dates', () => {
+    // Both athletes measured on the SAME single date -> only 1 team-series point.
+    const rows = [
+      row('a1', 'Alice', 'VJ', '2025-09-01', 20),
+      row('a2', 'Bob', 'VJ', '2025-09-01', 24),
+    ];
+    const trends = assembleTeamTrends(rows, ['VJ'], { VJ: 'higher' }, { VJ: [] });
+    expect(trends.VJ).toBeUndefined();
+  });
+
+  it('omits a metric with no rows at all', () => {
+    const trends = assembleTeamTrends([], ['VJ'], { VJ: 'higher' }, { VJ: [] });
+    expect(trends.VJ).toBeUndefined();
+  });
+});
+
+describe('computeTeamDistribution', () => {
+  it('computes five-number stats, teamAverage, and preserves per-athlete dots', () => {
+    const athletes = [
+      { athleteId: 'a1', athleteName: 'Alice', value: 10 },
+      { athleteId: 'a2', athleteName: 'Bob', value: 20 },
+      { athleteId: 'a3', athleteName: 'Carl', value: 40 },
+      { athleteId: 'a4', athleteName: 'Dee', value: 50 },
+    ];
+    const dist = computeTeamDistribution(athletes)!;
+    expect(dist.stats.min).toBe(10);
+    expect(dist.stats.max).toBe(50);
+    expect(dist.stats.median).toBe(30);
+    expect(dist.stats.q1).toBeCloseTo(17.5, 5);
+    expect(dist.stats.q3).toBeCloseTo(42.5, 5);
+    expect(dist.teamAverage).toBe(30);
+    expect(dist.values).toEqual([10, 20, 40, 50]);
+    expect(dist.athletes).toEqual(athletes);
+  });
+
+  it('returns sorted values for unsorted athlete input', () => {
+    const athletes = [
+      { athleteId: 'a1', athleteName: 'Alice', value: 40 },
+      { athleteId: 'a2', athleteName: 'Bob', value: 10 },
+    ];
+    const dist = computeTeamDistribution(athletes)!;
+    expect(dist.values).toEqual([10, 40]);
+  });
+
+  it('returns null for 0 or 1 athletes', () => {
+    expect(computeTeamDistribution([])).toBeNull();
+    expect(computeTeamDistribution([{ athleteId: 'a1', athleteName: 'Alice', value: 42 }])).toBeNull();
+  });
+
+  it('returns non-null for exactly 2 athletes', () => {
+    const dist = computeTeamDistribution([
+      { athleteId: 'a1', athleteName: 'Alice', value: 10 },
+      { athleteId: 'a2', athleteName: 'Bob', value: 20 },
+    ]);
+    expect(dist).not.toBeNull();
+  });
+});

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -31,9 +31,10 @@ import { type MetricExplanation } from '@shared/metric-explanations';
 import { getMetricExplanationsMap } from './metric-explanation-service';
 import { assembleTrends } from './report-trends';
 import { computeDistribution } from './report-distributions';
+import { assembleTeamTrends, computeTeamDistribution } from './report-team-charts';
 import { buildCohortLabel } from './cohort-label';
-import { resolveChartSelection, type ChartSelection } from '@shared/report-charts';
-import type { ReportTrends, ReportDistributions } from '@shared/report-trends-types';
+import { resolveChartSelection, resolveTeamChartSelection, type ChartSelection } from '@shared/report-charts';
+import type { ReportTrends, ReportDistributions, TeamReportTrends, TeamReportDistributions } from '@shared/report-trends-types';
 import type { BenchmarkComparison } from '@shared/benchmark-types';
 
 interface TimeframeConfig {
@@ -134,6 +135,9 @@ interface TeamReportData {
   metricExplanations: Record<string, MetricExplanation>;
   eventContext?: EventContext; // Present when eventId filter is used
   orgBranding?: OrgBranding;
+  teamTrends?: TeamReportTrends; // present only when chartSelection.trends is true
+  teamDistributions?: TeamReportDistributions; // present only when chartSelection.boxSwarm is true
+  comparisonLabel?: string; // cohort name when filters narrow the roster (undefined = whole org/report scope)
 }
 
 interface IndividualReportData {
@@ -269,6 +273,66 @@ export class ReportService extends BaseService {
       report.organizationId,
     );
 
+    const chartSelection = resolveTeamChartSelection(config);
+
+    // Build team-average time-series trends when the report opts in (additive; off by default)
+    let teamTrends: TeamReportTrends | undefined;
+    if (chartSelection.trends) {
+      const infos = await Promise.all(config.metrics.map(m => this.getMetricInfo(m)));
+      const directions: Record<string, 'higher' | 'lower'> = {};
+      config.metrics.forEach((metric, i) => {
+        directions[metric] = infos[i].lowerIsBetter ? 'lower' : 'higher';
+      });
+
+      // Reuse the per-athlete benchmark comparisons already computed by
+      // calculateAthleteRankings above — tier boundaries don't depend on which
+      // athlete's value triggered the evaluation, so any athlete with a
+      // comparison for the metric supplies the overlay for the whole team.
+      const comparisonsByMetric: Record<string, BenchmarkComparison[]> = {};
+      for (const metric of config.metrics) {
+        const withComparison = athleteRankings.find(a => a.benchmarkComparisons[metric]?.length);
+        comparisonsByMetric[metric] = withComparison?.benchmarkComparisons[metric] ?? [];
+      }
+
+      teamTrends = assembleTeamTrends(
+        // Reuse measurementData already fetched for teamStatistics — do not re-query.
+        measurementData.map(m => ({
+          athleteId: m.measurement.userId,
+          athleteName: m.user?.fullName || 'Unknown',
+          metric: m.measurement.metric,
+          date: typeof m.measurement.date === 'string'
+            ? m.measurement.date
+            : new Date(m.measurement.date).toISOString().split('T')[0],
+          value: m.measurement.value,
+        })),
+        config.metrics,
+        directions,
+        comparisonsByMetric,
+      );
+    }
+
+    // Build the team-wide five-number-summary + per-athlete dots for box+swarm
+    let teamDistributions: TeamReportDistributions | undefined;
+    if (chartSelection.boxSwarm) {
+      teamDistributions = {};
+      for (const metric of config.metrics) {
+        const athletesForMetric = athleteRankings
+          .filter(a => a.measurements[metric] !== undefined)
+          .map(a => ({ athleteId: a.userId, athleteName: a.userName, value: a.measurements[metric] }));
+        const dist = computeTeamDistribution(athletesForMetric);
+        if (dist) {
+          // getMetricInfo memoizes (warmed by calculateTeamStatistics/calculateAthleteRankings above).
+          const info = await this.getMetricInfo(metric);
+          teamDistributions[metric] = { ...dist, direction: info.lowerIsBetter ? 'lower' : 'higher' };
+        }
+      }
+      if (Object.keys(teamDistributions).length === 0) teamDistributions = undefined;
+    }
+
+    // Human label for the roster cohort (names the group when filters narrow it),
+    // matching the individual report's "Where You Stand" caption convention.
+    const comparisonLabel = await this.resolveComparisonLabel(report.organizationId, config.filters);
+
     // Get event context if eventId is specified
     let eventContext: EventContext | undefined;
     if (config.eventId) {
@@ -301,6 +365,9 @@ export class ReportService extends BaseService {
       metricUnits,
       metricExplanations,
       eventContext,
+      teamTrends,
+      teamDistributions,
+      comparisonLabel,
     };
 
     return result;
@@ -482,22 +549,7 @@ export class ReportService extends BaseService {
 
     // Human label for the peer cohort (names the group in the "Where You Stand"
     // caption). Undefined when no filter narrows the cohort → frontend says "your group".
-    let comparisonLabel: string | undefined;
-    const f = config.filters;
-    if (f && (f.teamIds?.length || f.gender || f.positions?.length)) {
-      let filterTeamNames: string[] = [];
-      if (f.teamIds?.length) {
-        const rows = await db
-          .select({ name: teams.name })
-          .from(teams)
-          // Scope to this report's org so a crafted cross-org teamId can't leak
-          // another org's team name into the caption.
-          .where(and(eq(teams.organizationId, report.organizationId), inArray(teams.id, f.teamIds)))
-          .orderBy(teams.name); // deterministic label order for multi-team cohorts
-        filterTeamNames = rows.map((r) => r.name);
-      }
-      comparisonLabel = buildCohortLabel(filterTeamNames, f.gender, f.positions);
-    }
+    const comparisonLabel = await this.resolveComparisonLabel(report.organizationId, config.filters);
 
     const athletePerformance: AthletePerformance = {
       userId: athlete.id,
@@ -1803,6 +1855,32 @@ export class ReportService extends BaseService {
     }
 
     return benchmarksByMetric;
+  }
+
+  /**
+   * Human label for a filter-narrowed cohort (e.g. "the Varsity Squad, Male"),
+   * shared by both the individual "Where You Stand" caption and the team
+   * report's roster caption. Undefined when no filter narrows the cohort.
+   */
+  private async resolveComparisonLabel(
+    organizationId: string,
+    filters: { teamIds?: string[]; gender?: string; positions?: string[] } | undefined,
+  ): Promise<string | undefined> {
+    if (!filters || !(filters.teamIds?.length || filters.gender || filters.positions?.length)) {
+      return undefined;
+    }
+    let filterTeamNames: string[] = [];
+    if (filters.teamIds?.length) {
+      const rows = await db
+        .select({ name: teams.name })
+        .from(teams)
+        // Scope to this report's org so a crafted cross-org teamId can't leak
+        // another org's team name into the caption.
+        .where(and(eq(teams.organizationId, organizationId), inArray(teams.id, filters.teamIds)))
+        .orderBy(teams.name); // deterministic label order for multi-team cohorts
+      filterTeamNames = rows.map((r) => r.name);
+    }
+    return buildCohortLabel(filterTeamNames, filters.gender, filters.positions);
   }
 
   private async getMetricInfo(metricCode: string) {

--- a/packages/api/services/report-team-charts.ts
+++ b/packages/api/services/report-team-charts.ts
@@ -49,12 +49,29 @@ export function assembleTeamTrends(
   const trends: TeamReportTrends = {};
 
   for (const metric of metrics) {
-    const metricRows = rowsByAthlete
+    const direction = directions[metric] ?? 'higher';
+    const isBetter = (candidate: number, current: number) =>
+      direction === 'lower' ? candidate < current : candidate > current;
+
+    const parsedRows = rowsByAthlete
       .filter(r => r.metric === metric)
       .map(r => ({ ...r, value: parseFloat(r.value) }))
       // Drop non-numeric measurement values: a malformed `value` would parse to
       // NaN and poison the team average / delta.
       .filter(r => !Number.isNaN(r.value));
+
+    // Collapse same-day retests to the best value per athlete before
+    // averaging — otherwise a retested athlete counts twice in that date's
+    // team average, silently double-weighting them relative to teammates.
+    const bestByAthleteDate = new Map<string, typeof parsedRows[number]>();
+    for (const r of parsedRows) {
+      const key = `${r.athleteId}|${r.date}`;
+      const existing = bestByAthleteDate.get(key);
+      if (!existing || isBetter(r.value, existing.value)) {
+        bestByAthleteDate.set(key, r);
+      }
+    }
+    const metricRows = Array.from(bestByAthleteDate.values());
 
     // Per-athlete ascending series (faint background context for Stage 2).
     const byAthlete = new Map<string, { athleteName: string; series: TrendPoint[] }>();
@@ -85,7 +102,6 @@ export function assembleTeamTrends(
 
     if (teamSeries.length < 2) continue;
 
-    const direction = directions[metric] ?? 'higher';
     const delta = computeTrendDelta(direction, teamSeries[0].value, teamSeries[teamSeries.length - 1].value);
 
     trends[metric] = {

--- a/packages/api/services/report-team-charts.ts
+++ b/packages/api/services/report-team-charts.ts
@@ -1,0 +1,126 @@
+// packages/api/services/report-team-charts.ts
+import { quantile, mean } from 'simple-statistics';
+import { deriveOverlay, computeTrendDelta } from './report-trends';
+import type {
+  TrendPoint, AthleteTrendSeries, TeamReportTrends, TeamMetricDistribution,
+} from '@shared/report-trends-types';
+
+/** Minimal per-athlete measurement row shape needed here (value is a decimal string). */
+interface TeamTrendMeasurementRow {
+  athleteId: string;
+  athleteName: string;
+  metric: string;
+  date: string;   // YYYY-MM-DD
+  value: string;
+}
+
+/** Subset of a benchmark comparison read by deriveOverlay (mirrors report-trends.ts's ComparisonLike). */
+interface ComparisonLike {
+  benchmarkName: string;
+  benchmarkValue: number;
+  allTiers?: Array<{
+    tierName: string; tierColor: string; tierOrder: number;
+    minValue: number | null; maxValue: number | null;
+  }>;
+}
+
+/**
+ * Build the per-metric team trend map. Pure: no DB access.
+ *
+ * Mirrors report-trends.ts's assembleTrends, but averages across the roster
+ * instead of tracking a single athlete: `teamSeries` is the mean of that
+ * date's values across every athlete measured on that exact date (no
+ * fuzzy date-window bucketing), while `athleteSeries` retains each athlete's
+ * own ascending series for later faint-overlay rendering.
+ *
+ * @param rowsByAthlete  all in-window measurements for the roster (any order)
+ * @param metrics        metric codes selected on the report
+ * @param directions     metric code -> 'higher' | 'lower' (lower = lower-is-better)
+ * @param comparisonsByMetric  metric code -> benchmark comparisons (any athlete's
+ *   evaluated comparisons for that metric — tier boundaries don't depend on
+ *   which athlete's value triggered the evaluation)
+ */
+export function assembleTeamTrends(
+  rowsByAthlete: TeamTrendMeasurementRow[],
+  metrics: string[],
+  directions: Record<string, 'higher' | 'lower'>,
+  comparisonsByMetric: Record<string, ComparisonLike[]>,
+): TeamReportTrends {
+  const trends: TeamReportTrends = {};
+
+  for (const metric of metrics) {
+    const metricRows = rowsByAthlete
+      .filter(r => r.metric === metric)
+      .map(r => ({ ...r, value: parseFloat(r.value) }))
+      // Drop non-numeric measurement values: a malformed `value` would parse to
+      // NaN and poison the team average / delta.
+      .filter(r => !Number.isNaN(r.value));
+
+    // Per-athlete ascending series (faint background context for Stage 2).
+    const byAthlete = new Map<string, { athleteName: string; series: TrendPoint[] }>();
+    for (const r of metricRows) {
+      if (!byAthlete.has(r.athleteId)) {
+        byAthlete.set(r.athleteId, { athleteName: r.athleteName, series: [] });
+      }
+      byAthlete.get(r.athleteId)!.series.push({ date: r.date, value: r.value });
+    }
+    const athleteSeries: AthleteTrendSeries[] = Array.from(byAthlete.entries()).map(
+      ([athleteId, { athleteName, series }]) => ({
+        athleteId,
+        athleteName,
+        series: series.slice().sort((a, b) => a.date.localeCompare(b.date)),
+      }),
+    );
+
+    // Team-average per exact date (only dates with at least one measurement).
+    const byDate = new Map<string, number[]>();
+    for (const r of metricRows) {
+      const values = byDate.get(r.date) || [];
+      values.push(r.value);
+      byDate.set(r.date, values);
+    }
+    const teamSeries: TrendPoint[] = Array.from(byDate.entries())
+      .map(([date, values]) => ({ date, value: mean(values) }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    if (teamSeries.length < 2) continue;
+
+    const direction = directions[metric] ?? 'higher';
+    const delta = computeTrendDelta(direction, teamSeries[0].value, teamSeries[teamSeries.length - 1].value);
+
+    trends[metric] = {
+      teamSeries,
+      athleteSeries,
+      direction,
+      delta,
+      benchmark: deriveOverlay(comparisonsByMetric[metric]),
+    };
+  }
+
+  return trends;
+}
+
+/**
+ * Build a team-level five-number-summary distribution for one metric. Pure.
+ *
+ * Analogous to report-distributions.ts's computeDistribution, but team-native:
+ * there's no single focal athlete to separate from the population — every
+ * athlete on the roster is plotted as a dot. Returns null when fewer than 2
+ * athletes have a value (no meaningful distribution).
+ */
+export function computeTeamDistribution(
+  athletes: Array<{ athleteId: string; athleteName: string; value: number }>,
+): Omit<TeamMetricDistribution, 'direction'> | null {
+  if (!athletes || athletes.length < 2) return null;
+
+  const values = athletes.map(a => a.value).sort((a, b) => a - b);
+  const stats = {
+    min: values[0],
+    q1: quantile(values, 0.25),
+    median: quantile(values, 0.5),
+    q3: quantile(values, 0.75),
+    max: values[values.length - 1],
+  };
+
+  return { values, athletes, stats, teamAverage: mean(values) };
+}

--- a/packages/api/services/report-trends.ts
+++ b/packages/api/services/report-trends.ts
@@ -22,6 +22,22 @@ interface ComparisonLike {
 
 const DEFAULT_THRESHOLD_COLOR = '#ef4444';
 
+/**
+ * Direction-aware percent change from `from` to `to` (0 when `from` is 0, to
+ * avoid a division-by-zero blowup). Shared by individual and team trend
+ * assembly so "improvement" is defined identically for both.
+ */
+export function computeTrendDelta(
+  direction: 'higher' | 'lower',
+  from: number,
+  to: number,
+): { from: number; to: number; pct: number } {
+  const pct = from === 0 ? 0
+    : direction === 'lower' ? ((from - to) / from) * 100
+    : ((to - from) / from) * 100;
+  return { from, to, pct };
+}
+
 /** Convert a metric's benchmark comparisons into a chart overlay. */
 export function deriveOverlay(comparisons: ComparisonLike[] | undefined): BenchmarkOverlay {
   if (!comparisons || comparisons.length === 0) return { kind: 'none' };
@@ -70,16 +86,12 @@ export function assembleTrends(
     if (series.length < 2) continue;
 
     const direction = directions[metric] ?? 'higher';
-    const from = series[0].value;
-    const to = series[series.length - 1].value;
-    const pct = from === 0 ? 0
-      : direction === 'lower' ? ((from - to) / from) * 100
-      : ((to - from) / from) * 100;
+    const delta = computeTrendDelta(direction, series[0].value, series[series.length - 1].value);
 
     const trend: MetricTrend = {
       series,
       direction,
-      delta: { from, to, pct },
+      delta,
       benchmark: deriveOverlay(comparisons[metric]),
     };
     trends[metric] = trend;

--- a/packages/shared/__tests__/report-charts-schema.test.ts
+++ b/packages/shared/__tests__/report-charts-schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { insertReportSchema, updateReportSchema } from '../schema-original';
+
+/**
+ * Regression coverage for a bug caught in code review: insertReportSchema /
+ * updateReportSchema's config.charts sub-schema only declared the 4
+ * individual-report keys. Zod's default "strip" behavior silently dropped
+ * the 3 team-native keys (leaderboard, tierDistribution, boxSwarm) from
+ * every team report submitted through POST/PUT /api/reports, even though
+ * the wizard and resolveTeamChartSelection both expect them to round-trip.
+ * The DB-level integration tests don't catch this because they insert rows
+ * directly, bypassing schema validation entirely — this test parses through
+ * the actual schema, the way the API route does.
+ */
+describe('insertReportSchema / updateReportSchema — config.charts', () => {
+  const teamChartsPayload = {
+    radar: true,
+    benchmarkStanding: false,
+    trends: true,
+    boxSwarm: true,
+    leaderboard: false,
+    tierDistribution: true,
+  };
+
+  it('insertReportSchema retains all team-native chart keys (no silent stripping)', () => {
+    const result = insertReportSchema.parse({
+      organizationId: 'org-1',
+      name: 'Team Report',
+      reportType: 'team',
+      config: {
+        timeframe: { type: 'preset', preset: 'season' },
+        metrics: ['VERTICAL_JUMP'],
+        charts: teamChartsPayload,
+      },
+    });
+
+    expect(result.config.charts).toEqual(teamChartsPayload);
+  });
+
+  it('updateReportSchema retains all team-native chart keys (no silent stripping)', () => {
+    const result = updateReportSchema.parse({
+      config: {
+        charts: teamChartsPayload,
+      },
+    });
+
+    expect(result.config?.charts).toEqual(teamChartsPayload);
+  });
+});

--- a/packages/shared/__tests__/report-charts.test.ts
+++ b/packages/shared/__tests__/report-charts.test.ts
@@ -30,8 +30,7 @@ describe('resolveChartSelection', () => {
 
 describe('resolveTeamChartSelection', () => {
   it('uses explicit charts config when present (missing keys -> false)', () => {
-    expect(resolveTeamChartSelection({ charts: { radar: true, boxSwarm: true } })).toEqual({
-      radar: true,
+    expect(resolveTeamChartSelection({ charts: { boxSwarm: true } })).toEqual({
       benchmarkStanding: false,
       trends: false,
       boxSwarm: true,
@@ -43,18 +42,18 @@ describe('resolveTeamChartSelection', () => {
   it('respects explicit false overrides', () => {
     expect(resolveTeamChartSelection({
       charts: {
-        radar: false, benchmarkStanding: true, trends: true,
+        benchmarkStanding: true, trends: true,
         boxSwarm: false, leaderboard: true, tierDistribution: false,
       },
     })).toEqual({
-      radar: false, benchmarkStanding: true, trends: true,
+      benchmarkStanding: true, trends: true,
       boxSwarm: false, leaderboard: true, tierDistribution: false,
     });
   });
 
   it('treats a present-but-empty charts object as all-off (explicit selection)', () => {
     expect(resolveTeamChartSelection({ charts: {} })).toEqual({
-      radar: false, benchmarkStanding: false, trends: false,
+      benchmarkStanding: false, trends: false,
       boxSwarm: false, leaderboard: false, tierDistribution: false,
     });
   });
@@ -65,15 +64,15 @@ describe('resolveTeamChartSelection', () => {
   // they never had. Legacy team configs must resolve to ALL FALSE.
   it('legacy config with no charts field resolves to ALL FALSE (not the individual defaults)', () => {
     expect(resolveTeamChartSelection({})).toEqual({
-      radar: false, benchmarkStanding: false, trends: false,
+      benchmarkStanding: false, trends: false,
       boxSwarm: false, leaderboard: false, tierDistribution: false,
     });
     expect(resolveTeamChartSelection(undefined)).toEqual({
-      radar: false, benchmarkStanding: false, trends: false,
+      benchmarkStanding: false, trends: false,
       boxSwarm: false, leaderboard: false, tierDistribution: false,
     });
     expect(resolveTeamChartSelection(null)).toEqual({
-      radar: false, benchmarkStanding: false, trends: false,
+      benchmarkStanding: false, trends: false,
       boxSwarm: false, leaderboard: false, tierDistribution: false,
     });
   });

--- a/packages/shared/__tests__/report-charts.test.ts
+++ b/packages/shared/__tests__/report-charts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveChartSelection } from '../report-charts';
+import { resolveChartSelection, resolveTeamChartSelection } from '../report-charts';
 
 describe('resolveChartSelection', () => {
   it('uses explicit charts config when present (missing keys -> false)', () => {
@@ -24,6 +24,57 @@ describe('resolveChartSelection', () => {
   it('treats a present-but-empty charts object as all-off (explicit selection)', () => {
     expect(resolveChartSelection({ charts: {} })).toEqual({
       radar: false, benchmarkStanding: false, trends: false, distribution: false,
+    });
+  });
+});
+
+describe('resolveTeamChartSelection', () => {
+  it('uses explicit charts config when present (missing keys -> false)', () => {
+    expect(resolveTeamChartSelection({ charts: { radar: true, boxSwarm: true } })).toEqual({
+      radar: true,
+      benchmarkStanding: false,
+      trends: false,
+      boxSwarm: true,
+      leaderboard: false,
+      tierDistribution: false,
+    });
+  });
+
+  it('respects explicit false overrides', () => {
+    expect(resolveTeamChartSelection({
+      charts: {
+        radar: false, benchmarkStanding: true, trends: true,
+        boxSwarm: false, leaderboard: true, tierDistribution: false,
+      },
+    })).toEqual({
+      radar: false, benchmarkStanding: true, trends: true,
+      boxSwarm: false, leaderboard: true, tierDistribution: false,
+    });
+  });
+
+  it('treats a present-but-empty charts object as all-off (explicit selection)', () => {
+    expect(resolveTeamChartSelection({ charts: {} })).toEqual({
+      radar: false, benchmarkStanding: false, trends: false,
+      boxSwarm: false, leaderboard: false, tierDistribution: false,
+    });
+  });
+
+  // Critical back-compat case: every pre-existing team report has no `charts`
+  // field. If this resolver reused resolveChartSelection's legacy defaults
+  // (radar+benchmarkStanding on), those reports would suddenly sprout charts
+  // they never had. Legacy team configs must resolve to ALL FALSE.
+  it('legacy config with no charts field resolves to ALL FALSE (not the individual defaults)', () => {
+    expect(resolveTeamChartSelection({})).toEqual({
+      radar: false, benchmarkStanding: false, trends: false,
+      boxSwarm: false, leaderboard: false, tierDistribution: false,
+    });
+    expect(resolveTeamChartSelection(undefined)).toEqual({
+      radar: false, benchmarkStanding: false, trends: false,
+      boxSwarm: false, leaderboard: false, tierDistribution: false,
+    });
+    expect(resolveTeamChartSelection(null)).toEqual({
+      radar: false, benchmarkStanding: false, trends: false,
+      boxSwarm: false, leaderboard: false, tierDistribution: false,
     });
   });
 });

--- a/packages/shared/report-charts.ts
+++ b/packages/shared/report-charts.ts
@@ -25,8 +25,19 @@ export const DEFAULT_CHART_SELECTION: ChartSelection = {
  *  athlete's percentile (computed against an external cohort), a team's
  *  average percentile is computed against its own roster, so averaging it
  *  across the team converges toward ~50% regardless of how good the team
- *  actually is — not a meaningful "team all-around profile." */
-export type TeamChartSelection = Omit<ChartSelection, 'distribution' | 'radar'>;
+ *  actually is — not a meaningful "team all-around profile."
+ *
+ *  A dedicated interface (rather than `Omit<ChartSelection, ...>`) so these
+ *  fields are required booleans here — resolveTeamChartSelection always sets
+ *  all five concretely, even though ChartSelection itself declares them
+ *  optional for the individual resolver's sake. */
+export interface TeamChartSelection {
+  benchmarkStanding: boolean;
+  trends: boolean;
+  leaderboard: boolean;
+  tierDistribution: boolean;
+  boxSwarm: boolean;
+}
 
 /** Config subset this resolver reads. */
 interface ChartConfigInput {

--- a/packages/shared/report-charts.ts
+++ b/packages/shared/report-charts.ts
@@ -5,12 +5,24 @@ export interface ChartSelection {
   benchmarkStanding: boolean;
   trends: boolean;
   distribution: boolean;
+  // Team-only charts (team-report-charts Stage 1). Optional here so
+  // resolveChartSelection's existing individual-only return values (which
+  // don't set these) keep type-checking unchanged; resolveTeamChartSelection
+  // always sets them concretely.
+  leaderboard?: boolean;
+  tierDistribution?: boolean;
+  boxSwarm?: boolean;
 }
 
 /** Default chart selection for new reports — all charts on. */
 export const DEFAULT_CHART_SELECTION: ChartSelection = {
   radar: true, benchmarkStanding: true, trends: true, distribution: true,
+  leaderboard: true, tierDistribution: true, boxSwarm: true,
 };
+
+/** Team reports don't use the individual-only `distribution` histogram — they
+ *  use `boxSwarm` instead. */
+export type TeamChartSelection = Omit<ChartSelection, 'distribution'>;
 
 /** Config subset this resolver reads. */
 interface ChartConfigInput {
@@ -40,5 +52,35 @@ export function resolveChartSelection(config: ChartConfigInput | undefined | nul
     benchmarkStanding: true,
     trends: config?.showTrends ?? false,
     distribution: false,
+  };
+}
+
+/**
+ * Resolve which team-report charts are enabled. Unlike {@link resolveChartSelection},
+ * the legacy branch (no `charts` field) returns ALL FALSE — every pre-existing
+ * team report has no `charts` field today and rendered tables only, so it must
+ * NOT inherit the individual resolver's "radar+benchmarkStanding on" default.
+ */
+export function resolveTeamChartSelection(config: ChartConfigInput | undefined | null): TeamChartSelection {
+  const c = config?.charts;
+  // A present `charts` object is the explicit selection — an empty object means
+  // all charts off (same convention as resolveChartSelection).
+  if (c) {
+    return {
+      radar: c.radar ?? false,
+      benchmarkStanding: c.benchmarkStanding ?? false,
+      trends: c.trends ?? false,
+      leaderboard: c.leaderboard ?? false,
+      tierDistribution: c.tierDistribution ?? false,
+      boxSwarm: c.boxSwarm ?? false,
+    };
+  }
+  return {
+    radar: false,
+    benchmarkStanding: false,
+    trends: false,
+    leaderboard: false,
+    tierDistribution: false,
+    boxSwarm: false,
   };
 }

--- a/packages/shared/report-charts.ts
+++ b/packages/shared/report-charts.ts
@@ -21,8 +21,12 @@ export const DEFAULT_CHART_SELECTION: ChartSelection = {
 };
 
 /** Team reports don't use the individual-only `distribution` histogram — they
- *  use `boxSwarm` instead. */
-export type TeamChartSelection = Omit<ChartSelection, 'distribution'>;
+ *  use `boxSwarm` instead. They also don't use `radar`: unlike an individual
+ *  athlete's percentile (computed against an external cohort), a team's
+ *  average percentile is computed against its own roster, so averaging it
+ *  across the team converges toward ~50% regardless of how good the team
+ *  actually is — not a meaningful "team all-around profile." */
+export type TeamChartSelection = Omit<ChartSelection, 'distribution' | 'radar'>;
 
 /** Config subset this resolver reads. */
 interface ChartConfigInput {
@@ -67,7 +71,6 @@ export function resolveTeamChartSelection(config: ChartConfigInput | undefined |
   // all charts off (same convention as resolveChartSelection).
   if (c) {
     return {
-      radar: c.radar ?? false,
       benchmarkStanding: c.benchmarkStanding ?? false,
       trends: c.trends ?? false,
       leaderboard: c.leaderboard ?? false,
@@ -76,7 +79,6 @@ export function resolveTeamChartSelection(config: ChartConfigInput | undefined |
     };
   }
   return {
-    radar: false,
     benchmarkStanding: false,
     trends: false,
     leaderboard: false,

--- a/packages/shared/report-trends-types.ts
+++ b/packages/shared/report-trends-types.ts
@@ -48,3 +48,34 @@ export interface MetricDistribution {
 
 /** Map of metric code -> distribution. Present only when the distribution chart is enabled. */
 export type ReportDistributions = Record<string, MetricDistribution>;
+
+/** One athlete's trend series, for faint-overlay rendering behind the team-average line. */
+export interface AthleteTrendSeries {
+  athleteId: string;
+  athleteName: string;
+  series: TrendPoint[];
+}
+
+/** Team-level trend data for one metric: a bold team-average line plus per-athlete context. */
+export interface TeamMetricTrend {
+  teamSeries: TrendPoint[];             // team-average per date, ascending, >= 2 points required
+  athleteSeries: AthleteTrendSeries[];  // per-athlete series (Stage 2 caps this to ~8 client-side)
+  direction: 'higher' | 'lower';         // higher-is-better vs lower-is-better
+  delta: { from: number; to: number; pct: number }; // computed on teamSeries; pct > 0 = improvement
+  benchmark: BenchmarkOverlay;
+}
+
+/** Map of metric code -> team trend. Present on a team report only when the trends chart is enabled. */
+export type TeamReportTrends = Record<string, TeamMetricTrend>;
+
+/** Team-wide distribution for one metric: every athlete's best value plus a five-number summary. */
+export interface TeamMetricDistribution {
+  values: number[];                     // every athlete's best-per-metric value, sorted ascending
+  athletes: Array<{ athleteId: string; athleteName: string; value: number }>;
+  stats: { min: number; q1: number; median: number; q3: number; max: number };
+  teamAverage: number;
+  direction: 'higher' | 'lower';  // higher-is-better vs lower-is-better
+}
+
+/** Map of metric code -> team distribution. Present only when the box+swarm chart is enabled. */
+export type TeamReportDistributions = Record<string, TeamMetricDistribution>;

--- a/packages/shared/schema-original.ts
+++ b/packages/shared/schema-original.ts
@@ -2206,6 +2206,9 @@ export const insertReportSchema = createInsertSchema(reports).omit({
       benchmarkStanding: z.boolean().optional(),
       trends: z.boolean().optional(),
       distribution: z.boolean().optional(),
+      leaderboard: z.boolean().optional(),
+      tierDistribution: z.boolean().optional(),
+      boxSwarm: z.boolean().optional(),
     }).optional(),
     compositeIndex: z.object({
       enabled: z.boolean(),
@@ -2252,6 +2255,9 @@ export const updateReportSchema = z.object({
       benchmarkStanding: z.boolean().optional(),
       trends: z.boolean().optional(),
       distribution: z.boolean().optional(),
+      leaderboard: z.boolean().optional(),
+      tierDistribution: z.boolean().optional(),
+      boxSwarm: z.boolean().optional(),
     }).optional(),
     compositeIndex: z.object({
       enabled: z.boolean(),

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -259,7 +259,6 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
     ['distribution', 'Where you stand (distribution)', 'The group spread with the athlete marked'],
   ];
   const teamChartItems: ReadonlyArray<readonly [ChartItemKey, string, string]> = [
-    ['radar', 'All-around profile (radar)', `${labels.team} average percentile shape across all metrics (needs ≥3 metrics)`],
     ['benchmarkStanding', 'Benchmark standing', `Where the ${labels.team.toLowerCase()} average sits vs each benchmark`],
     ['trends', 'Progress over time', `${labels.team} average trend line per metric (needs ≥2 measurements)`],
     ['boxSwarm', 'Distribution (box + swarm)', `The spread of every ${labels.athlete.toLowerCase()}'s performance per metric`],
@@ -376,7 +375,6 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
     // (e.g. team reports use `boxSwarm`, not `distribution`, and vice versa).
     config.charts = data.reportType === "team"
       ? {
-          radar: data.charts.radar,
           benchmarkStanding: data.charts.benchmarkStanding,
           trends: data.charts.trends,
           boxSwarm: data.charts.boxSwarm,

--- a/packages/web/src/components/reports/ReportWizard.tsx
+++ b/packages/web/src/components/reports/ReportWizard.tsx
@@ -62,6 +62,9 @@ const reportConfigSchema = z.object({
     benchmarkStanding: z.boolean().default(true),
     trends: z.boolean().default(true),
     distribution: z.boolean().default(true),
+    leaderboard: z.boolean().default(true),
+    tierDistribution: z.boolean().default(true),
+    boxSwarm: z.boolean().default(true),
   }).default(DEFAULT_CHART_SELECTION),
   compositeWeights: z.record(z.string(), z.number()).optional(),
 }).superRefine((data, ctx) => {
@@ -245,6 +248,39 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
     );
   };
 
+  // Chart selection items shown in the step-8 "Charts to include" panel.
+  // Individual and team reports show different chart sets (team doesn't use
+  // the individual-only `distribution` histogram — it uses `boxSwarm` instead).
+  type ChartItemKey = keyof NonNullable<ReportFormData["charts"]>;
+  const individualChartItems: ReadonlyArray<readonly [ChartItemKey, string, string]> = [
+    ['radar', 'All-around profile (radar)', 'Percentile shape across all metrics (needs ≥3 metrics)'],
+    ['benchmarkStanding', 'Benchmark standing', 'Where the athlete sits vs each benchmark'],
+    ['trends', 'Progress over time', 'Trend line per metric (needs ≥2 measurements)'],
+    ['distribution', 'Where you stand (distribution)', 'The group spread with the athlete marked'],
+  ];
+  const teamChartItems: ReadonlyArray<readonly [ChartItemKey, string, string]> = [
+    ['radar', 'All-around profile (radar)', `${labels.team} average percentile shape across all metrics (needs ≥3 metrics)`],
+    ['benchmarkStanding', 'Benchmark standing', `Where the ${labels.team.toLowerCase()} average sits vs each benchmark`],
+    ['trends', 'Progress over time', `${labels.team} average trend line per metric (needs ≥2 measurements)`],
+    ['boxSwarm', 'Distribution (box + swarm)', `The spread of every ${labels.athlete.toLowerCase()}'s performance per metric`],
+    ['leaderboard', 'Leaderboard', `Ranked bar chart of ${labels.athletes.toLowerCase()} per metric`],
+    ['tierDistribution', 'Tier distribution', `${labels.team} composition across benchmark tiers`],
+  ];
+  const renderChartCheckboxes = (items: ReadonlyArray<readonly [ChartItemKey, string, string]>) => (
+    <>
+      {items.map(([key, title, desc]) => (
+        <div key={key} className="flex items-start space-x-2">
+          <Checkbox id={`chart-${key}`} checked={charts?.[key] ?? true}
+            onCheckedChange={(v) => setValue(`charts.${key}` as const, v as boolean)} className="mt-1" />
+          <div>
+            <Label htmlFor={`chart-${key}`} className="cursor-pointer font-medium">{title}</Label>
+            <p className="text-sm text-muted-foreground">{desc}</p>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+
   const handleNext = (e?: React.MouseEvent) => {
     e?.preventDefault();
 
@@ -335,10 +371,24 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
       };
     }
 
-    // Chart selection is an individual-report feature; don't pollute team configs.
-    if (data.reportType === "individual") {
-      config.charts = data.charts;
-    }
+    // Each report type only persists the chart keys it actually uses, so the
+    // stored config doesn't carry inert fields from the other report type
+    // (e.g. team reports use `boxSwarm`, not `distribution`, and vice versa).
+    config.charts = data.reportType === "team"
+      ? {
+          radar: data.charts.radar,
+          benchmarkStanding: data.charts.benchmarkStanding,
+          trends: data.charts.trends,
+          boxSwarm: data.charts.boxSwarm,
+          leaderboard: data.charts.leaderboard,
+          tierDistribution: data.charts.tierDistribution,
+        }
+      : {
+          radar: data.charts.radar,
+          benchmarkStanding: data.charts.benchmarkStanding,
+          trends: data.charts.trends,
+          distribution: data.charts.distribution,
+        };
 
     if (data.teamIds?.length || data.gender || data.positions?.length) {
       config.filters = {
@@ -897,6 +947,12 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
                   Skip composite index to create a report without athlete rankings. Click "Create Report" to continue.
                 </p>
               )}
+
+              <Separator />
+              <div className="border rounded-lg p-4 bg-muted/30 space-y-4">
+                <Label className="font-medium">Charts to include</Label>
+                {renderChartCheckboxes(teamChartItems)}
+              </div>
             </div>
           )}
 
@@ -925,21 +981,7 @@ export function ReportWizard({ open, onClose, onSuccess }: ReportWizardProps) {
               </div>
               <div className="border rounded-lg p-4 bg-muted/30 space-y-4">
                 <Label className="font-medium">Charts to include</Label>
-                {([
-                  ['radar', 'All-around profile (radar)', 'Percentile shape across all metrics (needs ≥3 metrics)'],
-                  ['benchmarkStanding', 'Benchmark standing', 'Where the athlete sits vs each benchmark'],
-                  ['trends', 'Progress over time', 'Trend line per metric (needs ≥2 measurements)'],
-                  ['distribution', 'Where you stand (distribution)', 'The group spread with the athlete marked'],
-                ] as const).map(([key, title, desc]) => (
-                  <div key={key} className="flex items-start space-x-2">
-                    <Checkbox id={`chart-${key}`} checked={charts?.[key] ?? true}
-                      onCheckedChange={(v) => setValue(`charts.${key}` as const, v as boolean)} className="mt-1" />
-                    <div>
-                      <Label htmlFor={`chart-${key}`} className="cursor-pointer font-medium">{title}</Label>
-                      <p className="text-sm text-muted-foreground">{desc}</p>
-                    </div>
-                  </div>
-                ))}
+                {renderChartCheckboxes(individualChartItems)}
               </div>
             </div>
           )}

--- a/packages/web/src/types/report-types.ts
+++ b/packages/web/src/types/report-types.ts
@@ -1,7 +1,7 @@
 import type { MetricExplanation } from '@shared/metric-explanations';
 import type { ReportTrends, ReportDistributions, TeamReportTrends, TeamReportDistributions } from '@shared/report-trends-types';
 import type { BenchmarkComparison } from '@shared/benchmark-types';
-import type { ChartSelection } from '@shared/report-charts';
+import type { ChartSelection, TeamChartSelection } from '@shared/report-charts';
 
 export interface Benchmark {
   name: string;
@@ -75,7 +75,10 @@ export interface TeamReportConfig {
     enabled: boolean;
     weights?: Record<string, number>;
   };
-  charts?: Partial<ChartSelection>;
+  // Partial<TeamChartSelection>, not ChartSelection: team configs don't have
+  // radar/distribution, so this rejects those individual-only keys at compile
+  // time instead of only filtering them out at wizard-submit time.
+  charts?: Partial<TeamChartSelection>;
 }
 
 export interface IndividualReportConfig {
@@ -108,6 +111,10 @@ export interface TeamReportData {
   metricLabels?: Record<string, string>;
   metricUnits?: Record<string, string>;
   metricExplanations?: Record<string, MetricExplanation>;
+  /** Per-metric direction ('lower' = lower-is-better), so client components can
+   *  evaluate tier standing without needing authenticated org-scoped metric
+   *  config — required for the public/anonymous report view. */
+  metricDirections?: Record<string, 'higher' | 'lower'>;
   orgBranding?: OrgBranding;
   teamTrends?: TeamReportTrends;
   teamDistributions?: TeamReportDistributions;

--- a/packages/web/src/types/report-types.ts
+++ b/packages/web/src/types/report-types.ts
@@ -1,5 +1,5 @@
 import type { MetricExplanation } from '@shared/metric-explanations';
-import type { ReportTrends, ReportDistributions } from '@shared/report-trends-types';
+import type { ReportTrends, ReportDistributions, TeamReportTrends, TeamReportDistributions } from '@shared/report-trends-types';
 import type { BenchmarkComparison } from '@shared/benchmark-types';
 import type { ChartSelection } from '@shared/report-charts';
 
@@ -75,6 +75,7 @@ export interface TeamReportConfig {
     enabled: boolean;
     weights?: Record<string, number>;
   };
+  charts?: Partial<ChartSelection>;
 }
 
 export interface IndividualReportConfig {
@@ -108,6 +109,9 @@ export interface TeamReportData {
   metricUnits?: Record<string, string>;
   metricExplanations?: Record<string, MetricExplanation>;
   orgBranding?: OrgBranding;
+  teamTrends?: TeamReportTrends;
+  teamDistributions?: TeamReportDistributions;
+  comparisonLabel?: string;
 }
 
 export interface IndividualAthleteData {

--- a/tests/integration/report-team-chart-selection.test.ts
+++ b/tests/integration/report-team-chart-selection.test.ts
@@ -46,6 +46,7 @@ async function hashPassword(password: string): Promise<string> {
 let app: Express;
 let testOrg: any;
 let testCoach: any;
+let coachAuthCookie: string;
 let createdReportIds: string[] = [];
 let createdAthleteIds: string[] = [];
 
@@ -95,8 +96,6 @@ beforeEach(async () => {
 
   coachAuthCookie = coachLogin.headers['set-cookie'][0];
 });
-
-let coachAuthCookie: string;
 
 afterEach(async () => {
   for (const reportId of createdReportIds) {
@@ -292,5 +291,44 @@ describe('POST /api/reports/:id/generate — back-compat (no charts field)', () 
     expect(response.body).toHaveProperty('reportType', 'team');
     expect(response.body.teamTrends).toBeUndefined();
     expect(response.body.teamDistributions).toBeUndefined();
+  });
+});
+
+// --- Stage 3: public snapshot surfaces the same team chart payload ---
+//
+// createSnapshot() calls generateTeamReport() directly (see report-service.ts),
+// so the trends/distributions computation itself is already fully covered by
+// the `/generate` tests above. This is a thin end-to-end check that the PUBLIC
+// route (GET /api/public/reports/:token) actually forwards those same fields
+// in snapshotData, rather than re-deriving or dropping them.
+describe('GET /api/public/reports/:token — team chart payload passthrough', () => {
+  it('surfaces teamTrends and teamDistributions on the public snapshot when selected', async () => {
+    await seedAthlete([
+      { date: '2024-01-15', value: '20.000' },
+      { date: '2024-03-15', value: '24.000' },
+    ]);
+    await seedAthlete([
+      { date: '2024-01-15', value: '30.000' },
+      { date: '2024-03-15', value: '32.000' },
+    ]);
+    const report = await createTeamReport({ charts: { trends: true, boxSwarm: true } });
+
+    const snapshotRes = await request(app)
+      .post(`/api/reports/${report.id}/snapshots`)
+      .set('Cookie', coachAuthCookie)
+      .send({ expirationDays: 7 });
+    expect(snapshotRes.status).toBe(201);
+    const publicToken = snapshotRes.body.publicToken;
+    expect(publicToken).toBeTruthy();
+
+    const publicRes = await request(app).get(`/api/public/reports/${publicToken}`);
+
+    expect(publicRes.status).toBe(200);
+    const { snapshotData } = publicRes.body;
+    expect(snapshotData).toHaveProperty('reportType', 'team');
+    expect(snapshotData.teamTrends).toBeDefined();
+    expect(snapshotData.teamTrends).toHaveProperty('VERTICAL_JUMP');
+    expect(snapshotData.teamDistributions).toBeDefined();
+    expect(snapshotData.teamDistributions).toHaveProperty('VERTICAL_JUMP');
   });
 });

--- a/tests/integration/report-team-chart-selection.test.ts
+++ b/tests/integration/report-team-chart-selection.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Integration Tests for Team Report Chart Selection + Trend/Distribution Payload
+ *
+ * Verifies resolveTeamChartSelection and the teamTrends/teamDistributions payload
+ * produced by generateTeamReport (via POST /api/reports/:id/generate) against a
+ * real test database:
+ *   1. config.charts.trends=true seeds `teamTrends[METRIC]`.
+ *   2. config.charts.boxSwarm=true seeds `teamDistributions[METRIC]`.
+ *   3. config.charts present but both false -> teamTrends/teamDistributions omitted.
+ *   4. Back-compat: a team config with NO `charts` field omits BOTH
+ *      teamTrends and teamDistributions (proves resolveTeamChartSelection's
+ *      all-off legacy default end-to-end, not just at the unit level).
+ *
+ * Modeled on tests/integration/report-chart-selection.test.ts (same harness/bootstrap).
+ */
+
+// Set environment variables BEFORE any imports
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET = 'test-secret-key-for-integration-tests-only-at-least-32-characters-long';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+process.env.BYPASS_GENERAL_RATE_LIMIT = 'true'; // Bypass rate limits for these tests
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { type Express } from 'express';
+import { db } from '../../packages/api/db';
+import { organizations, users, userOrganizations, reports, measurements } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import bcrypt from 'bcrypt';
+import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
+
+// Mock vite module before importing registerRoutes
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn()
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, BCRYPT_SALT_ROUNDS);
+}
+
+let app: Express;
+let testOrg: any;
+let testCoach: any;
+let createdReportIds: string[] = [];
+let createdAthleteIds: string[] = [];
+
+beforeAll(async () => {
+  app = express();
+  const defaultJsonParser = express.json();
+  const isLargePdfUpload = (req: express.Request) =>
+    req.method === 'POST' &&
+    req.path.endsWith('/pdf') &&
+    (req.path.startsWith('/api/reports/') || req.path.startsWith('/api/public/reports/'));
+  app.use((req, res, next) =>
+    isLargePdfUpload(req) ? next() : defaultJsonParser(req, res, next),
+  );
+  app.use(express.urlencoded({ extended: false }));
+  await registerRoutes(app);
+});
+
+beforeEach(async () => {
+  [testOrg] = await db.insert(organizations).values({
+    name: `TeamChartSel Org ${Date.now()}`,
+    description: 'Test organization for team report chart-selection integration tests',
+    isActive: true,
+  }).returning();
+
+  const coachPassword = await hashPassword('TestCoach123!');
+  [testCoach] = await db.insert(users).values({
+    username: `teamchartselcoach_${Date.now()}`,
+    emails: [`teamchartselcoach_${Date.now()}@test.com`],
+    password: coachPassword,
+    firstName: 'TeamChartSel',
+    lastName: 'Coach',
+    fullName: 'TeamChartSel Coach',
+  }).returning();
+
+  await db.insert(userOrganizations).values({
+    userId: testCoach.id,
+    organizationId: testOrg.id,
+    role: 'coach',
+  });
+
+  const coachLogin = await request(app)
+    .post('/api/auth/login')
+    .send({
+      username: testCoach.username,
+      password: 'TestCoach123!',
+    });
+
+  coachAuthCookie = coachLogin.headers['set-cookie'][0];
+});
+
+let coachAuthCookie: string;
+
+afterEach(async () => {
+  for (const reportId of createdReportIds) {
+    await db.delete(reports).where(eq(reports.id, reportId));
+  }
+  createdReportIds = [];
+
+  for (const athleteId of createdAthleteIds) {
+    await db.delete(measurements).where(eq(measurements.userId, athleteId));
+    await db.delete(userOrganizations).where(eq(userOrganizations.userId, athleteId));
+    await db.delete(users).where(eq(users.id, athleteId));
+  }
+  createdAthleteIds = [];
+
+  if (testCoach && testOrg) {
+    await db.delete(userOrganizations).where(eq(userOrganizations.userId, testCoach.id));
+  }
+  if (testCoach) {
+    await db.delete(users).where(eq(users.id, testCoach.id));
+    testCoach = null;
+  }
+  if (testOrg) {
+    await db.delete(organizations).where(eq(organizations.id, testOrg.id));
+  }
+});
+
+/**
+ * Seed a roster athlete with two VERTICAL_JUMP measurements on distinct dates
+ * (so trends has a >= 2 team-series point when combined across the roster).
+ */
+async function seedAthlete(values: Array<{ date: string; value: string }>) {
+  const stamp = `${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const [athlete] = await db.insert(users).values({
+    username: `teamchartselathlete_${stamp}`,
+    emails: [`teamchartselathlete_${stamp}@test.com`],
+    password: await hashPassword('AthletePass123!'),
+    firstName: 'TeamChartSel',
+    lastName: 'Athlete',
+    fullName: 'TeamChartSel Athlete',
+  }).returning();
+  createdAthleteIds.push(athlete.id);
+
+  await db.insert(userOrganizations).values({
+    userId: athlete.id,
+    organizationId: testOrg.id,
+    role: 'athlete',
+  });
+
+  for (const { date, value } of values) {
+    await db.insert(measurements).values({
+      userId: athlete.id,
+      submittedBy: testCoach.id,
+      date,
+      age: 17,
+      metric: 'VERTICAL_JUMP',
+      value,
+      units: 'in',
+      organizationId: testOrg.id,
+      isVerified: true,
+    });
+  }
+
+  return athlete;
+}
+
+async function createTeamReport(extraConfig: Record<string, any>) {
+  const [report] = await db.insert(reports).values({
+    name: 'Team Chart-Selection Report',
+    organizationId: testOrg.id,
+    reportType: 'team',
+    config: {
+      timeframe: { type: 'preset', preset: 'all_time' },
+      metrics: ['VERTICAL_JUMP'],
+      ...extraConfig,
+    },
+    createdBy: testCoach.id,
+  }).returning();
+  createdReportIds.push(report.id);
+  return report;
+}
+
+async function generate(reportId: string) {
+  return request(app)
+    .post(`/api/reports/${reportId}/generate`)
+    .set('Cookie', coachAuthCookie)
+    .send({});
+}
+
+describe('POST /api/reports/:id/generate — team teamTrends payload', () => {
+  it('includes teamTrends[METRIC] when charts.trends is true', async () => {
+    // Two athletes each with two dated measurements -> teamSeries has >= 2 points.
+    await seedAthlete([
+      { date: '2024-01-15', value: '20.000' },
+      { date: '2024-03-15', value: '24.000' },
+    ]);
+    await seedAthlete([
+      { date: '2024-01-15', value: '22.000' },
+      { date: '2024-03-15', value: '26.000' },
+    ]);
+    const report = await createTeamReport({ charts: { trends: true } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('reportType', 'team');
+    expect(response.body.teamTrends).toBeDefined();
+    expect(response.body.teamTrends).toHaveProperty('VERTICAL_JUMP');
+    expect(Array.isArray(response.body.teamTrends.VERTICAL_JUMP.teamSeries)).toBe(true);
+    expect(response.body.teamTrends.VERTICAL_JUMP.teamSeries.length).toBeGreaterThanOrEqual(2);
+    expect(Array.isArray(response.body.teamTrends.VERTICAL_JUMP.athleteSeries)).toBe(true);
+    expect(response.body.teamTrends.VERTICAL_JUMP.athleteSeries.length).toBe(2);
+  });
+
+  it('omits teamTrends when charts.trends is false', async () => {
+    await seedAthlete([
+      { date: '2024-01-15', value: '20.000' },
+      { date: '2024-03-15', value: '24.000' },
+    ]);
+    const report = await createTeamReport({ charts: { trends: false } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.teamTrends).toBeUndefined();
+  });
+});
+
+describe('POST /api/reports/:id/generate — team teamDistributions payload', () => {
+  it('includes teamDistributions[METRIC] when charts.boxSwarm is true and >= 2 athletes have values', async () => {
+    await seedAthlete([{ date: '2024-01-15', value: '20.000' }]);
+    await seedAthlete([{ date: '2024-01-15', value: '30.000' }]);
+    const report = await createTeamReport({ charts: { boxSwarm: true } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.teamDistributions).toBeDefined();
+    const dist = response.body.teamDistributions.VERTICAL_JUMP;
+    expect(dist).toBeDefined();
+    expect(dist.values).toEqual([20, 30]);
+    expect(dist.teamAverage).toBe(25);
+    expect(Array.isArray(dist.athletes)).toBe(true);
+    expect(dist.athletes).toHaveLength(2);
+    expect(dist.direction).toBe('higher');
+  });
+
+  it('omits teamDistributions when charts.boxSwarm is false', async () => {
+    await seedAthlete([{ date: '2024-01-15', value: '20.000' }]);
+    await seedAthlete([{ date: '2024-01-15', value: '30.000' }]);
+    const report = await createTeamReport({ charts: { boxSwarm: false } });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.teamDistributions).toBeUndefined();
+  });
+});
+
+describe('POST /api/reports/:id/generate — explicit empty charts (all-off)', () => {
+  it('an explicit empty charts object omits both teamTrends and teamDistributions', async () => {
+    await seedAthlete([
+      { date: '2024-01-15', value: '20.000' },
+      { date: '2024-03-15', value: '24.000' },
+    ]);
+    await seedAthlete([{ date: '2024-01-15', value: '30.000' }]);
+    const report = await createTeamReport({ charts: {} });
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.teamTrends).toBeUndefined();
+    expect(response.body.teamDistributions).toBeUndefined();
+  });
+});
+
+describe('POST /api/reports/:id/generate — back-compat (no charts field)', () => {
+  it('a legacy team config with NO charts field omits both teamTrends and teamDistributions', async () => {
+    // Seed data that WOULD produce both if charts were (wrongly) defaulted on,
+    // proving the all-off legacy default end-to-end, not just at the unit level.
+    await seedAthlete([
+      { date: '2024-01-15', value: '20.000' },
+      { date: '2024-03-15', value: '24.000' },
+    ]);
+    await seedAthlete([
+      { date: '2024-01-15', value: '30.000' },
+      { date: '2024-03-15', value: '32.000' },
+    ]);
+    const report = await createTeamReport({});
+
+    const response = await generate(report.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('reportType', 'team');
+    expect(response.body.teamTrends).toBeUndefined();
+    expect(response.body.teamDistributions).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Backend/type foundation to bring team reports up to par with the individual report's chart stack (radar, benchmark standing, trends, distribution). No UI renders this yet — that's stages 2/3, tracked in separate PRs.

- `resolveTeamChartSelection` — team's own chart-selection resolver, with an **all-off legacy default** (kept separate from the individual `resolveChartSelection`, since reusing its legacy defaults would have silently turned on charts for every pre-existing team report).
- `generateTeamReport` now computes `teamTrends`/`teamDistributions`/`comparisonLabel` via the new pure `report-team-charts.ts` module, reusing already-fetched measurement/ranking data rather than re-querying.
- `ReportWizard` persists a per-report-type charts selection instead of gating it to individual reports only.
- Fixed `insertReportSchema`/`updateReportSchema`, which still only declared the 4 individual-report chart keys and were silently stripping the 3 new team-native keys from every real API request (caught in code review — the DB-level integration tests missed it because they insert rows directly, bypassing schema validation).
- Extracted `resolveComparisonLabel` and `computeTrendDelta` to remove duplication between the new team code paths and their individual-report counterparts.

## Test plan
- [x] `npm run check` clean
- [x] New unit tests (`report-team-charts.test.ts`, `report-charts.test.ts`, `report-charts-schema.test.ts`) green
- [x] New integration test (`report-team-chart-selection.test.ts`) green, including the legacy-config-stays-chart-free case
- [x] Full existing individual-report suites re-run, zero regression
- [x] High-effort automated code review pass, all confirmed findings fixed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary by Sourcery

Add backend support for team report chart payloads and per-report-type chart selection, aligning team reports with individual reports while preserving legacy team behavior.

New Features:
- Introduce team-specific chart selection resolution and include team trends and distributions data in generated team reports.
- Extend report configuration and wizard UI to support team chart types such as box+swarm, leaderboard, and tier distribution for team reports.
- Provide shared types and pure computation utilities for team trends and distributions to be reused across services.

Bug Fixes:
- Fix report config validation schemas so team-native chart keys are preserved instead of being stripped from API requests.

Enhancements:
- Refactor cohort comparison label resolution into a shared helper reused by both individual and team reports.
- Share trend delta calculation logic between individual and team trend assembly for consistent improvement metrics.

Tests:
- Add unit tests for team chart selection resolution, team trend/distribution assembly, and chart schema validation.
- Add integration tests verifying team report chart selection behavior and payload shape for trends and distributions.