### PR TITLE
fix(reports): detect minors on team-report rosters for COPPA snapshot gating

### DIFF
--- a/packages/api/routes/athlete-routes.ts
+++ b/packages/api/routes/athlete-routes.ts
@@ -386,9 +386,19 @@ export function registerAthleteRoutes(app: Express) {
       if (validatedData.parentEmail !== undefined) {
         const currentUser = req.session.user!;
         if (!currentUser.isSiteAdmin) {
-          const userOrgs = await storage.getUserOrganizations(currentUser.id);
-          const isOrgAdmin = userOrgs.some((org) => org.role === 'org_admin');
-          if (!isOrgAdmin) {
+          // Must be org_admin specifically in an org shared with the athlete —
+          // org_admin status in an unrelated org must not combine with a
+          // shared-org coach role (already required by
+          // requireAthleteAccessPermission) to authorize this.
+          const [userOrgs, athleteOrgs] = await Promise.all([
+            storage.getUserOrganizations(currentUser.id),
+            storage.getUserOrganizations(athleteId),
+          ]);
+          const athleteOrgIds = new Set(athleteOrgs.map((org) => org.organizationId));
+          const isOrgAdminForAthlete = userOrgs.some(
+            (org) => org.role === 'org_admin' && athleteOrgIds.has(org.organizationId)
+          );
+          if (!isOrgAdminForAthlete) {
             return res.status(403).json({
               message: "Organization admin or site admin role required to update parent email",
             });

--- a/packages/api/routes/athlete-routes.ts
+++ b/packages/api/routes/athlete-routes.ts
@@ -378,6 +378,24 @@ export function registerAthleteRoutes(app: Express) {
       const updateSchema = insertAthleteSchema.partial();
       const validatedData = updateSchema.parse(req.body);
 
+      // Setting parentEmail creates a parentAthleteLinks row and emails that
+      // address with the minor's name — restrict to org_admin/site_admin so a
+      // coach can't redirect that link (and notification) to an arbitrary
+      // address without admin approval. Checked BEFORE any write so a denied
+      // coach can't get parentEmail persisted via the main update below.
+      if (validatedData.parentEmail !== undefined) {
+        const currentUser = req.session.user!;
+        if (!currentUser.isSiteAdmin) {
+          const userOrgs = await storage.getUserOrganizations(currentUser.id);
+          const isOrgAdmin = userOrgs.some((org) => org.role === 'org_admin');
+          if (!isOrgAdmin) {
+            return res.status(403).json({
+              message: "Organization admin or site admin role required to update parent email",
+            });
+          }
+        }
+      }
+
       const updatedAthlete = await storage.updateAthlete(athleteId, validatedData);
 
       // Handle parentEmail: persist to user record and create parentAthleteLinks

--- a/packages/api/routes/coppa-deletion-routes.ts
+++ b/packages/api/routes/coppa-deletion-routes.ts
@@ -97,7 +97,8 @@ export function registerCoppaDeletionRoutes(app: Express) {
           });
         }
 
-        const { athleteUserId, requestedByEmail, consentToken, notes } = bodyResult.data;
+        const { athleteUserId, consentToken, notes } = bodyResult.data;
+        let requestedByEmail = bodyResult.data.requestedByEmail;
 
         // Authenticate BEFORE looking up the athlete to prevent unauthenticated
         // callers from probing athlete IDs and discovering minor status.
@@ -106,6 +107,10 @@ export function registerCoppaDeletionRoutes(app: Express) {
 
         if (actor) {
           actorUserId = actor.id;
+          // Authenticated actors cannot redirect the confirmation email (which
+          // includes the minor's name) to an arbitrary address — always use the
+          // session's own email, ignoring whatever the client sent.
+          requestedByEmail = actor.email;
         } else if (consentToken) {
           // Public token-gated path: verify the consent token proves parent identity.
           // Uses verifyConfirmedToken() which returns a typed result — no error string parsing.

--- a/packages/api/routes/coppa-export-routes.ts
+++ b/packages/api/routes/coppa-export-routes.ts
@@ -87,7 +87,11 @@ export function registerCoppaExportRoutes(app: Express) {
           });
         }
 
-        const { athleteUserId, requestedByEmail } = bodyResult.data;
+        const { athleteUserId } = bodyResult.data;
+        // Authenticated actors cannot redirect the download-ready notification
+        // (a one-time link to the athlete's full data export) to an arbitrary
+        // address — always use the session's own email, ignoring the body.
+        const requestedByEmail = actor.email;
 
         // Authorization: site_admin can request for any athlete.
         // parent must have an active link to the athlete (covers 13-17 minors with no consent record).

--- a/packages/api/routes/coppa-routes.ts
+++ b/packages/api/routes/coppa-routes.ts
@@ -208,9 +208,10 @@ export function registerCoppaRoutes(app: Express) {
         }
 
         // Opaque, single-use token so the client's "Create Parent Account" link
-        // can carry the parent's email + consentId without putting either in
-        // the /register URL (browser history, referrer headers, access logs).
-        const registrationToken = generateRegistrationToken(consentId, verifyResult.consent!.parentEmail);
+        // can reference this consent without putting the parent's email or the
+        // consentId in the /register URL (browser history, referrer headers,
+        // access logs).
+        const registrationToken = generateRegistrationToken(consentId);
 
         res.json({
           success: true,

--- a/packages/api/routes/coppa-routes.ts
+++ b/packages/api/routes/coppa-routes.ts
@@ -14,6 +14,7 @@ import { shouldSkipRateLimiting } from "../utils/rate-limit-utils";
 import { storage } from "../storage";
 import { db } from "../db";
 import { consumeParentEmailToken } from "../services/coppa-email-token-store";
+import { generateRegistrationToken } from "../services/registration-token-store";
 import { users } from "@shared/schema/tables/core";
 import { eq, and, inArray } from "drizzle-orm";
 import { isUnder13, wasUnder13At, COPPA_ACTIONS } from "@shared/coppa-utils";
@@ -123,6 +124,11 @@ export function registerCoppaRoutes(app: Express) {
    * Returns consent info needed to render the consent page (no PII beyond athleteName/org).
    */
   app.get("/api/coppa/consent/verify/:token", consentReadLimiter, async (req, res) => {
+    // The token lives in the URL path, so it can end up in access logs,
+    // browser history, and Referer headers on any outbound link from this
+    // page. Stop it from also being cached or forwarded onward.
+    res.set('Cache-Control', 'no-store');
+    res.set('Referrer-Policy', 'no-referrer');
     try {
       const { token } = req.params;
 
@@ -201,7 +207,17 @@ export function registerCoppaRoutes(app: Express) {
           return res.status(400).json({ message: result.error });
         }
 
-        res.json({ success: true, granted: true, message: "Consent confirmed. The athlete's account is now active." });
+        // Opaque, single-use token so the client's "Create Parent Account" link
+        // can carry the parent's email + consentId without putting either in
+        // the /register URL (browser history, referrer headers, access logs).
+        const registrationToken = generateRegistrationToken(consentId, verifyResult.consent!.parentEmail);
+
+        res.json({
+          success: true,
+          granted: true,
+          message: "Consent confirmed. The athlete's account is now active.",
+          registrationToken,
+        });
       } else {
         const result = await coppaService.denyConsent(consentId, ip, userAgent);
 

--- a/packages/api/routes/registration-routes.ts
+++ b/packages/api/routes/registration-routes.ts
@@ -434,15 +434,15 @@ export function registerRegistrationRoutes(app: Express) {
       // consentId it was minted for. Takes precedence over a raw consentId —
       // the ref token is what the web UI now sends instead.
       if (ref) {
-        const resolved = consumeRegistrationToken(ref);
-        if (!resolved) {
+        const resolvedConsentId = consumeRegistrationToken(ref);
+        if (!resolvedConsentId) {
           return res.status(400).json({
             success: false,
             message: "This registration link has expired or already been used.",
             errors: [{ field: 'ref', message: 'Invalid or expired registration link.' }],
           });
         }
-        consentId = resolved.consentId;
+        consentId = resolvedConsentId;
       }
 
       // Check username uniqueness

--- a/packages/api/routes/registration-routes.ts
+++ b/packages/api/routes/registration-routes.ts
@@ -17,6 +17,7 @@ import {
   AUDIT_ACTION_LEGAL_ACCEPTED
 } from "@shared/legal-acceptance";
 import { coppaService } from "../services/coppa-service";
+import { consumeRegistrationToken } from "../services/registration-token-store";
 import { isUnder13, isMinorAge, isTeenMinor } from "@shared/coppa-utils";
 import { db } from "../db";
 import { parentalConsents, parentAthleteLinks } from "@shared/schema/tables/coppa";
@@ -149,6 +150,10 @@ const parentRegistrationSchema = z.object({
     ),
   // consentId links this registration to a pre-existing VPC consent record
   consentId: z.string().optional(),
+  // Opaque single-use token minted at consent-grant time, resolving server-side
+  // to { consentId, parentEmail } — replaces passing consentId/email via the
+  // /register URL. Takes precedence over a client-supplied consentId.
+  ref: z.string().optional(),
 });
 
 // Validation schema for resend verification
@@ -422,7 +427,23 @@ export function registerRegistrationRoutes(app: Express) {
         return res.status(400).json({ success: false, message: "Validation failed", errors });
       }
 
-      const { firstName, lastName, email, username, password, legalAcceptedAt, consentId } = validationResult.data;
+      const { firstName, lastName, email, username, password, legalAcceptedAt, ref } = validationResult.data;
+      let consentId = validationResult.data.consentId;
+
+      // Resolve the opaque post-consent registration token (if present) to the
+      // consentId it was minted for. Takes precedence over a raw consentId —
+      // the ref token is what the web UI now sends instead.
+      if (ref) {
+        const resolved = consumeRegistrationToken(ref);
+        if (!resolved) {
+          return res.status(400).json({
+            success: false,
+            message: "This registration link has expired or already been used.",
+            errors: [{ field: 'ref', message: 'Invalid or expired registration link.' }],
+          });
+        }
+        consentId = resolved.consentId;
+      }
 
       // Check username uniqueness
       const existingUsername = await storage.getUserByUsername(username);

--- a/packages/api/services/registration-token-store.ts
+++ b/packages/api/services/registration-token-store.ts
@@ -1,0 +1,70 @@
+/**
+ * In-memory token store for the post-consent parent-registration flow.
+ *
+ * Replaces embedding parentEmail + consentId directly in the /register URL
+ * (browser history, referrer headers, server access logs). Tokens are
+ * short-lived (1 hour) and single-use (consumed on first lookup).
+ *
+ * Acceptable as in-memory because:
+ * - App runs as a single process (no clustering)
+ * - Tokens live 1 hour max — restart just requires re-granting consent
+ * - No sensitive data stored beyond consentId + parentEmail, keyed by token hash
+ */
+
+import crypto from 'crypto';
+
+const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+const CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // Purge expired entries every 15 minutes
+
+interface TokenEntry {
+  consentId: string;
+  parentEmail: string;
+  expiresAt: number;
+}
+
+const store = new Map<string, TokenEntry>();
+
+function hashToken(raw: string): string {
+  return crypto.createHash('sha256').update(raw).digest('hex');
+}
+
+/**
+ * Generate an opaque token for a parent who just granted consent, so the
+ * registration page can be linked to without exposing their email or
+ * consentId in the URL. Returns the raw (unhashed) token — only the hash is
+ * stored.
+ */
+export function generateRegistrationToken(consentId: string, parentEmail: string): string {
+  const raw = crypto.randomBytes(32).toString('hex');
+  store.set(hashToken(raw), { consentId, parentEmail, expiresAt: Date.now() + TOKEN_TTL_MS });
+  return raw;
+}
+
+/**
+ * Consume a token: returns the { consentId, parentEmail } if the token is
+ * valid and not expired, then deletes it (single-use). Returns null if
+ * invalid/expired/already used.
+ */
+export function consumeRegistrationToken(rawToken: string): { consentId: string; parentEmail: string } | null {
+  const hash = hashToken(rawToken);
+  const entry = store.get(hash);
+
+  if (!entry) return null;
+
+  // Always delete — token is single-use regardless of expiry
+  store.delete(hash);
+
+  if (Date.now() > entry.expiresAt) return null;
+
+  return { consentId: entry.consentId, parentEmail: entry.parentEmail };
+}
+
+// Periodic cleanup of expired entries to prevent unbounded growth
+setInterval(() => {
+  const now = Date.now();
+  for (const [hash, entry] of store) {
+    if (now > entry.expiresAt) {
+      store.delete(hash);
+    }
+  }
+}, CLEANUP_INTERVAL_MS).unref();

--- a/packages/api/services/registration-token-store.ts
+++ b/packages/api/services/registration-token-store.ts
@@ -18,7 +18,6 @@ const CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // Purge expired entries every 15 mi
 
 interface TokenEntry {
   consentId: string;
-  parentEmail: string;
   expiresAt: number;
 }
 
@@ -33,19 +32,24 @@ function hashToken(raw: string): string {
  * registration page can be linked to without exposing their email or
  * consentId in the URL. Returns the raw (unhashed) token — only the hash is
  * stored.
+ *
+ * Only the consentId is carried: the registration route re-fetches the
+ * consent record by that id and validates the user-supplied email against
+ * its authoritative parentEmail, so there is no need to also carry (and risk
+ * staleness on) a copy of the email here.
  */
-export function generateRegistrationToken(consentId: string, parentEmail: string): string {
+export function generateRegistrationToken(consentId: string): string {
   const raw = crypto.randomBytes(32).toString('hex');
-  store.set(hashToken(raw), { consentId, parentEmail, expiresAt: Date.now() + TOKEN_TTL_MS });
+  store.set(hashToken(raw), { consentId, expiresAt: Date.now() + TOKEN_TTL_MS });
   return raw;
 }
 
 /**
- * Consume a token: returns the { consentId, parentEmail } if the token is
- * valid and not expired, then deletes it (single-use). Returns null if
+ * Consume a token: returns the consentId if the token is valid and not
+ * expired, then deletes it (single-use). Returns null if
  * invalid/expired/already used.
  */
-export function consumeRegistrationToken(rawToken: string): { consentId: string; parentEmail: string } | null {
+export function consumeRegistrationToken(rawToken: string): string | null {
   const hash = hashToken(rawToken);
   const entry = store.get(hash);
 
@@ -56,7 +60,7 @@ export function consumeRegistrationToken(rawToken: string): { consentId: string;
 
   if (Date.now() > entry.expiresAt) return null;
 
-  return { consentId: entry.consentId, parentEmail: entry.parentEmail };
+  return entry.consentId;
 }
 
 // Periodic cleanup of expired entries to prevent unbounded growth

--- a/packages/api/services/report-service.ts
+++ b/packages/api/services/report-service.ts
@@ -1068,9 +1068,9 @@ export class ReportService extends BaseService {
       if (report.reportType === 'individual') {
         const config = report.config as any;
         if (config?.athleteId) athleteIds.push(config.athleteId);
-      } else if (data?.athletes) {
-        for (const a of data.athletes) {
-          if (a?.userId || a?.id) athleteIds.push(a.userId || a.id);
+      } else if (data?.athleteRankings) {
+        for (const a of data.athleteRankings) {
+          if (a?.userId) athleteIds.push(a.userId);
         }
       }
 

--- a/packages/web/src/pages/__tests__/register-parent-ref.test.tsx
+++ b/packages/web/src/pages/__tests__/register-parent-ref.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Regression test — parent registration via the opaque `ref` token.
+ *
+ * consent-confirmation.tsx now links to /register?role=parent&ref=<token>
+ * instead of &email=...&consent=..., so `prefilledEmail` is empty for this
+ * flow. The email input's onChange handler was gated on `!isParentMode`
+ * alone, which silently discarded every keystroke in parent mode even
+ * though the field was not readOnly — the form could never be submitted.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Register from '../register';
+
+vi.mock('wouter', () => ({
+  useLocation: () => ['/register', vi.fn()],
+}));
+
+vi.mock('@/components/auth/oauth-buttons', () => ({
+  OAuthButtons: () => null,
+}));
+
+describe('Register page — parent mode email field', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('ref-only flow (no prefilled email): typing in the email field updates its value', () => {
+    vi.stubGlobal('location', { search: '?role=parent&ref=sometoken' });
+
+    render(<Register />);
+
+    const emailInput = screen.getByLabelText('Email') as HTMLInputElement;
+    expect(emailInput).not.toHaveAttribute('readonly');
+
+    fireEvent.change(emailInput, { target: { value: 'parent@example.com' } });
+
+    expect(emailInput.value).toBe('parent@example.com');
+  });
+
+  it('email-prefilled flow (notification link): email field stays read-only and pre-filled', () => {
+    vi.stubGlobal('location', { search: '?role=parent&email=parent%40example.com' });
+
+    render(<Register />);
+
+    const emailInput = screen.getByLabelText('Email') as HTMLInputElement;
+    expect(emailInput).toHaveAttribute('readonly');
+    expect(emailInput.value).toBe('parent@example.com');
+  });
+});

--- a/packages/web/src/pages/consent-confirmation.tsx
+++ b/packages/web/src/pages/consent-confirmation.tsx
@@ -35,6 +35,7 @@ export default function ConsentConfirmation() {
   const [aiConsentGranted, setAiConsentGranted] = useState(false);
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>('idle');
   const [submitError, setSubmitError] = useState('');
+  const [registrationToken, setRegistrationToken] = useState('');
   const [showParentAccountCta, setShowParentAccountCta] = useState(true);
   const [dataCollectionOpen, setDataCollectionOpen] = useState(false);
   // Synchronous guard prevents double-click from firing two requests before
@@ -76,6 +77,10 @@ export default function ConsentConfirmation() {
         body: JSON.stringify({ granted, aiConsentGranted: granted ? aiConsentGranted : false }),
       });
       if (res.ok) {
+        const body = await res.json().catch(() => ({}));
+        if (granted && body.registrationToken) {
+          setRegistrationToken(body.registrationToken);
+        }
         setSubmitStatus(granted ? 'granted' : 'denied');
       } else {
         const body = await res.json().catch(() => ({}));
@@ -149,10 +154,11 @@ export default function ConsentConfirmation() {
   // ── Post-submit states ──
   if (submitStatus === 'granted') {
     const athleteName = consentData?.athleteName ?? 'the athlete';
-    const parentEmail = consentData?.parentEmail ?? '';
-    const consentId = consentData?.consentId ?? '';
 
-    const registerUrl = `/register?role=parent${parentEmail ? `&email=${encodeURIComponent(parentEmail)}` : ''}${consentId ? `&consent=${encodeURIComponent(consentId)}` : ''}`;
+    // registrationToken is an opaque, single-use, server-issued reference —
+    // it replaces putting the parent's email/consentId in the URL, where they
+    // would leak into browser history, referrer headers, and access logs.
+    const registerUrl = `/register?role=parent${registrationToken ? `&ref=${encodeURIComponent(registrationToken)}` : ''}`;
 
     return (
       <ConsentStatusCard

--- a/packages/web/src/pages/register.tsx
+++ b/packages/web/src/pages/register.tsx
@@ -36,11 +36,18 @@ export default function Register() {
   // Parse query params for parent registration mode
   const searchParams = new URLSearchParams(window.location.search);
   const isParentMode = searchParams.get('role') === 'parent';
+  // `email` is used by the separate 13-17 parent-notification email link (sent
+  // directly to that address, so it carries no additional exposure) — see
+  // email-service.ts sendParentNotification(). `ref` is an opaque, single-use,
+  // server-issued token minted when consent was granted via /consent/:token;
+  // it replaces passing the parent's email/consentId directly in that flow's
+  // URL, where they would leak into browser history, referrer headers, and
+  // access logs from the SAME browsing session.
   const prefilledEmail = searchParams.get('email') || '';
-  const prefilledConsentId = searchParams.get('consent') || '';
+  const prefilledRef = searchParams.get('ref') || '';
 
   // Dead-end gate: parent mode without any valid context (no email invite, no consent link)
-  const parentModeBlocked = isParentMode && !prefilledEmail && !prefilledConsentId;
+  const parentModeBlocked = isParentMode && !prefilledEmail && !prefilledRef;
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string>('');
@@ -238,8 +245,8 @@ export default function Register() {
       if (!isParentMode) {
         body.birthDate = formData.birthDate || undefined;
         body.parentEmail = minor && formData.parentEmail ? formData.parentEmail.trim().toLowerCase() : undefined;
-      } else if (prefilledConsentId) {
-        body.consentId = prefilledConsentId;
+      } else if (prefilledRef) {
+        body.ref = prefilledRef;
       }
 
       const response = await fetch(endpoint, {

--- a/packages/web/src/pages/register.tsx
+++ b/packages/web/src/pages/register.tsx
@@ -530,7 +530,7 @@ export default function Register() {
                   id="email"
                   type="email"
                   value={formData.email}
-                  onChange={(e) => !isParentMode && setFormData({ ...formData, email: e.target.value })}
+                  onChange={(e) => !(isParentMode && prefilledEmail) && setFormData({ ...formData, email: e.target.value })}
                   placeholder="you@example.com"
                   className={`pl-10 ${isParentMode && prefilledEmail ? 'bg-gray-50' : ''}`}
                   readOnly={isParentMode && !!prefilledEmail}

--- a/tests/integration/athlete-parent-email.test.ts
+++ b/tests/integration/athlete-parent-email.test.ts
@@ -131,6 +131,7 @@ async function loginAs(app: Express, username: string) {
 
 let app: Express;
 let coachUser: any;
+let orgAdminUser: any;
 let testOrg: any;
 const createdUserIds: string[] = [];
 const createdOrgIds: string[] = [];
@@ -151,6 +152,10 @@ beforeAll(async () => {
   coachUser = await createUser('coach', 'coach');
   createdUserIds.push(coachUser.id);
   await addUserToOrg(coachUser.id, testOrg.id, 'coach');
+
+  orgAdminUser = await createUser('orgadmin', 'org_admin');
+  createdUserIds.push(orgAdminUser.id);
+  await addUserToOrg(orgAdminUser.id, testOrg.id, 'org_admin');
 });
 
 afterAll(async () => {
@@ -187,7 +192,7 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
     createdUserIds.push(athlete.id);
     await addUserToOrg(athlete.id, testOrg.id, 'athlete');
 
-    const cookie = await loginAs(app, coachUser.username);
+    const cookie = await loginAs(app, orgAdminUser.username);
     const parentEmail = `${TEST_PREFIX}parent_set_${uid()}@example.com`;
 
     const res = await request(app)
@@ -215,7 +220,7 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
     createdUserIds.push(athlete.id);
     await addUserToOrg(athlete.id, testOrg.id, 'athlete');
 
-    const cookie = await loginAs(app, coachUser.username);
+    const cookie = await loginAs(app, orgAdminUser.username);
     const parentEmail = `${TEST_PREFIX}parent_minor_${uid()}@example.com`;
 
     const res = await request(app)
@@ -248,7 +253,7 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
     createdUserIds.push(athlete.id);
     await addUserToOrg(athlete.id, testOrg.id, 'athlete');
 
-    const cookie = await loginAs(app, coachUser.username);
+    const cookie = await loginAs(app, orgAdminUser.username);
     const parentEmail = `${TEST_PREFIX}parent_adult_${uid()}@example.com`;
 
     const res = await request(app)
@@ -280,7 +285,7 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
     createdUserIds.push(athlete.id);
     await addUserToOrg(athlete.id, testOrg.id, 'athlete');
 
-    const cookie = await loginAs(app, coachUser.username);
+    const cookie = await loginAs(app, orgAdminUser.username);
 
     const res = await request(app)
       .put(`/api/athletes/${athlete.id}`)
@@ -315,7 +320,7 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
       isActive: true,
     });
 
-    const cookie = await loginAs(app, coachUser.username);
+    const cookie = await loginAs(app, orgAdminUser.username);
 
     const res = await request(app)
       .put(`/api/athletes/${athlete.id}`)
@@ -345,7 +350,7 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
     createdUserIds.push(athlete.id);
     await addUserToOrg(athlete.id, testOrg.id, 'athlete');
 
-    const cookie = await loginAs(app, coachUser.username);
+    const cookie = await loginAs(app, orgAdminUser.username);
 
     const res = await request(app)
       .put(`/api/athletes/${athlete.id}`)
@@ -353,5 +358,53 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
       .send({ parentEmail: 'not-a-valid-email' });
 
     expect(res.status).toBe(400);
+  });
+
+  // Security fix (issue #348): a coach could otherwise set parentEmail to any
+  // address, creating a parentAthleteLinks row and sending that address a
+  // notification containing the minor's name — with no org_admin approval.
+  it("coach role → 403, parentEmail is not updated", async () => {
+    const athlete = await createUser('athlete_coachdenied', 'athlete', {
+      birthDate: adultBirthDate(),
+    });
+    createdUserIds.push(athlete.id);
+    await addUserToOrg(athlete.id, testOrg.id, 'athlete');
+
+    const cookie = await loginAs(app, coachUser.username);
+    const parentEmail = `${TEST_PREFIX}parent_coachdenied_${uid()}@example.com`;
+
+    const res = await request(app)
+      .put(`/api/athletes/${athlete.id}`)
+      .set('Cookie', cookie)
+      .send({ parentEmail });
+
+    expect(res.status).toBe(403);
+
+    const [updated] = await db
+      .select({ parentEmail: users.parentEmail })
+      .from(users)
+      .where(eq(users.id, athlete.id))
+      .limit(1);
+
+    expect(updated.parentEmail).toBeNull();
+  });
+
+  // A coach must still be able to update other athlete fields — only
+  // parentEmail is gated to org_admin/site_admin.
+  it("coach role → other fields still update successfully", async () => {
+    const athlete = await createUser('athlete_coachother', 'athlete', {
+      birthDate: adultBirthDate(),
+    });
+    createdUserIds.push(athlete.id);
+    await addUserToOrg(athlete.id, testOrg.id, 'athlete');
+
+    const cookie = await loginAs(app, coachUser.username);
+
+    const res = await request(app)
+      .put(`/api/athletes/${athlete.id}`)
+      .set('Cookie', cookie)
+      .send({ firstName: 'Updated' });
+
+    expect(res.status).toBe(200);
   });
 });

--- a/tests/integration/athlete-parent-email.test.ts
+++ b/tests/integration/athlete-parent-email.test.ts
@@ -407,4 +407,42 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
 
     expect(res.status).toBe(200);
   });
+
+  // Security fix: org_admin status must be scoped to an org shared with the
+  // target athlete. A user who is only a coach in the athlete's org, but
+  // org_admin in a wholly unrelated org, must not be able to combine the two
+  // memberships to bypass the parentEmail restriction.
+  it("coach in athlete's org + org_admin in an unrelated org → 403", async () => {
+    const otherOrg = await createOrg(uid());
+    createdOrgIds.push(otherOrg.id);
+
+    const confusedDeputy = await createUser('confused_deputy', 'coach');
+    createdUserIds.push(confusedDeputy.id);
+    await addUserToOrg(confusedDeputy.id, testOrg.id, 'coach');
+    await addUserToOrg(confusedDeputy.id, otherOrg.id, 'org_admin');
+
+    const athlete = await createUser('athlete_confuseddep', 'athlete', {
+      birthDate: adultBirthDate(),
+    });
+    createdUserIds.push(athlete.id);
+    await addUserToOrg(athlete.id, testOrg.id, 'athlete');
+
+    const cookie = await loginAs(app, confusedDeputy.username);
+    const parentEmail = `${TEST_PREFIX}parent_confuseddep_${uid()}@example.com`;
+
+    const res = await request(app)
+      .put(`/api/athletes/${athlete.id}`)
+      .set('Cookie', cookie)
+      .send({ parentEmail });
+
+    expect(res.status).toBe(403);
+
+    const [updated] = await db
+      .select({ parentEmail: users.parentEmail })
+      .from(users)
+      .where(eq(users.id, athlete.id))
+      .limit(1);
+
+    expect(updated.parentEmail).toBeNull();
+  });
 });

--- a/tests/integration/coppa-deletion.test.ts
+++ b/tests/integration/coppa-deletion.test.ts
@@ -403,6 +403,35 @@ describe('POST /api/coppa/data-deletion/request', () => {
     await db.delete(dataDeletionRequests)
       .where(eq(dataDeletionRequests.id, first.body.requestId));
   });
+
+  // Security fix (issue #349): on the authenticated path, requestedByEmail must
+  // come from the session, not the request body — otherwise any authenticated
+  // actor could redirect the deletion-confirmation email (which includes the
+  // minor's name) to an address they control.
+  it('authenticated request ignores body-supplied requestedByEmail, uses session user email', async () => {
+    const res = await request(app)
+      .post('/api/coppa/data-deletion/request')
+      .set('Cookie', siteAdminCookie)
+      .send({
+        athleteUserId: minorAthleteId,
+        requestedByEmail: 'attacker@evil.example',
+        notes: 'Session-email regression test',
+      });
+
+    expect(res.status).toBe(201);
+
+    const stored = await db.select({ requestedByEmail: dataDeletionRequests.requestedByEmail })
+      .from(dataDeletionRequests)
+      .where(eq(dataDeletionRequests.id, res.body.requestId))
+      .then((rows) => rows[0]);
+
+    expect(stored?.requestedByEmail).toBe(process.env.ADMIN_EMAIL);
+    expect(stored?.requestedByEmail).not.toBe('attacker@evil.example');
+
+    // Clean up
+    await db.delete(dataDeletionRequests)
+      .where(eq(dataDeletionRequests.id, res.body.requestId));
+  });
 });
 
 // ============================================================================

--- a/tests/integration/coppa-export.test.ts
+++ b/tests/integration/coppa-export.test.ts
@@ -290,6 +290,30 @@ describe('POST /api/coppa/data-export/request', () => {
     expect(res.status).toBe(404);
   });
 
+  // Security fix: on the authenticated path, requestedByEmail must come from
+  // the session, not the request body — the download-ready notification (a
+  // one-time link to the athlete's full data export) must not be redirectable
+  // to an address the client controls.
+  it('authenticated request ignores body-supplied requestedByEmail, uses session user email', async () => {
+    const res = await request(app)
+      .post('/api/coppa/data-export/request')
+      .set('Cookie', siteAdminCookie)
+      .send({
+        athleteUserId: minorAthleteId,
+        requestedByEmail: 'attacker@evil.example',
+      });
+
+    expect(res.status).toBe(200);
+
+    const stored = await db.select({ requestedByEmail: dataExportRequests.requestedByEmail })
+      .from(dataExportRequests)
+      .where(eq(dataExportRequests.id, res.body.exportRequestId))
+      .then((rows) => rows[0]);
+
+    expect(stored?.requestedByEmail).toBe(process.env.ADMIN_EMAIL);
+    expect(stored?.requestedByEmail).not.toBe('attacker@evil.example');
+  });
+
   it('token-gated: valid consentId + matching parentEmail → 200', async () => {
     const parentEmail = `parent-export-${Date.now()}@testcoppaexport.local`;
 

--- a/tests/integration/coppa-routes.test.ts
+++ b/tests/integration/coppa-routes.test.ts
@@ -362,6 +362,23 @@ describe('GET /api/coppa/consent/verify/:token', () => {
 
     expect(res.status).toBe(400);
   });
+
+  // The token lives in the URL path, so it leaks into access logs, browser
+  // history, and Referer headers on any outbound link from this page.
+  // These headers stop it from also being cached or forwarded onward.
+  it('sets Cache-Control: no-store and Referrer-Policy: no-referrer', async () => {
+    const { rawToken } = await insertConsentRecord({
+      athleteUserId: pendingMinorId,
+      parentEmail: 'parent@example.com',
+      status: 'pending',
+    });
+
+    const res = await request(app)
+      .get(`/api/coppa/consent/verify/${rawToken}`);
+
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+  });
 });
 
 // ============================================================================

--- a/tests/integration/parent-registration.test.ts
+++ b/tests/integration/parent-registration.test.ts
@@ -510,7 +510,7 @@ describe('POST /api/auth/register/parent', () => {
       const { consent } = await createTestConsent(athlete.id, parentEmail);
       createdConsentIds.push(consent.id);
 
-      const ref = generateRegistrationToken(consent.id, parentEmail);
+      const ref = generateRegistrationToken(consent.id);
       const username = `${TEST_PREFIX}ref${id}`;
 
       const res = await request(app)
@@ -552,6 +552,42 @@ describe('POST /api/auth/register/parent', () => {
       expect(res.body.errors[0].field).toBe('ref');
     });
 
+    // A ref token proves nothing about who is holding it — an intercepted link
+    // must not let an attacker register with their own email against the real
+    // parent's consent record. The token resolves to a consentId, and the
+    // existing consentId→email match rejects a mismatched email even though
+    // the token itself carries the (discarded) real parentEmail.
+    it('rejects a valid ref token when the submitted email does not match the consent record → 400', async () => {
+      const id = uniqueId();
+      const { athlete, parentEmail } = await createTestAthleteUser(`${TEST_PREFIX}refmis_`);
+      createdAthleteIds.push(athlete.id);
+
+      const { consent } = await createTestConsent(athlete.id, parentEmail);
+      createdConsentIds.push(consent.id);
+
+      const ref = generateRegistrationToken(consent.id);
+
+      const res = await request(app)
+        .post('/api/auth/register/parent')
+        .send({
+          firstName: 'Mallory',
+          lastName: 'Attacker',
+          email: `${TEST_PREFIX}attacker_${id}@example.com`, // NOT the consent's parentEmail
+          username: `${TEST_PREFIX}refmis${id}`,
+          password: VALID_PASSWORD,
+          legalAcceptedAt: new Date().toISOString(),
+          ref,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.errors[0].field).toBe('email');
+
+      // No account was created for the attacker.
+      const created = await db.select().from(users)
+        .where(like(users.username, `${TEST_PREFIX}refmis${id}`));
+      expect(created.length).toBe(0);
+    });
+
     it('a ref token is single-use — a second registration attempt with it fails', async () => {
       const id = uniqueId();
       const { athlete, parentEmail } = await createTestAthleteUser(`${TEST_PREFIX}refonce_`);
@@ -560,7 +596,7 @@ describe('POST /api/auth/register/parent', () => {
       const { consent } = await createTestConsent(athlete.id, parentEmail);
       createdConsentIds.push(consent.id);
 
-      const ref = generateRegistrationToken(consent.id, parentEmail);
+      const ref = generateRegistrationToken(consent.id);
       const username1 = `${TEST_PREFIX}ro1${id}`;
       const username2 = `${TEST_PREFIX}ro2${id}`;
 

--- a/tests/integration/parent-registration.test.ts
+++ b/tests/integration/parent-registration.test.ts
@@ -29,6 +29,7 @@ import { users } from '@shared/schema/tables/core';
 import { parentalConsents, parentAthleteLinks } from '@shared/schema/tables/coppa';
 import { eq, like } from 'drizzle-orm';
 import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
+import { generateRegistrationToken } from '../../packages/api/services/registration-token-store';
 
 vi.mock('../../packages/api/vite.js', () => ({
   setupVite: vi.fn().mockResolvedValue(undefined),
@@ -494,6 +495,104 @@ describe('POST /api/auth/register/parent', () => {
       // Track created user for cleanup
       const [createdUser] = await db.select().from(users).where(like(users.username, username));
       if (createdUser) createdUserIds.push(createdUser.id);
+    });
+  });
+
+  // Security fix (issue #345): the web UI now sends this opaque token instead
+  // of a raw consentId, so the parent's email/consentId never appear in the
+  // /register URL. The token resolves server-side to the consentId.
+  describe('ref token (opaque post-consent registration token)', () => {
+    it('registers successfully via a valid ref token, resolving consentId server-side', async () => {
+      const id = uniqueId();
+      const { athlete, parentEmail } = await createTestAthleteUser(`${TEST_PREFIX}ref_`);
+      createdAthleteIds.push(athlete.id);
+
+      const { consent } = await createTestConsent(athlete.id, parentEmail);
+      createdConsentIds.push(consent.id);
+
+      const ref = generateRegistrationToken(consent.id, parentEmail);
+      const username = `${TEST_PREFIX}ref${id}`;
+
+      const res = await request(app)
+        .post('/api/auth/register/parent')
+        .send({
+          firstName: 'Jane',
+          lastName: 'Smith',
+          email: parentEmail,
+          username,
+          password: VALID_PASSWORD,
+          legalAcceptedAt: new Date().toISOString(),
+          ref,
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.linkedAthletes).toBeGreaterThanOrEqual(1);
+
+      const [createdUser] = await db.select().from(users).where(like(users.username, username));
+      if (createdUser) createdUserIds.push(createdUser.id);
+    });
+
+    it('rejects an invalid ref token → 400', async () => {
+      const id = uniqueId();
+      const res = await request(app)
+        .post('/api/auth/register/parent')
+        .send({
+          firstName: 'Jane',
+          lastName: 'Smith',
+          email: `${TEST_PREFIX}parent_${id}@example.com`,
+          username: `${TEST_PREFIX}badref${id}`,
+          password: VALID_PASSWORD,
+          legalAcceptedAt: new Date().toISOString(),
+          ref: 'not-a-real-token',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.errors[0].field).toBe('ref');
+    });
+
+    it('a ref token is single-use — a second registration attempt with it fails', async () => {
+      const id = uniqueId();
+      const { athlete, parentEmail } = await createTestAthleteUser(`${TEST_PREFIX}refonce_`);
+      createdAthleteIds.push(athlete.id);
+
+      const { consent } = await createTestConsent(athlete.id, parentEmail);
+      createdConsentIds.push(consent.id);
+
+      const ref = generateRegistrationToken(consent.id, parentEmail);
+      const username1 = `${TEST_PREFIX}ro1${id}`;
+      const username2 = `${TEST_PREFIX}ro2${id}`;
+
+      const first = await request(app)
+        .post('/api/auth/register/parent')
+        .send({
+          firstName: 'Jane',
+          lastName: 'Smith',
+          email: parentEmail,
+          username: username1,
+          password: VALID_PASSWORD,
+          legalAcceptedAt: new Date().toISOString(),
+          ref,
+        });
+      expect(first.status).toBe(201);
+      const [createdUser] = await db.select().from(users).where(like(users.username, username1));
+      if (createdUser) createdUserIds.push(createdUser.id);
+
+      const second = await request(app)
+        .post('/api/auth/register/parent')
+        .send({
+          firstName: 'Jane',
+          lastName: 'Smith',
+          email: `${TEST_PREFIX}other_${id}@example.com`,
+          username: username2,
+          password: VALID_PASSWORD,
+          legalAcceptedAt: new Date().toISOString(),
+          ref,
+        });
+
+      expect(second.status).toBe(400);
+      expect(second.body.errors[0].field).toBe('ref');
     });
   });
 });

--- a/tests/integration/report-snapshot-coppa.test.ts
+++ b/tests/integration/report-snapshot-coppa.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Regression test — COPPA minor-detection at team-report snapshot creation.
+ *
+ * ReportService.createSnapshot() flags a snapshot as publicAccessRestricted
+ * when the report's roster includes a minor (isMinor=true), so the public
+ * link is gated by enforcePublicSnapshotAccess (see coppa-routes.test.ts's
+ * "A3" suite for the gate itself).
+ *
+ * For team reports, the roster comes back as `athleteRankings`
+ * (TeamReportData), not `athletes` — createSnapshot's minor-detection was
+ * still looking for `data?.athletes`, so it never found any athlete IDs to
+ * check and `publicAccessRestricted` stayed false for every team snapshot,
+ * regardless of whether a minor was on the roster.
+ *
+ * Modeled on tests/integration/report-team-chart-selection.test.ts (same
+ * harness/bootstrap).
+ */
+
+// Set environment variables BEFORE any imports
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET = 'test-secret-key-for-integration-tests-only-at-least-32-characters-long';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+process.env.BYPASS_GENERAL_RATE_LIMIT = 'true'; // Bypass rate limits for these tests
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import express, { type Express } from 'express';
+import { db } from '../../packages/api/db';
+import { organizations, users, userOrganizations, reports, measurements } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import bcrypt from 'bcrypt';
+import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
+
+// Mock vite module before importing registerRoutes
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn()
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, BCRYPT_SALT_ROUNDS);
+}
+
+let app: Express;
+let testOrg: any;
+let testCoach: any;
+let coachAuthCookie: string;
+let createdReportIds: string[] = [];
+let createdAthleteIds: string[] = [];
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  await registerRoutes(app);
+});
+
+beforeEach(async () => {
+  [testOrg] = await db.insert(organizations).values({
+    name: `SnapshotCoppa Org ${Date.now()}`,
+    description: 'Test organization for report snapshot COPPA integration tests',
+    isActive: true,
+  }).returning();
+
+  const coachPassword = await hashPassword('TestCoach123!');
+  [testCoach] = await db.insert(users).values({
+    username: `snapshotcoppacoach_${Date.now()}`,
+    emails: [`snapshotcoppacoach_${Date.now()}@test.com`],
+    password: coachPassword,
+    firstName: 'SnapshotCoppa',
+    lastName: 'Coach',
+    fullName: 'SnapshotCoppa Coach',
+  }).returning();
+
+  await db.insert(userOrganizations).values({
+    userId: testCoach.id,
+    organizationId: testOrg.id,
+    role: 'coach',
+  });
+
+  const coachLogin = await request(app)
+    .post('/api/auth/login')
+    .send({
+      username: testCoach.username,
+      password: 'TestCoach123!',
+    });
+
+  coachAuthCookie = coachLogin.headers['set-cookie'][0];
+});
+
+afterEach(async () => {
+  for (const reportId of createdReportIds) {
+    // report_snapshots.report_id cascades on report delete.
+    await db.delete(reports).where(eq(reports.id, reportId));
+  }
+  createdReportIds = [];
+
+  for (const athleteId of createdAthleteIds) {
+    await db.delete(measurements).where(eq(measurements.userId, athleteId));
+    await db.delete(userOrganizations).where(eq(userOrganizations.userId, athleteId));
+    await db.delete(users).where(eq(users.id, athleteId));
+  }
+  createdAthleteIds = [];
+
+  if (testCoach && testOrg) {
+    await db.delete(userOrganizations).where(eq(userOrganizations.userId, testCoach.id));
+  }
+  if (testCoach) {
+    await db.delete(users).where(eq(users.id, testCoach.id));
+    testCoach = null;
+  }
+  if (testOrg) {
+    await db.delete(organizations).where(eq(organizations.id, testOrg.id));
+  }
+});
+
+/** Seed a roster athlete with one VERTICAL_JUMP measurement, optionally a minor. */
+async function seedAthlete(value: string, options: { isMinor?: boolean } = {}) {
+  const stamp = `${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const [athlete] = await db.insert(users).values({
+    username: `snapshotcoppaathlete_${stamp}`,
+    emails: [`snapshotcoppaathlete_${stamp}@test.com`],
+    password: await hashPassword('AthletePass123!'),
+    firstName: 'SnapshotCoppa',
+    lastName: 'Athlete',
+    fullName: 'SnapshotCoppa Athlete',
+    isMinor: options.isMinor ?? false,
+  }).returning();
+  createdAthleteIds.push(athlete.id);
+
+  await db.insert(userOrganizations).values({
+    userId: athlete.id,
+    organizationId: testOrg.id,
+    role: 'athlete',
+  });
+
+  await db.insert(measurements).values({
+    userId: athlete.id,
+    submittedBy: testCoach.id,
+    date: '2024-01-15',
+    age: options.isMinor ? 15 : 22,
+    metric: 'VERTICAL_JUMP',
+    value,
+    units: 'in',
+    organizationId: testOrg.id,
+    isVerified: true,
+  });
+
+  return athlete;
+}
+
+async function createTeamReport() {
+  const [report] = await db.insert(reports).values({
+    name: 'Snapshot COPPA Report',
+    organizationId: testOrg.id,
+    reportType: 'team',
+    config: {
+      timeframe: { type: 'preset', preset: 'all_time' },
+      metrics: ['VERTICAL_JUMP'],
+    },
+    createdBy: testCoach.id,
+  }).returning();
+  createdReportIds.push(report.id);
+  return report;
+}
+
+function createSnapshot(reportId: string) {
+  return request(app)
+    .post(`/api/reports/${reportId}/snapshots`)
+    .set('Cookie', coachAuthCookie)
+    .send({});
+}
+
+describe('POST /api/reports/:id/snapshots — team-report COPPA minor detection', () => {
+  it('flags publicAccessRestricted when a minor is on the roster', async () => {
+    await seedAthlete('24.000', { isMinor: true });
+    const report = await createTeamReport();
+
+    const response = await createSnapshot(report.id);
+
+    expect(response.status).toBe(201);
+    expect(response.body.containsMinorData).toBe(true);
+    expect(response.body.publicAccessRestricted).toBe(true);
+  });
+
+  it('leaves publicAccessRestricted false when no minor is on the roster', async () => {
+    await seedAthlete('24.000', { isMinor: false });
+    const report = await createTeamReport();
+
+    const response = await createSnapshot(report.id);
+
+    expect(response.status).toBe(201);
+    expect(response.body.containsMinorData).toBe(false);
+    expect(response.body.publicAccessRestricted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

**1. Team-report COPPA snapshot bug (original fix):**
- `ReportService.createSnapshot`'s minor-detection read `data?.athletes` to collect a team report's roster for the COPPA check, but `TeamReportData` has no `athletes` field — the roster lives in `athleteRankings`. Every team-report snapshot silently found zero athlete IDs, so `containsMinorData`/`publicAccessRestricted` were never set to `true` even when minors were on the roster, leaving their data unprotected once a public share link was created.
- Fixed the field check to `data?.athleteRankings`, reading `a.userId` (the real field on `AthletePerformance`).

**2. Follow-up: closed the remaining filed COPPA security issues (#345, #347, #348, #349) plus one code-scan finding:**
- **#349** + same bug in data-export route (found via scan): `POST /api/coppa/data-deletion/request` and `POST /api/coppa/data-export/request` now derive `requestedByEmail` from the session on the authenticated path instead of trusting the body — an authenticated actor could otherwise redirect a deletion/export confirmation (minor's name, or a one-time data-export download link) to an arbitrary address.
- **#348**: `PUT /api/athletes/:id` now restricts `parentEmail` updates to `org_admin`/`site_admin`. A coach could previously set it to any address, creating a `parentAthleteLinks` row and emailing that address the minor's name, with no admin approval.
- **#347**: `GET /api/coppa/consent/verify/:token` now sets `Cache-Control: no-store` and `Referrer-Policy: no-referrer`, since the token lives in the URL path.
- **#345**: the post-consent "Create Parent Account" link no longer embeds the parent's email/consentId in the `/register` URL. Consent-grant now mints an opaque, single-use `registrationToken` resolved server-side by registration, mirroring the existing `coppa-email-token-store.ts` pattern. This also fixes a latent functional bug: the URL carried the *masked* email from the verify endpoint into a read-only form field, which could never match the real consent record — so this flow could never actually complete before this fix.
- **#346/#350**: verified already fixed by a prior commit that landed ~2.5 hours after they were filed and was never used to close them. No code change; closing as already resolved.

## Test plan
- [x] `tests/integration/report-snapshot-coppa.test.ts` — new regression test for the original snapshot bug (minor-present vs. no-minor cases).
- [x] `tests/integration/coppa-deletion.test.ts` / `coppa-export.test.ts` — new regression tests proving `requestedByEmail` is session-derived, not body-derived, on the authenticated path.
- [x] `tests/integration/athlete-parent-email.test.ts` — updated to exercise org_admin (the now-authorized role) plus a new coach-denied regression test proving the field write doesn't happen even though other fields still update.
- [x] `tests/integration/coppa-routes.test.ts` — new regression test for the `Cache-Control`/`Referrer-Policy` headers.
- [x] `tests/integration/parent-registration.test.ts` — new regression tests for the `ref` token flow (success, invalid token, single-use enforcement).
- [x] Full sweep: all 9 touched/related integration suites (204 tests) pass with no regressions.
- [x] `npm run check` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)