### PR TITLE
fix(security): Wave 1 — privilege escalation, tenant isolation & hardening

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -212,7 +212,17 @@ process.on('SIGINT', () => shutdownHandler?.('SIGINT'));
 // gracefully shut down on uncaught exceptions instead of dying silently.
 registerProcessSafetyHandlers({
   log: (message) => console.error(message),
-  onFatal: () => shutdownHandler?.('uncaughtException'),
+  onFatal: () => {
+    if (shutdownHandler) {
+      shutdownHandler('uncaughtException');
+    } else {
+      // The crash happened during startup, before the graceful-shutdown handler
+      // was wired up. Exit non-zero so the platform restarts a clean process
+      // instead of leaving a half-initialized one running (health checks would
+      // otherwise fail indefinitely without a restart).
+      process.exit(1);
+    }
+  },
 });
 
 (async () => {

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -6,6 +6,7 @@ import { shutdownAuditLogQueue } from "./middleware/organization-type-middleware
 import { startWellnessDigestJob, stopWellnessDigestJob } from "./jobs/wellness-digest-job";
 import { startWellnessScheduledJob, stopWellnessScheduledJob } from "./jobs/wellness-scheduled-job";
 import { startCoppaTokenCleanupJob, stopCoppaTokenCleanupJob } from "./jobs/coppa-token-cleanup";
+import { registerProcessSafetyHandlers } from "./lib/process-safety";
 
 // Default NODE_ENV to production for security (fail-secure approach)
 // Production mode ensures: error sanitization, rate limiting, secure cookies
@@ -206,6 +207,13 @@ let shutdownHandler: ((signal: string) => Promise<void>) | null = null;
 // Register signal handlers immediately (before server starts)
 process.on('SIGTERM', () => shutdownHandler?.('SIGTERM'));
 process.on('SIGINT', () => shutdownHandler?.('SIGINT'));
+
+// Register process-safety handlers: log unhandled rejections (keep serving) and
+// gracefully shut down on uncaught exceptions instead of dying silently.
+registerProcessSafetyHandlers({
+  log: (message) => console.error(message),
+  onFatal: () => shutdownHandler?.('uncaughtException'),
+});
 
 (async () => {
   const server = await registerRoutes(app);

--- a/packages/api/lib/__tests__/process-safety.test.ts
+++ b/packages/api/lib/__tests__/process-safety.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  handleUnhandledRejection,
+  handleUncaughtException,
+} from '../process-safety';
+
+describe('process safety handlers', () => {
+  it('logs an unhandled rejection and keeps the process running', () => {
+    const log = vi.fn();
+    handleUnhandledRejection(new Error('boom'), log);
+    expect(log).toHaveBeenCalled();
+  });
+
+  it('logs an uncaught exception and triggers graceful shutdown', () => {
+    const log = vi.fn();
+    const onFatal = vi.fn();
+    const err = new Error('fatal');
+
+    handleUncaughtException(err, log, onFatal);
+
+    expect(log).toHaveBeenCalled();
+    expect(onFatal).toHaveBeenCalledWith(err);
+  });
+});

--- a/packages/api/lib/process-safety.ts
+++ b/packages/api/lib/process-safety.ts
@@ -1,0 +1,39 @@
+/**
+ * Process-level safety handlers.
+ *
+ * A single-process Node server has no supervisor thread: an unhandled promise
+ * rejection or an uncaught exception that escapes all try/catch blocks can take
+ * the whole server down (or, depending on Node flags, be silently swallowed).
+ * These handlers make that behaviour explicit and observable.
+ *
+ * Policy:
+ *  - unhandledRejection: log loudly but keep serving. These are frequently
+ *    benign (a fire-and-forget notification that rejected) and crashing the
+ *    entire multi-tenant server for one stray rejection would be worse.
+ *  - uncaughtException: the process is now in an undefined state, so log and
+ *    trigger the graceful-shutdown path, letting the platform restart cleanly.
+ */
+
+type LogFn = (message: string) => void;
+type FatalFn = (error: unknown) => void;
+
+export function handleUnhandledRejection(reason: unknown, log: LogFn): void {
+  const detail = reason instanceof Error ? (reason.stack ?? reason.message) : String(reason);
+  log(`Unhandled promise rejection (process continuing): ${detail}`);
+}
+
+export function handleUncaughtException(error: unknown, log: LogFn, onFatal: FatalFn): void {
+  const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  log(`Uncaught exception (initiating graceful shutdown): ${detail}`);
+  onFatal(error);
+}
+
+/**
+ * Register the process-safety handlers. `log` receives a formatted message and
+ * `onFatal` is invoked for uncaught exceptions (typically the graceful-shutdown
+ * routine).
+ */
+export function registerProcessSafetyHandlers(deps: { log: LogFn; onFatal: FatalFn }): void {
+  process.on('unhandledRejection', (reason) => handleUnhandledRejection(reason, deps.log));
+  process.on('uncaughtException', (error) => handleUncaughtException(error, deps.log, deps.onFatal));
+}

--- a/packages/api/lib/session-helpers.ts
+++ b/packages/api/lib/session-helpers.ts
@@ -1,0 +1,31 @@
+import type { Request } from 'express';
+
+/**
+ * Regenerate the session to prevent session fixation on authentication.
+ *
+ * The pre-authentication CSRF secret is preserved across the regeneration so a
+ * CSRF token the client fetched before logging in stays valid — otherwise the
+ * first state-changing request after login would fail with "Invalid session"
+ * until the client refetched a token.
+ */
+export async function regenerateSession(req: Request): Promise<void> {
+  const csrfSecret = (req.session as any)?.csrfSecret;
+  await new Promise<void>((resolve, reject) => {
+    req.session.regenerate((err) => (err ? reject(err) : resolve()));
+  });
+  if (csrfSecret) {
+    (req.session as any).csrfSecret = csrfSecret;
+  }
+}
+
+/**
+ * Persist the session to the store before responding, so the Set-Cookie header
+ * for the newly regenerated session is written before the response body. Without
+ * this, express-session's lazy save can race with res.json()/res.redirect() and
+ * the client's next request may be treated as unauthenticated.
+ */
+export async function saveSession(req: Request): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    req.session.save((err) => (err ? reject(err) : resolve()));
+  });
+}

--- a/packages/api/middleware/athlete-permissions.ts
+++ b/packages/api/middleware/athlete-permissions.ts
@@ -54,82 +54,96 @@ export async function requireAthleteManagementPermission(
 }
 
 /**
- * Checks if user has permission to access a specific athlete
- * Requires:
- * - Athletes can access their own profile
- * - Org admins and coaches can access athletes in same organization
- * - Site admins can access any athlete
+ * Factory for athlete-access middleware.
+ *
+ * Requires org_admin/coach role in an organization shared with the athlete
+ * (site admins always pass). When `allowSelf` is true, an athlete may also
+ * access their own record — appropriate for reads and self-profile edits, but
+ * NOT for destructive actions (delete, status toggle) where self-access would
+ * let an athlete delete themselves or reverse an admin's deactivation.
  */
-export async function requireAthleteAccessPermission(
-  req: Request,
-  res: Response,
-  next: NextFunction
-) {
-  try {
-    const currentUser = req.session.user;
-    const athleteId = req.params.id;
+function athleteAccessPermission(options: { allowSelf: boolean }) {
+  return async function (req: Request, res: Response, next: NextFunction) {
+    try {
+      const currentUser = req.session.user;
+      const athleteId = req.params.id;
 
-    if (!currentUser?.id) {
-      return res.status(401).json({ message: "User not authenticated" });
+      if (!currentUser?.id) {
+        return res.status(401).json({ message: "User not authenticated" });
+      }
+
+      // Validate athleteId format (UUID v4 format)
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      if (!athleteId || !uuidRegex.test(athleteId)) {
+        return res.status(400).json({ message: "Invalid athlete ID format" });
+      }
+
+      const userIsSiteAdmin = currentUser.isSiteAdmin === true;
+
+      // Site admins can access any athlete
+      if (userIsSiteAdmin) {
+        return next();
+      }
+
+      // Athletes can access their own profile (read/self-edit only)
+      if (options.allowSelf && currentUser.id === athleteId) {
+        return next();
+      }
+
+      const [userOrgs, athleteOrgs] = await Promise.all([
+        storage.getUserOrganizations(currentUser.id),
+        storage.getUserOrganizations(athleteId)
+      ]);
+
+      if (userOrgs.length === 0) {
+        return res.status(403).json({ message: "No organization access" });
+      }
+
+      // Check if user has appropriate role
+      const hasRole = userOrgs.some(org =>
+        org.role === 'org_admin' || org.role === 'coach'
+      );
+
+      if (!hasRole) {
+        return res.status(403).json({
+          message: "Organization admin or coach role required"
+        });
+      }
+
+      // Check if athlete exists (athleteOrgs will be empty if user doesn't exist)
+      if (athleteOrgs.length === 0) {
+        return res.status(404).json({ message: "Athlete not found" });
+      }
+
+      // Check if athlete is in user's organization
+      const athleteOrgIds = athleteOrgs.map(org => org.organizationId);
+      const userOrgIds = userOrgs.map(org => org.organizationId);
+      const hasSharedOrg = athleteOrgIds.some(orgId => userOrgIds.includes(orgId));
+
+      if (!hasSharedOrg) {
+        return res.status(403).json({
+          message: "Access denied - athlete not in your organization"
+        });
+      }
+
+      next();
+    } catch (error) {
+      console.error("Error in athleteAccessPermission:", error);
+      return res.status(500).json({ message: "Internal server error" });
     }
-
-    // Validate athleteId format (UUID v4 format)
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-    if (!athleteId || !uuidRegex.test(athleteId)) {
-      return res.status(400).json({ message: "Invalid athlete ID format" });
-    }
-
-    const userIsSiteAdmin = currentUser.isSiteAdmin === true;
-
-    // Site admins can access any athlete
-    if (userIsSiteAdmin) {
-      return next();
-    }
-
-    // Athletes can access their own profile
-    if (currentUser.id === athleteId) {
-      return next();
-    }
-
-    const [userOrgs, athleteOrgs] = await Promise.all([
-      storage.getUserOrganizations(currentUser.id),
-      storage.getUserOrganizations(athleteId)
-    ]);
-
-    if (userOrgs.length === 0) {
-      return res.status(403).json({ message: "No organization access" });
-    }
-
-    // Check if user has appropriate role
-    const hasRole = userOrgs.some(org =>
-      org.role === 'org_admin' || org.role === 'coach'
-    );
-
-    if (!hasRole) {
-      return res.status(403).json({
-        message: "Organization admin or coach role required"
-      });
-    }
-
-    // Check if athlete exists (athleteOrgs will be empty if user doesn't exist)
-    if (athleteOrgs.length === 0) {
-      return res.status(404).json({ message: "Athlete not found" });
-    }
-
-    // Check if athlete is in user's organization
-    const athleteOrgIds = athleteOrgs.map(org => org.organizationId);
-    const userOrgIds = userOrgs.map(org => org.organizationId);
-    const hasSharedOrg = athleteOrgIds.some(orgId => userOrgIds.includes(orgId));
-
-    if (!hasSharedOrg) {
-      return res.status(403).json({
-        message: "Access denied - athlete not in your organization"
-      });
-    }
-
-    next();
-  } catch (error) {
-    console.error("Error in requireAthleteAccessPermission:", error);
-    return res.status(500).json({ message: "Internal server error" });
-  }
+  };
 }
+
+/**
+ * Access to a specific athlete for reads and self-profile edits.
+ * Athletes may access their own record; org_admin/coach may access athletes in
+ * a shared organization; site admins may access any.
+ */
+export const requireAthleteAccessPermission = athleteAccessPermission({ allowSelf: true });
+
+/**
+ * Access to a specific athlete for destructive/management actions (delete,
+ * status toggle). Same as above but WITHOUT the athlete self-access branch, so
+ * an athlete cannot delete or re-activate their own record.
+ */
+export const requireAthleteManagementAccess = athleteAccessPermission({ allowSelf: false });

--- a/packages/api/routes.ts
+++ b/packages/api/routes.ts
@@ -715,6 +715,20 @@ export async function registerRoutes(app: Express) {
       return next();
     }
 
+    // CSRF only defends against an attacker riding a victim's authenticated
+    // session cookie. A request with no authenticated identity (mirrors
+    // requireAuth: no session.user and no legacy session.admin) has no such
+    // surface, so skip it. This covers every pre-authentication and public
+    // token-based endpoint (registration, COPPA/parent consent links,
+    // invitation/event-invitation accept-decline, email verification, magic
+    // links) without having to enumerate each one — those tokens are themselves
+    // unguessable and provide the CSRF protection. Authenticated mutations still
+    // require a token (the web client attaches one to every request).
+    const isAuthenticated = !!((req.session as any)?.user || (req.session as any)?.admin);
+    if (!isAuthenticated) {
+      return next();
+    }
+
     // Skip CSRF for certain API endpoints that use other authentication
     // Note: req.path is relative to the mount point, so '/api' prefix is not included
     // - /login and /register: Pre-authentication endpoints
@@ -792,11 +806,26 @@ export async function registerRoutes(app: Express) {
   app.use('/api', csrfProtection);
 
   // Input sanitization middleware
+  // Credential and opaque-token fields are never HTML-sanitized: DOMPurify would
+  // silently truncate a password/token containing an HTML-special character
+  // (e.g. "abc<def" -> "abc"), corrupting the value before the handler hashes or
+  // compares it and locking the user out. These fields are never rendered as
+  // HTML, so sanitizing them has no security benefit.
+  const SANITIZE_SKIP_FIELDS = new Set([
+    'password',
+    'currentpassword',
+    'newpassword',
+    'oldpassword',
+    'confirmpassword',
+    'confirmnewpassword',
+    'token',
+    '_csrf',
+  ]);
   const sanitizeInput = (req: Request, res: Response, next: NextFunction) => {
     // Sanitize string fields in request body
     if (req.body && typeof req.body === 'object') {
       for (const key in req.body) {
-        if (typeof req.body[key] === 'string') {
+        if (typeof req.body[key] === 'string' && !SANITIZE_SKIP_FIELDS.has(key.toLowerCase())) {
           req.body[key] = DOMPurify.sanitize(req.body[key]);
         }
       }

--- a/packages/api/routes.ts
+++ b/packages/api/routes.ts
@@ -673,11 +673,10 @@ export async function registerRoutes(app: Express) {
     next();
   });
 
-  // Register OAuth routes - BEFORE other routes
-  registerOAuthRoutes(app);
-
-  // Register new refactored routes - AFTER session middleware
-  registerAllRoutes(app);
+  // NOTE: Application routes are registered further below, AFTER the security
+  // middleware (helmet, CSRF, input sanitization, rate limiting). Express runs
+  // middleware in registration order and a matched route ends the chain, so the
+  // security middleware must be registered first to actually protect the routes.
 
   // Security headers middleware
   app.use(helmet({
@@ -704,6 +703,15 @@ export async function registerRoutes(app: Express) {
   const csrfProtection = (req: Request, res: Response, next: NextFunction) => {
     // Skip CSRF for GET requests (safe operations)
     if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') {
+      return next();
+    }
+
+    // Allow disabling CSRF outside production so the integration test suite can
+    // drive the API without fetching a token. This is IGNORED when
+    // NODE_ENV === 'production', where CSRF is always enforced. (The test suite
+    // runs under NODE_ENV=development, so a NODE_ENV-based check is unreliable;
+    // the flag is set explicitly by tests/setup/integration-setup.ts.)
+    if (process.env.NODE_ENV !== 'production' && process.env.DISABLE_CSRF === 'true') {
       return next();
     }
 
@@ -928,6 +936,14 @@ export async function registerRoutes(app: Express) {
 
   // Apply general rate limiting to all API routes
   app.use('/api', apiLimiter);
+
+  // Register application routes AFTER the security middleware above so that
+  // helmet, CSRF protection, input sanitization and rate limiting all run
+  // before any route handler can end the request.
+  // Register OAuth routes - BEFORE other routes
+  registerOAuthRoutes(app);
+  // Register new refactored routes - AFTER session middleware
+  registerAllRoutes(app);
 
   // Email validation function
   const isValidEmail = (value: string): boolean => {

--- a/packages/api/routes/athlete-routes.ts
+++ b/packages/api/routes/athlete-routes.ts
@@ -19,7 +19,8 @@ import { requireAuth, requireSiteAdmin } from "../middleware";
 import { insertUserSchema, insertAthleteSchema } from "@shared/schema";
 import {
   requireAthleteManagementPermission,
-  requireAthleteAccessPermission
+  requireAthleteAccessPermission,
+  requireAthleteManagementAccess
 } from "../middleware/athlete-permissions";
 import { athleteQuerySchema } from "../validation/athlete-validation";
 import { ZodError } from "zod";
@@ -443,7 +444,7 @@ export function registerAthleteRoutes(app: Express) {
   /**
    * Toggle athlete active status (org admins and coaches within their organization)
    */
-  app.patch("/api/athletes/:id/status", athleteLimiter, requireAuth, requireAthleteAccessPermission, async (req, res) => {
+  app.patch("/api/athletes/:id/status", athleteLimiter, requireAuth, requireAthleteManagementAccess, async (req, res) => {
     try {
       const athleteId = req.params.id;
       const { isActive } = req.body;
@@ -471,7 +472,7 @@ export function registerAthleteRoutes(app: Express) {
   /**
    * Delete athlete (org admins and coaches within their organization)
    */
-  app.delete("/api/athletes/:id", athleteDeleteLimiter, requireAuth, requireAthleteAccessPermission, async (req, res) => {
+  app.delete("/api/athletes/:id", athleteDeleteLimiter, requireAuth, requireAthleteManagementAccess, async (req, res) => {
     try {
       const athleteId = req.params.id;
 
@@ -490,7 +491,7 @@ export function registerAthleteRoutes(app: Express) {
   /**
    * Bulk delete athletes (org admins and coaches within their organization)
    */
-  app.post("/api/athletes/bulk-delete", athleteDeleteLimiter, requireAuth, async (req, res) => {
+  app.post("/api/athletes/bulk-delete", athleteDeleteLimiter, requireAuth, requireAthleteManagementPermission, async (req, res) => {
     try {
       const { athleteIds } = req.body;
 
@@ -592,7 +593,7 @@ export function registerAthleteRoutes(app: Express) {
   /**
    * Bulk invite athletes (org admins and coaches within their organization)
    */
-  app.post("/api/athletes/bulk-invite", athleteLimiter, requireAuth, async (req, res) => {
+  app.post("/api/athletes/bulk-invite", athleteLimiter, requireAuth, requireAthleteManagementPermission, async (req, res) => {
     try {
       const { athleteIds, organizationId } = req.body;
 

--- a/packages/api/routes/auth-routes.ts
+++ b/packages/api/routes/auth-routes.ts
@@ -81,6 +81,12 @@ export function registerAuthRoutes(app: Express) {
       // Determine user's actual role and organization context
       const roleContext = await authService.determineUserRoleAndContext(user);
 
+      // Regenerate the session before storing the authenticated user to prevent
+      // session fixation (mirrors the OAuth and invitation-acceptance flows).
+      await new Promise<void>((resolve, reject) => {
+        req.session.regenerate((err) => (err ? reject(err) : resolve()));
+      });
+
       // Set session
       req.session.user = {
         id: user.id,

--- a/packages/api/routes/auth-routes.ts
+++ b/packages/api/routes/auth-routes.ts
@@ -11,6 +11,7 @@ import { shouldSkipRateLimiting } from "../utils/rate-limit-utils";
 import { COPPA_ACTIONS } from "@shared/coppa-utils";
 import { storage } from "../storage";
 import { generateParentEmailToken } from "../services/coppa-email-token-store";
+import { regenerateSession, saveSession } from "../lib/session-helpers";
 // Session types are loaded globally
 
 const authService = new AuthService();
@@ -83,9 +84,7 @@ export function registerAuthRoutes(app: Express) {
 
       // Regenerate the session before storing the authenticated user to prevent
       // session fixation (mirrors the OAuth and invitation-acceptance flows).
-      await new Promise<void>((resolve, reject) => {
-        req.session.regenerate((err) => (err ? reject(err) : resolve()));
-      });
+      await regenerateSession(req);
 
       // Set session
       req.session.user = {
@@ -114,6 +113,10 @@ export function registerAuthRoutes(app: Express) {
         redirectUrl = '/parent-dashboard';
       }
       // org_admin, coach, and others default to /dashboard
+
+      // Persist the regenerated session before responding so the Set-Cookie is
+      // written before the body (avoids a race with the client's next request).
+      await saveSession(req);
 
       res.json({
         user: req.session.user,

--- a/packages/api/routes/enhanced-auth.ts
+++ b/packages/api/routes/enhanced-auth.ts
@@ -5,6 +5,7 @@ import { AuthSecurity } from '../auth/security';
 import { PasswordResetService } from '../auth/password-reset';
 import { RoleManager } from '../auth/role-manager';
 import { requirePermission } from '../permissions/index';
+import { regenerateSession, saveSession } from '../lib/session-helpers';
 import { z } from 'zod';
 
 const router = Router();
@@ -120,9 +121,7 @@ router.post('/login', async (req: Request, res: Response) => {
     // Regenerate the session before storing auth state to prevent session
     // fixation (mirrors login, registration and the OAuth flow). Must run before
     // assigning sessionToken/user since regenerate() replaces the session.
-    await new Promise<void>((resolve, reject) => {
-      req.session.regenerate((err) => (err ? reject(err) : resolve()));
-    });
+    await regenerateSession(req);
 
     // Set session cookie
     req.session.sessionToken = sessionToken;
@@ -144,6 +143,10 @@ router.post('/login', async (req: Request, res: Response) => {
     else if (userRole === 'org_admin') redirectUrl = '/organization';
     else if (userRole === 'coach') redirectUrl = '/coaching';
     else if (userRole === 'athlete') redirectUrl = '/my-dashboard';
+
+    // Persist the regenerated session before responding (avoids a Set-Cookie
+    // vs response-body race with the client's next request).
+    await saveSession(req);
 
     return res.status(200).json({
       success: true,

--- a/packages/api/routes/enhanced-auth.ts
+++ b/packages/api/routes/enhanced-auth.ts
@@ -117,6 +117,13 @@ router.post('/login', async (req: Request, res: Response) => {
       }
     }
 
+    // Regenerate the session before storing auth state to prevent session
+    // fixation (mirrors login, registration and the OAuth flow). Must run before
+    // assigning sessionToken/user since regenerate() replaces the session.
+    await new Promise<void>((resolve, reject) => {
+      req.session.regenerate((err) => (err ? reject(err) : resolve()));
+    });
+
     // Set session cookie
     req.session.sessionToken = sessionToken;
     req.session.user = {

--- a/packages/api/routes/organization-routes.ts
+++ b/packages/api/routes/organization-routes.ts
@@ -715,6 +715,17 @@ export function registerOrganizationRoutes(app: Express) {
         return res.status(400).json({ message: "Invalid organization ID format" });
       }
 
+      // Only organization administrators (or site admins) may add users.
+      // Membership alone is not sufficient — mirrors the role check on the
+      // sibling PUT /users/:userId/role endpoint.
+      const requestingUser = req.session.user!;
+      const requestingUserRoles = await storage.getUserRoles(requestingUser.id, organizationId);
+      const isOrgAdmin = requestingUserRoles.includes('org_admin');
+      const isSiteAdmin = requestingUser.isSiteAdmin === true;
+      if (!isOrgAdmin && !isSiteAdmin) {
+        return res.status(403).json({ message: "Access denied. Only organization administrators can add users." });
+      }
+
       const user = await organizationService.addUserToOrganization(
         organizationId,
         req.body,

--- a/packages/api/routes/registration-routes.ts
+++ b/packages/api/routes/registration-routes.ts
@@ -356,6 +356,12 @@ export function registerRegistrationRoutes(app: Express) {
       // all other users — including teen minors (13-17) — can log in immediately.
       // Guard against missing session middleware (e.g. in unit test environments).
       if (req.session) {
+        // Regenerate the session before storing the authenticated user to
+        // prevent session fixation (mirrors login and the OAuth flow).
+        await new Promise<void>((resolve, reject) => {
+          req.session.regenerate((err) => (err ? reject(err) : resolve()));
+        });
+
         req.session.user = {
           id: userId,
           username,

--- a/packages/api/routes/registration-routes.ts
+++ b/packages/api/routes/registration-routes.ts
@@ -17,6 +17,7 @@ import {
   AUDIT_ACTION_LEGAL_ACCEPTED
 } from "@shared/legal-acceptance";
 import { coppaService } from "../services/coppa-service";
+import { regenerateSession, saveSession } from "../lib/session-helpers";
 import { consumeRegistrationToken } from "../services/registration-token-store";
 import { isUnder13, isMinorAge, isTeenMinor } from "@shared/coppa-utils";
 import { db } from "../db";
@@ -358,9 +359,7 @@ export function registerRegistrationRoutes(app: Express) {
       if (req.session) {
         // Regenerate the session before storing the authenticated user to
         // prevent session fixation (mirrors login and the OAuth flow).
-        await new Promise<void>((resolve, reject) => {
-          req.session.regenerate((err) => (err ? reject(err) : resolve()));
-        });
+        await regenerateSession(req);
 
         req.session.user = {
           id: userId,
@@ -376,12 +375,7 @@ export function registerRegistrationRoutes(app: Express) {
         // Explicitly save the session so the Set-Cookie header is written
         // before the response body is sent. Without this, express-session's
         // lazy save may race with res.json() in test environments.
-        await new Promise<void>((resolve, reject) => {
-          req.session.save((err) => {
-            if (err) reject(err);
-            else resolve();
-          });
-        });
+        await saveSession(req);
       }
 
       // Send verification email (outside transaction - email failure shouldn't rollback registration)

--- a/packages/api/services/organization-service.ts
+++ b/packages/api/services/organization-service.ts
@@ -435,9 +435,14 @@ export class OrganizationService extends BaseService {
       }
 
       // Create user and add to organization
-      // Each user can only have one role per organization
-      const role = userData.role || 'athlete';
-      const user = await this.storage.createUser(userData);
+      // Each user can only have one role per organization.
+      // Clamp the role to valid organization roles and never let a
+      // client-supplied `isSiteAdmin` flag through to createUser — site-admin
+      // status is granted only via dedicated site-admin tooling, never here.
+      const validOrgRoles = ['org_admin', 'coach', 'athlete'];
+      const role = validOrgRoles.includes(userData.role) ? userData.role : 'athlete';
+      const { isSiteAdmin: _ignoredIsSiteAdmin, ...safeUserData } = userData;
+      const user = await this.storage.createUser(safeUserData);
       await this.storage.addUserToOrganization(user.id, organizationId, role);
 
       return user;

--- a/packages/api/services/organization-service.ts
+++ b/packages/api/services/organization-service.ts
@@ -436,10 +436,11 @@ export class OrganizationService extends BaseService {
 
       // Create user and add to organization
       // Each user can only have one role per organization.
-      // Clamp the role to valid organization roles and never let a
-      // client-supplied `isSiteAdmin` flag through to createUser — site-admin
-      // status is granted only via dedicated site-admin tooling, never here.
-      const validOrgRoles = ['org_admin', 'coach', 'athlete'];
+      // Clamp the role to valid organization-scoped roles (every role except the
+      // global 'site_admin') and never let a client-supplied `isSiteAdmin` flag
+      // through to createUser — site-admin status is granted only via dedicated
+      // site-admin tooling, never here. See packages/shared/role-types.ts.
+      const validOrgRoles = ['org_admin', 'coach', 'athlete', 'parent', 'guest'];
       const role = validOrgRoles.includes(userData.role) ? userData.role : 'athlete';
       const { isSiteAdmin: _ignoredIsSiteAdmin, ...safeUserData } = userData;
       const user = await this.storage.createUser(safeUserData);

--- a/tests/integration/athlete-authorization.test.ts
+++ b/tests/integration/athlete-authorization.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Security regression tests for athlete management authorization.
+ *
+ * Guards against two authorization gaps:
+ *  1. DELETE /api/athletes/:id and PATCH /api/athletes/:id/status used
+ *     requireAthleteAccessPermission, whose self-access branch let an athlete
+ *     delete their own account or re-activate themselves after an admin
+ *     deactivated them.
+ *  2. POST /api/athletes/bulk-delete and /bulk-invite checked org membership
+ *     only (no role), so any athlete-role member could delete/invite teammates.
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { storage } from '../../packages/api/storage';
+import type { Organization, User, Team } from '@shared/schema';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+const PASSWORD = 'TestPass123!';
+
+describe('Athlete management authorization', () => {
+  let org: Organization;
+  let team: Team;
+  let orgAdmin: User;
+  let coach: User;
+  let app: express.Express;
+  const trackedUserIds: string[] = [];
+
+  let seq = 0;
+  async function makeUser(role: 'org_admin' | 'coach' | 'athlete'): Promise<User> {
+    const uniq = `${Date.now()}${seq++}`;
+    const user = await storage.createUser({
+      username: `wave1${role.replace('_', '')}${uniq}`,
+      password: PASSWORD,
+      emails: [`wave1${role.replace('_', '')}${uniq}@test.com`],
+      firstName: 'Test',
+      lastName: role,
+    });
+    await storage.addUserToOrganization(user.id, org.id, role);
+    trackedUserIds.push(user.id);
+    return user;
+  }
+
+  async function agentFor(user: User) {
+    const agent = request.agent(app);
+    await agent
+      .post('/api/auth/login')
+      .send({ username: user.username, password: PASSWORD })
+      .expect(200);
+    return agent;
+  }
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+
+    org = await storage.createOrganization({
+      name: `Wave1 Athlete Auth Org ${Date.now()}`,
+      description: 'athlete authorization tests',
+    });
+    team = await storage.createTeam({
+      name: `Wave1 Auth Team ${Date.now()}`,
+      level: 'Club',
+      organizationId: org.id,
+    });
+    orgAdmin = await makeUser('org_admin');
+    coach = await makeUser('coach');
+  });
+
+  afterAll(async () => {
+    for (const id of trackedUserIds) {
+      try { await storage.deleteUser(id); } catch { /* best-effort */ }
+    }
+    try { await storage.deleteTeam(team.id); } catch { /* ignore */ }
+    try { await storage.deleteOrganization(org.id); } catch { /* ignore */ }
+  });
+
+  it('forbids an athlete from deleting their own account', async () => {
+    const athlete = await makeUser('athlete');
+    const agent = await agentFor(athlete);
+
+    const res = await agent.delete(`/api/athletes/${athlete.id}`);
+
+    expect(res.status).toBe(403);
+    expect(await storage.getUser(athlete.id)).toBeTruthy();
+  });
+
+  it('forbids an athlete from re-activating themselves via status toggle', async () => {
+    const athlete = await makeUser('athlete');
+    // Log in while active (a deactivated user cannot authenticate), then the
+    // admin deactivates them; the athlete's existing session must not be able
+    // to reverse it.
+    const agent = await agentFor(athlete);
+    await storage.updateUser(athlete.id, { isActive: false });
+
+    const res = await agent
+      .patch(`/api/athletes/${athlete.id}/status`)
+      .send({ isActive: true });
+
+    expect(res.status).toBe(403);
+    const after = await storage.getUser(athlete.id);
+    expect(after?.isActive).toBe(false);
+  });
+
+  it('forbids an athlete from bulk-deleting a teammate', async () => {
+    const attacker = await makeUser('athlete');
+    const victim = await makeUser('athlete');
+    const agent = await agentFor(attacker);
+
+    const res = await agent
+      .post('/api/athletes/bulk-delete')
+      .send({ athleteIds: [victim.id] });
+
+    expect(res.status).toBe(403);
+    expect(await storage.getUser(victim.id)).toBeTruthy();
+  });
+
+  it('forbids an athlete from bulk-inviting teammates', async () => {
+    const attacker = await makeUser('athlete');
+    const target = await makeUser('athlete');
+    const agent = await agentFor(attacker);
+
+    const res = await agent
+      .post('/api/athletes/bulk-invite')
+      .send({ athleteIds: [target.id], organizationId: org.id });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('still allows an org admin to delete an athlete', async () => {
+    const athlete = await makeUser('athlete');
+    const agent = await agentFor(orgAdmin);
+
+    const res = await agent.delete(`/api/athletes/${athlete.id}`);
+
+    expect(res.status).toBe(200);
+    expect(await storage.getUser(athlete.id)).toBeFalsy();
+  });
+
+  it('still allows a coach to bulk-delete an athlete in the org', async () => {
+    const athlete = await makeUser('athlete');
+    // bulk-delete scopes each athlete by their team's organization, so the
+    // athlete must be on a team in the org for the coach to reach them.
+    await storage.addUserToTeam(athlete.id, team.id);
+    const agent = await agentFor(coach);
+
+    const res = await agent
+      .post('/api/athletes/bulk-delete')
+      .send({ athleteIds: [athlete.id] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(1);
+  });
+});

--- a/tests/integration/organization-add-user-security.test.ts
+++ b/tests/integration/organization-add-user-security.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Security regression tests for POST /api/organizations/:id/users
+ *
+ * Guards against a privilege-escalation / mass-assignment vulnerability where:
+ *  - the route only required authentication (any org member passed the check), and
+ *  - req.body was passed straight into createUser, whose column whitelist includes
+ *    `isSiteAdmin` and whose role defaulted from client-supplied `role`.
+ *
+ * That allowed any athlete-role member to mint a site administrator.
+ */
+
+// Set environment variables before any imports
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { storage } from '../../packages/api/storage';
+import type { Organization, User } from '@shared/schema';
+
+// Mock vite module before importing registerRoutes
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+const PASSWORD = 'TestPass123!';
+
+describe('POST /api/organizations/:id/users — authorization', () => {
+  let org: Organization;
+  let orgAdmin: User;
+  let athlete: User;
+  let app: express.Express;
+  const createdUsernames: string[] = [];
+
+  async function agentFor(user: User) {
+    const agent = request.agent(app);
+    await agent
+      .post('/api/auth/login')
+      .send({ username: user.username, password: PASSWORD })
+      .expect(200);
+    return agent;
+  }
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) {
+      throw new Error('DATABASE_URL must be set to run integration tests.');
+    }
+
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+
+    const ts = Date.now();
+    org = await storage.createOrganization({
+      name: `Wave1 Security Org ${ts}`,
+      description: 'add-user authorization tests',
+    });
+
+    orgAdmin = await storage.createUser({
+      username: `wave1admin${ts}`,
+      password: PASSWORD,
+      emails: [`wave1admin${ts}@test.com`],
+      firstName: 'Org',
+      lastName: 'Admin',
+    });
+    await storage.addUserToOrganization(orgAdmin.id, org.id, 'org_admin');
+
+    athlete = await storage.createUser({
+      username: `wave1athlete${ts}`,
+      password: PASSWORD,
+      emails: [`wave1athlete${ts}@test.com`],
+      firstName: 'Reg',
+      lastName: 'Athlete',
+    });
+    await storage.addUserToOrganization(athlete.id, org.id, 'athlete');
+  });
+
+  afterAll(async () => {
+    for (const username of createdUsernames) {
+      try {
+        const u = await storage.getUserByUsername(username);
+        if (u) await storage.deleteUser(u.id);
+      } catch { /* best-effort cleanup */ }
+    }
+    try { await storage.deleteUser(orgAdmin.id); } catch { /* ignore */ }
+    try { await storage.deleteUser(athlete.id); } catch { /* ignore */ }
+    try { await storage.deleteOrganization(org.id); } catch { /* ignore */ }
+  });
+
+  it('forbids an athlete-role member from creating a site admin', async () => {
+    const agent = await agentFor(athlete);
+    const username = `wave1escalated${Date.now()}`;
+    createdUsernames.push(username);
+
+    const res = await agent
+      .post(`/api/organizations/${org.id}/users`)
+      .send({
+        username,
+        password: PASSWORD,
+        emails: [`${username}@test.com`],
+        firstName: 'Esc',
+        lastName: 'Alated',
+        role: 'org_admin',
+        isSiteAdmin: true,
+      });
+
+    expect(res.status).toBe(403);
+
+    // And no escalated account may exist as a side effect.
+    const created = await storage.getUserByUsername(username);
+    expect(created).toBeFalsy();
+  });
+
+  it('ignores a client-supplied isSiteAdmin flag when an org admin adds a user', async () => {
+    const agent = await agentFor(orgAdmin);
+    const username = `wave1coach${Date.now()}`;
+    createdUsernames.push(username);
+
+    const res = await agent
+      .post(`/api/organizations/${org.id}/users`)
+      .send({
+        username,
+        password: PASSWORD,
+        emails: [`${username}@test.com`],
+        firstName: 'New',
+        lastName: 'Coach',
+        role: 'coach',
+        isSiteAdmin: true,
+      });
+
+    expect(res.status).toBe(201);
+
+    const created = await storage.getUserByUsername(username);
+    expect(created).toBeTruthy();
+    expect(created!.isSiteAdmin).toBe(false);
+  });
+});

--- a/tests/integration/security-middleware-order.test.ts
+++ b/tests/integration/security-middleware-order.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression test for security middleware registration order.
+ *
+ * helmet, csrfProtection, input sanitization and the general rate limiter were
+ * registered AFTER the application routes in routes.ts. Because Express runs
+ * middleware in registration order and a matched route ends the chain, none of
+ * them executed for the real API surface. They must be registered BEFORE the
+ * routes.
+ *
+ * Note: CSRF is intentionally skipped when NODE_ENV === 'test' (consistent with
+ * the rate-limiter skips elsewhere in the codebase), so this test temporarily
+ * runs the CSRF assertion under NODE_ENV = 'development' to exercise the real
+ * (non-test) code path.
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+describe('Security middleware registration order', () => {
+  let app: express.Express;
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+  });
+
+  it('applies helmet security headers to application routes', async () => {
+    // /api/auth/me is registered by the application route modules; if helmet
+    // runs before them, its headers are present even on the 401 response.
+    const res = await request(app).get('/api/auth/me');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('enforces CSRF on state-changing /api routes when not bypassed', async () => {
+    // Integration setup sets DISABLE_CSRF=true; unset it to exercise the real
+    // CSRF path (the suite runs under NODE_ENV=development, so CSRF is active
+    // once the bypass flag is removed).
+    const prev = process.env.DISABLE_CSRF;
+    delete process.env.DISABLE_CSRF;
+    try {
+      const res = await request(app)
+        .post('/api/teams')
+        .send({ name: 'csrf-probe' });
+      expect(res.status).toBe(403);
+      expect(String(res.body.error)).toMatch(/csrf/i);
+    } finally {
+      process.env.DISABLE_CSRF = prev;
+    }
+  });
+});

--- a/tests/integration/security-middleware-order.test.ts
+++ b/tests/integration/security-middleware-order.test.ts
@@ -19,9 +19,11 @@ process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
 process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
 process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
 
-import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+import { storage } from '../../packages/api/storage';
+import type { User } from '@shared/schema';
 
 vi.mock('../../packages/api/vite.js', () => ({
   setupVite: vi.fn().mockResolvedValue(undefined),
@@ -30,8 +32,12 @@ vi.mock('../../packages/api/vite.js', () => ({
 
 import { registerRoutes } from '../../packages/api/routes';
 
+const PASSWORD = 'TestPass123!';
+
 describe('Security middleware registration order', () => {
   let app: express.Express;
+  let user: User;
+  let authedAgent: ReturnType<typeof request.agent>;
 
   beforeAll(async () => {
     if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
@@ -39,6 +45,24 @@ describe('Security middleware registration order', () => {
     app.use(express.json());
     app.use(express.urlencoded({ extended: false }));
     await registerRoutes(app);
+
+    const ts = Date.now();
+    user = await storage.createUser({
+      username: `wave1csrf${ts}`,
+      password: PASSWORD,
+      emails: [`wave1csrf${ts}@test.com`],
+      firstName: 'Csrf',
+      lastName: 'Probe',
+    });
+    authedAgent = request.agent(app);
+    await authedAgent
+      .post('/api/auth/login')
+      .send({ username: user.username, password: PASSWORD })
+      .expect(200);
+  });
+
+  afterAll(async () => {
+    try { await storage.deleteUser(user.id); } catch { /* ignore */ }
   });
 
   it('applies helmet security headers to application routes', async () => {
@@ -48,18 +72,53 @@ describe('Security middleware registration order', () => {
     expect(res.headers['x-content-type-options']).toBe('nosniff');
   });
 
-  it('enforces CSRF on state-changing /api routes when not bypassed', async () => {
+  it('enforces CSRF on authenticated state-changing /api routes when not bypassed', async () => {
     // Integration setup sets DISABLE_CSRF=true; unset it to exercise the real
-    // CSRF path (the suite runs under NODE_ENV=development, so CSRF is active
-    // once the bypass flag is removed).
+    // CSRF path. CSRF only applies to authenticated requests, so use the
+    // logged-in agent and send no CSRF token.
+    const prev = process.env.DISABLE_CSRF;
+    delete process.env.DISABLE_CSRF;
+    try {
+      const res = await authedAgent
+        .post('/api/teams')
+        .send({ name: 'csrf-probe' });
+      expect(res.status).toBe(403);
+      expect(String(res.body.error)).toMatch(/csrf/i);
+    } finally {
+      process.env.DISABLE_CSRF = prev;
+    }
+  });
+
+  it('does not HTML-sanitize passwords (login succeeds with special characters)', async () => {
+    const ts = Date.now();
+    const specialPassword = 'abc<def>&Ghi123!';
+    const pwUser = await storage.createUser({
+      username: `wave1pw${ts}`,
+      password: specialPassword,
+      emails: [`wave1pw${ts}@test.com`],
+      firstName: 'Pw',
+      lastName: 'Special',
+    });
+    try {
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ username: pwUser.username, password: specialPassword });
+      expect(res.status).toBe(200);
+    } finally {
+      try { await storage.deleteUser(pwUser.id); } catch { /* ignore */ }
+    }
+  });
+
+  it('skips CSRF for unauthenticated (pre-auth/token) requests', async () => {
+    // A request with no authenticated session has no CSRF surface, so it must
+    // not be blocked by CSRF (it fails auth instead, not CSRF).
     const prev = process.env.DISABLE_CSRF;
     delete process.env.DISABLE_CSRF;
     try {
       const res = await request(app)
         .post('/api/teams')
         .send({ name: 'csrf-probe' });
-      expect(res.status).toBe(403);
-      expect(String(res.body.error)).toMatch(/csrf/i);
+      expect(res.status).not.toBe(403);
     } finally {
       process.env.DISABLE_CSRF = prev;
     }

--- a/tests/integration/session-fixation.test.ts
+++ b/tests/integration/session-fixation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression test for session fixation on the username/password login.
+ *
+ * The login handler set req.session.user without first calling
+ * req.session.regenerate(), so a session ID planted before authentication
+ * survived login and could be reused to hijack the authenticated session.
+ * OAuth and invitation-acceptance already regenerate; login/register did not.
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { storage } from '../../packages/api/storage';
+import type { User } from '@shared/schema';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+const PASSWORD = 'TestPass123!';
+
+function sidFromSetCookie(setCookie: string[] | undefined): string | undefined {
+  if (!setCookie) return undefined;
+  const header = setCookie.find((c) => c.startsWith('connect.sid='));
+  if (!header) return undefined;
+  return header.split(';')[0].split('=')[1];
+}
+
+describe('Login session fixation', () => {
+  let app: express.Express;
+  let user: User;
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+
+    const ts = Date.now();
+    user = await storage.createUser({
+      username: `wave1session${ts}`,
+      password: PASSWORD,
+      emails: [`wave1session${ts}@test.com`],
+      firstName: 'Session',
+      lastName: 'Fixation',
+    });
+  });
+
+  afterAll(async () => {
+    try { await storage.deleteUser(user.id); } catch { /* ignore */ }
+  });
+
+  it('regenerates the session ID on login', async () => {
+    const agent = request.agent(app);
+
+    // Establish a pre-auth session (csrf-token endpoint writes to the session).
+    const pre = await agent.get('/api/csrf-token');
+    const sidBefore = sidFromSetCookie(pre.headers['set-cookie'] as unknown as string[]);
+    expect(sidBefore).toBeTruthy();
+
+    const login = await agent
+      .post('/api/auth/login')
+      .send({ username: user.username, password: PASSWORD })
+      .expect(200);
+    const sidAfter = sidFromSetCookie(login.headers['set-cookie'] as unknown as string[]);
+
+    expect(sidAfter).toBeTruthy();
+    expect(sidAfter).not.toBe(sidBefore);
+  });
+});

--- a/tests/setup/integration-setup.ts
+++ b/tests/setup/integration-setup.ts
@@ -15,6 +15,11 @@ process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
 process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
 process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';  // MUST match benchmark-integration.test.ts
 
+// The integration suite drives the API with supertest agents that do not fetch
+// CSRF tokens. Disable CSRF for tests via the app's non-production bypass flag.
+// This is ignored when NODE_ENV === 'production', so production stays protected.
+process.env.DISABLE_CSRF = 'true';
+
 // DATABASE_URL validation with production/staging protection
 const dbUrl = process.env.DATABASE_URL || '';
 


### PR DESCRIPTION
## Wave 1 — Security & reliability fixes

Five prioritized fixes from a full-branch security & architecture review, implemented test-first (regression test written and watched fail before each fix) and hardened after a high-effort code review.

### Fixes

| # | Severity | Fix |
|---|----------|-----|
| 1 | 🔴 Critical | **Privilege escalation via mass assignment.** `POST /api/organizations/:id/users` only required auth and passed `req.body` into `createUser`, whose whitelist includes `isSiteAdmin` — any athlete-role member could mint a site admin. Now gated to org_admin/site_admin; `isSiteAdmin` stripped and `role` clamped in the service. |
| 2 | 🔴 Critical | **Missing role gates on athlete endpoints.** `bulk-delete`/`bulk-invite` checked org membership only; `DELETE`/`PATCH status` used the self-access middleware (an athlete could delete or re-activate themselves). Added `requireAthleteManagementAccess` (no self-access branch) and the management-permission gate. |
| 4 | 🔴 Critical | **Dead security middleware.** helmet, CSRF, input sanitization and the rate limiter were registered *after* the routes, so Express never ran them. Route registration moved after the security middleware. CSRF now enforced for authenticated requests in dev/staging/prod (the web client already attaches tokens). |
| 8 | 🟠 High | **Session fixation.** Login, enhanced-auth and registration set `req.session.user` without regenerating the session. Now regenerate (preserving the CSRF secret) and explicitly save before responding. |
| 12 | 🟠 High | **No process crash handlers.** Added `unhandledRejection` (log, keep serving) and `uncaughtException` (log + graceful shutdown; hard-exit if the crash happens before shutdown is wired) handlers, extracted to a unit-tested module. |

### Code-review follow-ups (included)

The high-effort review caught real regressions from #4, all fixed here:
- **CSRF is skipped for unauthenticated requests** (mirrors `requireAuth`) so pre-auth/token flows — COPPA parent registration, resend-verification, consent links, invitation accept — are not blocked. Token endpoints are self-protected by their unguessable tokens.
- **Credential/token fields are excluded from `sanitizeInput`** — DOMPurify was truncating passwords containing HTML-special characters, breaking login.
- **`guest`/`parent` roles** are no longer silently downgraded to `athlete` by the add-user role clamp.

### ⚠️ Reviewer note — production behavior change

Item 4 activates middleware that was previously dead: **CSRF, helmet, and the general rate limiter are now live for the whole API** in dev/staging/production. The web client (`packages/web/src/lib/api.ts`) already fetches and attaches CSRF tokens, and unauthenticated flows are exempt — but please **smoke-test against staging** before this reaches production, especially: any non-browser/native API consumer, and the CSV import / OCR upload paths (`sanitizeInput` now runs on request bodies).

### Testing

- New regression tests: add-user escalation, athlete authorization (6), middleware order + CSRF (authenticated vs unauthenticated) + special-character password, session fixation, process-safety unit tests.
- Full suite green: **1139 passed, 0 failed** (203 pre-skipped); unit suite green; `tsc` clean.

### Deferred (tracked for later waves)

- Unify the duplicated org-admin authorization checks into one middleware (Wave 2, item 10).
- Remaining review items were correct as-is (the graceful-shutdown window matches existing SIGTERM behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden API security and reliability across authentication, authorization, and process handling.

New Features:
- Introduce process-level safety handlers for unhandled promise rejections and uncaught exceptions.
- Add reusable session helper utilities for secure regeneration and explicit persistence of authenticated sessions.

Bug Fixes:
- Prevent privilege escalation when adding organization users by enforcing org_admin/site_admin authorization and blocking client-supplied site-admin flags.
- Tighten athlete management authorization so only org_admin/coach (or site admins) can perform destructive and bulk management actions, removing unsafe self-access paths.
- Ensure security middleware (helmet, CSRF protection, input sanitization, and rate limiting) are registered before application routes so they apply to all API endpoints.
- Fix session fixation vulnerabilities in login and registration flows by regenerating and saving sessions before storing authenticated state.
- Exclude credential and token fields from HTML sanitization to avoid corrupting passwords and secrets during authentication.
- Allow CSRF protection to be bypassed only for unauthenticated and non-production test flows while enforcing it for authenticated state-changing API requests.

Enhancements:
- Refactor athlete access middleware into a configurable factory supporting distinct read and management access policies.
- Strengthen organization add-user role handling by clamping roles to valid organization-scoped values and preserving guest/parent roles.
- Add targeted integration and unit tests to cover security middleware behavior, session handling, and authorization edge cases.

Tests:
- Add integration suites covering athlete management authorization, organization add-user security, security middleware ordering and behavior, and session fixation prevention.
- Introduce unit tests for process-safety handlers to validate logging and graceful shutdown behavior under failures.