### PR TITLE
fix(security): Wave 2 — tenant isolation, password reset, auth hardening, COPPA, token hashing

### DIFF
--- a/migrations/0138_add_password_reset_tokens.sql
+++ b/migrations/0138_add_password_reset_tokens.sql
@@ -1,0 +1,20 @@
+-- Migration 0138: Add password_reset_tokens table
+--
+-- Backs the password-reset flow (previously stubbed with no table). The raw
+-- reset token is only ever delivered in the emailed link; only its SHA-256 hash
+-- is persisted here, so a leaked database row cannot be used to reset a
+-- password. Tokens are single-use (is_used) and expiring (expires_at).
+
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+  id           VARCHAR PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      VARCHAR NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash   TEXT NOT NULL UNIQUE,
+  is_used      BOOLEAN NOT NULL DEFAULT FALSE,
+  expires_at   TIMESTAMP NOT NULL,
+  ip_address   TEXT,
+  user_agent   TEXT,
+  created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS password_reset_tokens_token_hash_idx
+  ON password_reset_tokens (token_hash);

--- a/migrations/0138_add_password_reset_tokens_down.sql
+++ b/migrations/0138_add_password_reset_tokens_down.sql
@@ -1,0 +1,4 @@
+-- Down Migration 0138: Drop password_reset_tokens table
+--
+-- Safe to drop: the table holds only short-lived, single-use reset tokens.
+DROP TABLE IF EXISTS password_reset_tokens;

--- a/packages/api/__tests__/global-athlete-claim.test.ts
+++ b/packages/api/__tests__/global-athlete-claim.test.ts
@@ -11,6 +11,7 @@ import {
   globalAthleteClaims
 } from "@shared/schema";
 import { eq, inArray } from "drizzle-orm";
+import { hashToken } from '../lib/token-hash';
 import { GlobalAthleteService } from "../services/global-athlete-service";
 import { emailService } from "../services/email-service";
 
@@ -248,7 +249,7 @@ describe("Global Athlete Claim Features", () => {
       // Manually expire the token
       await db.update(globalAthleteClaims)
         .set({ expiresAt: new Date(Date.now() - 3600000) }) // 1 hour ago
-        .where(eq(globalAthleteClaims.token, token));
+        .where(eq(globalAthleteClaims.token, hashToken(token)));
 
       const result = await service.verifyClaim(token);
 
@@ -285,7 +286,7 @@ describe("Global Athlete Claim Features", () => {
 
       const [claim] = await db.select()
         .from(globalAthleteClaims)
-        .where(eq(globalAthleteClaims.token, token));
+        .where(eq(globalAthleteClaims.token, hashToken(token)));
 
       expect(claim.status).toBe("verified");
       expect(claim.verifiedAt).toBeDefined();
@@ -325,7 +326,7 @@ describe("Global Athlete Claim Features", () => {
       // Manually expire the claim
       await db.update(globalAthleteClaims)
         .set({ status: "expired" })
-        .where(eq(globalAthleteClaims.token, token));
+        .where(eq(globalAthleteClaims.token, hashToken(token)));
 
       const pendingClaims = await service.getPendingClaims(testUser1Id);
 
@@ -345,7 +346,7 @@ describe("Global Athlete Claim Features", () => {
 
       const [claim] = await db.select()
         .from(globalAthleteClaims)
-        .where(eq(globalAthleteClaims.token, token));
+        .where(eq(globalAthleteClaims.token, hashToken(token)));
 
       await service.cancelClaim(testUser1Id, claim.id);
 
@@ -362,7 +363,7 @@ describe("Global Athlete Claim Features", () => {
 
       const [claim] = await db.select()
         .from(globalAthleteClaims)
-        .where(eq(globalAthleteClaims.token, token));
+        .where(eq(globalAthleteClaims.token, hashToken(token)));
 
       // User2 tries to cancel user1's claim
       await expect(

--- a/packages/api/__tests__/oauth-routes.test.ts
+++ b/packages/api/__tests__/oauth-routes.test.ts
@@ -8,6 +8,7 @@ import { db } from "../db";
 import { storage } from "../storage";
 import { users, accountLinkingTokens } from "@shared/schema";
 import { eq } from "drizzle-orm";
+import { hashToken } from '../lib/token-hash';
 import crypto from "crypto";
 import type { OAuthProfile, OAuthResult } from "../services/oauth-service";
 
@@ -400,7 +401,7 @@ describe.skip("OAuth Routes", () => {
 
         await db.insert(accountLinkingTokens).values({
           userId: testAthleteId,
-          token: expiredToken,
+          token: hashToken(expiredToken),
           provider: 'google',
           providerId: `google_expired_${testSuffix}`,
           providerEmail: EXISTING_USER_EMAIL,
@@ -412,7 +413,7 @@ describe.skip("OAuth Routes", () => {
         expect(result.error).toMatch(/expired/i);
 
         // Cleanup
-        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, expiredToken));
+        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, hashToken(expiredToken)));
       });
 
       it("should reject already-used token", async () => {
@@ -422,7 +423,7 @@ describe.skip("OAuth Routes", () => {
 
         await db.insert(accountLinkingTokens).values({
           userId: testAthleteId,
-          token: usedToken,
+          token: hashToken(usedToken),
           provider: 'apple',
           providerId: `apple_used_${testSuffix}`,
           providerEmail: EXISTING_USER_EMAIL,
@@ -435,7 +436,7 @@ describe.skip("OAuth Routes", () => {
         expect(result.error).toMatch(/already.*used/i);
 
         // Cleanup
-        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, usedToken));
+        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, hashToken(usedToken)));
       });
 
       it("should redirect to login with success message after linking", () => {
@@ -455,7 +456,7 @@ describe.skip("OAuth Routes", () => {
 
         await db.insert(accountLinkingTokens).values({
           userId: testAthleteId,
-          token: oneTimeToken,
+          token: hashToken(oneTimeToken),
           provider: 'google',
           providerId: `google_onetime_${testSuffix}`,
           providerEmail: EXISTING_USER_EMAIL,
@@ -472,7 +473,7 @@ describe.skip("OAuth Routes", () => {
         expect(secondResult.error).toMatch(/already.*used/i);
 
         // Cleanup
-        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, oneTimeToken));
+        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, hashToken(oneTimeToken)));
       });
     });
 
@@ -514,7 +515,7 @@ describe.skip("OAuth Routes", () => {
         expect(linkingToken?.providerId).toBe('google_123');
         expect(linkingToken?.providerEmail).toBe('test@example.com');
 
-        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, token));
+        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, hashToken(token)));
       });
     });
   });
@@ -591,7 +592,7 @@ describe.skip("OAuth Routes", () => {
         expect(usedToken?.usedAt).toBeDefined();
         expect(usedToken?.usedAt).toBeInstanceOf(Date);
 
-        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, token));
+        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, hashToken(token)));
       });
 
       it("should prevent token reuse", async () => {
@@ -615,7 +616,7 @@ describe.skip("OAuth Routes", () => {
         const secondResult = await storage.confirmAccountLinking(token);
         expect(secondResult.success).toBe(false);
 
-        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, token));
+        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, hashToken(token)));
       });
 
       it("should enforce token expiration", async () => {
@@ -635,7 +636,7 @@ describe.skip("OAuth Routes", () => {
         expect(result.success).toBe(false);
         expect(result.error).toMatch(/expired/i);
 
-        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, token));
+        await db.delete(accountLinkingTokens).where(eq(accountLinkingTokens.token, hashToken(token)));
       });
     });
 

--- a/packages/api/__tests__/oauth-service.test.ts
+++ b/packages/api/__tests__/oauth-service.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach, vi, beforeEach } 
 import { db } from "../db";
 import { users, accountLinkingTokens } from "@shared/schema";
 import { eq, and } from "drizzle-orm";
+import { hashToken } from '../lib/token-hash';
 import { OAuthService, type OAuthProfile } from "../services/oauth-service";
 import { EmailService } from "../services/email-service";
 
@@ -406,7 +407,7 @@ describe.skip("OAuth Service", () => {
       validToken = "valid_token_" + Math.random().toString(36).substring(2);
       await db.insert(accountLinkingTokens).values({
         userId: testUserId,
-        token: validToken,
+        token: hashToken(validToken),
         provider: "google",
         providerId: "test_google_id",
         providerEmail: `linktest${testSuffix}@example.com`,
@@ -436,7 +437,7 @@ describe.skip("OAuth Service", () => {
       // Verify token was marked as used
       const tokens = await db.select()
         .from(accountLinkingTokens)
-        .where(eq(accountLinkingTokens.token, validToken));
+        .where(eq(accountLinkingTokens.token, hashToken(validToken)));
 
       expect(tokens[0].usedAt).toBeDefined();
     });
@@ -448,7 +449,7 @@ describe.skip("OAuth Service", () => {
           provider: "apple",
           providerId: "test_apple_id",
         })
-        .where(eq(accountLinkingTokens.token, validToken));
+        .where(eq(accountLinkingTokens.token, hashToken(validToken)));
 
       const result = await oauthService.confirmAccountLinking(validToken);
 
@@ -465,7 +466,7 @@ describe.skip("OAuth Service", () => {
       const expiredToken = "expired_token_" + Math.random().toString(36).substring(2);
       await db.insert(accountLinkingTokens).values({
         userId: testUserId,
-        token: expiredToken,
+        token: hashToken(expiredToken),
         provider: "google",
         providerId: "test_google_id_2",
         providerEmail: `linktest${testSuffix}@example.com`,
@@ -486,7 +487,7 @@ describe.skip("OAuth Service", () => {
       // Mark token as used
       await db.update(accountLinkingTokens)
         .set({ usedAt: new Date() })
-        .where(eq(accountLinkingTokens.token, validToken));
+        .where(eq(accountLinkingTokens.token, hashToken(validToken)));
 
       const result = await oauthService.confirmAccountLinking(validToken);
 

--- a/packages/api/auth/password-reset.ts
+++ b/packages/api/auth/password-reset.ts
@@ -212,9 +212,15 @@ export class PasswordResetService {
         severity: 'info',
       });
 
-      // The raw token is intentionally never logged (only its hash is stored).
-      // Email delivery for this path is handled by the caller.
-      void token;
+      // Send the verification link. The raw token is only ever transmitted here
+      // (never logged) — the database holds only its hash.
+      const user = await storage.getUser(userId);
+      const baseUrl = process.env.APP_URL || process.env.BASE_URL || '';
+      const verificationLink = `${baseUrl}/verify-email?token=${token}`;
+      await emailService.sendEmailVerification(email, {
+        userName: user?.firstName || 'there',
+        verificationLink,
+      });
 
       return {
         success: true,

--- a/packages/api/auth/password-reset.ts
+++ b/packages/api/auth/password-reset.ts
@@ -212,17 +212,13 @@ export class PasswordResetService {
         severity: 'info',
       });
 
-      // TODO: Send verification email
-      // await emailService.sendEmailVerification(email, {
-      //   verificationUrl: `${process.env.BASE_URL}/verify-email?token=${token}`,
-      //   expiresIn: '24 hours'
-      // });
+      // The raw token is intentionally never logged (only its hash is stored).
+      // Email delivery for this path is handled by the caller.
+      void token;
 
-      console.log(`Email verification requested for ${email}. Token: ${token}`);
-
-      return { 
-        success: true, 
-        message: 'Verification email sent. Please check your inbox.' 
+      return {
+        success: true,
+        message: 'Verification email sent. Please check your inbox.'
       };
     } catch (error) {
       console.error('Email verification request error:', error);

--- a/packages/api/auth/password-reset.ts
+++ b/packages/api/auth/password-reset.ts
@@ -75,7 +75,7 @@ export class PasswordResetService {
 
       // Send the reset link. The raw token is only ever transmitted here (never
       // logged or stored) — the database holds only its hash.
-      const baseUrl = process.env.APP_URL || process.env.BASE_URL || '';
+      const baseUrl = process.env.APP_URL || process.env.BASE_URL || 'https://athletemetrics.app';
       const resetLink = `${baseUrl}/reset-password?token=${token}`;
       const recipient = user.emails?.[0];
       if (recipient) {
@@ -215,7 +215,7 @@ export class PasswordResetService {
       // Send the verification link. The raw token is only ever transmitted here
       // (never logged) — the database holds only its hash.
       const user = await storage.getUser(userId);
-      const baseUrl = process.env.APP_URL || process.env.BASE_URL || '';
+      const baseUrl = process.env.APP_URL || process.env.BASE_URL || 'https://athletemetrics.app';
       const verificationLink = `${baseUrl}/verify-email?token=${token}`;
       await emailService.sendEmailVerification(email, {
         userName: user?.firstName || 'there',

--- a/packages/api/auth/password-reset.ts
+++ b/packages/api/auth/password-reset.ts
@@ -5,6 +5,7 @@ import { passwordSchema } from '@shared/password-validation';
 import bcrypt from 'bcrypt';
 import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
 import { globalAthleteService } from '../services/global-athlete-service';
+import { emailService } from '../services/email-service';
 
 export class PasswordResetService {
   private static readonly RESET_TOKEN_EXPIRY = 60 * 60 * 1000; // 1 hour
@@ -72,16 +73,19 @@ export class PasswordResetService {
         severity: 'info',
       });
 
-      // TODO: Send email with reset link
-      // await emailService.sendPasswordReset(user.emails[0], {
-      //   resetUrl: `${process.env.BASE_URL}/reset-password?token=${token}`,
-      //   firstName: user.firstName,
-      //   expiresIn: '1 hour'
-      // });
+      // Send the reset link. The raw token is only ever transmitted here (never
+      // logged or stored) — the database holds only its hash.
+      const baseUrl = process.env.APP_URL || process.env.BASE_URL || '';
+      const resetLink = `${baseUrl}/reset-password?token=${token}`;
+      const recipient = user.emails?.[0];
+      if (recipient) {
+        await emailService.sendPasswordReset(recipient, {
+          userName: user.firstName || 'there',
+          resetLink,
+        });
+      }
 
-      console.log(`Password reset requested for ${email}. Token: ${token}`);
-
-      return { 
+      return {
         success: true, 
         message: 'If an account with that email exists, a password reset link has been sent.' 
       };
@@ -107,7 +111,7 @@ export class PasswordResetService {
         return { valid: false };
       }
 
-      if (resetToken.isUsed === 'true') {
+      if (resetToken.isUsed === true) {
         return { valid: false, used: true };
       }
 

--- a/packages/api/lib/token-hash.ts
+++ b/packages/api/lib/token-hash.ts
@@ -1,0 +1,14 @@
+import crypto from "crypto";
+
+/**
+ * Deterministically hash a bearer token for storage/lookup.
+ *
+ * Single-use, high-entropy tokens (invitations, email verification, OAuth
+ * account linking, global-athlete claims) are stored only as their SHA-256 hash,
+ * so a leaked database row cannot be used as a working token. Lookups hash the
+ * value from the URL and compare hashes. Because the hash is deterministic,
+ * unique-index and equality-lookup semantics are preserved.
+ */
+export function hashToken(rawToken: string): string {
+  return crypto.createHash("sha256").update(rawToken).digest("hex");
+}

--- a/packages/api/routes/athlete-routes.ts
+++ b/packages/api/routes/athlete-routes.ts
@@ -384,26 +384,34 @@ export function registerAthleteRoutes(app: Express) {
       // coach can't redirect that link (and notification) to an arbitrary
       // address without admin approval. Checked BEFORE any write so a denied
       // coach can't get parentEmail persisted via the main update below.
+      // Organization that authorizes and scopes the parent-email change. It is
+      // captured here so the parentAthleteLinks row (created below) is attributed
+      // to the org the requester actually administers, not an arbitrary
+      // (alphabetically-first) org the athlete happens to also belong to.
+      let parentLinkOrgId: string | null = null;
       if (validatedData.parentEmail !== undefined) {
         const currentUser = req.session.user!;
-        if (!currentUser.isSiteAdmin) {
+        const athleteOrgs = await storage.getUserOrganizations(athleteId);
+        if (currentUser.isSiteAdmin) {
+          // A site admin has no requester-org context; fall back to the
+          // athlete's first organization for the link scope.
+          parentLinkOrgId = athleteOrgs[0]?.organizationId ?? null;
+        } else {
           // Must be org_admin specifically in an org shared with the athlete —
           // org_admin status in an unrelated org must not combine with a
           // shared-org coach role (already required by
           // requireAthleteAccessPermission) to authorize this.
-          const [userOrgs, athleteOrgs] = await Promise.all([
-            storage.getUserOrganizations(currentUser.id),
-            storage.getUserOrganizations(athleteId),
-          ]);
+          const userOrgs = await storage.getUserOrganizations(currentUser.id);
           const athleteOrgIds = new Set(athleteOrgs.map((org) => org.organizationId));
-          const isOrgAdminForAthlete = userOrgs.some(
+          const authorizingOrg = userOrgs.find(
             (org) => org.role === 'org_admin' && athleteOrgIds.has(org.organizationId)
           );
-          if (!isOrgAdminForAthlete) {
+          if (!authorizingOrg) {
             return res.status(403).json({
               message: "Organization admin or site admin role required to update parent email",
             });
           }
+          parentLinkOrgId = authorizingOrg.organizationId;
         }
       }
 
@@ -417,15 +425,13 @@ export function registerAthleteRoutes(app: Express) {
         // updated above, or was already present from a previous request).
         const freshAthlete = await storage.getUser(athleteId);
         if (freshAthlete) {
-          // Determine the organization the athlete belongs to (for the link row).
-          const athleteOrgs = await storage.getUserOrganizations(athleteId);
-          const orgId = athleteOrgs[0]?.organizationId ?? null;
-
+          // Use the authorizing organization captured during the permission
+          // check above, not an arbitrary org the athlete belongs to.
           await handleParentEmailUpdate(
             athleteId,
             validatedData.parentEmail,
             freshAthlete,
-            orgId,
+            parentLinkOrgId,
           );
         }
       }

--- a/packages/api/routes/auth-routes.ts
+++ b/packages/api/routes/auth-routes.ts
@@ -12,6 +12,7 @@ import { COPPA_ACTIONS } from "@shared/coppa-utils";
 import { storage } from "../storage";
 import { generateParentEmailToken } from "../services/coppa-email-token-store";
 import { regenerateSession, saveSession } from "../lib/session-helpers";
+import { PasswordResetService } from "../auth/password-reset";
 // Session types are loaded globally
 
 const authService = new AuthService();
@@ -312,5 +313,53 @@ export function registerAuthRoutes(app: Express) {
       } : null,
       originalUser: req.session.originalUser || null
     });
+  });
+
+  // ---- Password reset (pre-authentication) ----
+  // Mounted at /api/auth/* to match the web client. CSRF is skipped for these
+  // unauthenticated requests. Responses never reveal whether an account exists.
+
+  app.post("/api/auth/forgot-password", authLimiter, async (req, res) => {
+    try {
+      const { email } = req.body;
+      if (!email || typeof email !== 'string') {
+        return res.status(400).json({ success: false, message: "Email is required" });
+      }
+      const ipAddress = req.ip || '0.0.0.0';
+      const result = await PasswordResetService.requestPasswordReset(email, ipAddress, req.get('User-Agent'));
+      return res.status(200).json(result);
+    } catch (error) {
+      console.error("Forgot-password error:", error);
+      return res.status(500).json({ success: false, message: "Failed to process request" });
+    }
+  });
+
+  app.post("/api/auth/validate-reset-token", authLimiter, async (req, res) => {
+    try {
+      const { token } = req.body;
+      if (!token || typeof token !== 'string') {
+        return res.status(400).json({ valid: false, message: "Token is required" });
+      }
+      const validation = await PasswordResetService.validateResetToken(token);
+      return res.status(200).json(validation);
+    } catch (error) {
+      console.error("Validate-reset-token error:", error);
+      return res.status(500).json({ valid: false, message: "Failed to validate token" });
+    }
+  });
+
+  app.post("/api/auth/reset-password", authLimiter, async (req, res) => {
+    try {
+      const { token, newPassword } = req.body;
+      if (!token || !newPassword) {
+        return res.status(400).json({ success: false, message: "Token and new password are required" });
+      }
+      const ipAddress = req.ip || '0.0.0.0';
+      const result = await PasswordResetService.resetPassword(token, newPassword, ipAddress, req.get('User-Agent'));
+      return res.status(200).json(result);
+    } catch (error) {
+      console.error("Reset-password error:", error);
+      return res.status(500).json({ success: false, message: "Failed to reset password" });
+    }
   });
 }

--- a/packages/api/routes/auth-routes.ts
+++ b/packages/api/routes/auth-routes.ts
@@ -33,11 +33,29 @@ export function registerAuthRoutes(app: Express) {
    */
   app.post("/api/auth/login", authLimiter, async (req, res) => {
     try {
-      const { username, password } = req.body;
+      const { username, password, mfaToken } = req.body;
 
-      const result = await authService.login({ username, password });
+      const result = await authService.login({
+        username,
+        password,
+        mfaToken,
+        ipAddress: req.ip || '0.0.0.0',
+        userAgent: req.get('User-Agent'),
+      });
 
       if (!result.success) {
+        // MFA challenge: not an error — the client should prompt for a code.
+        if (result.requiresMFA) {
+          return res.status(200).json({ requiresMFA: true, message: "Enter your authentication code" });
+        }
+        // Locked account: 423 Locked so the client can show a distinct message.
+        if (result.accountLocked) {
+          return res.status(423).json({
+            message: result.error,
+            accountLocked: true,
+            lockUntil: result.lockUntil,
+          });
+        }
         return res.status(401).json({ message: result.error });
       }
 

--- a/packages/api/routes/enhanced-auth.ts
+++ b/packages/api/routes/enhanced-auth.ts
@@ -6,12 +6,26 @@ import { PasswordResetService } from '../auth/password-reset';
 import { RoleManager } from '../auth/role-manager';
 import { requirePermission } from '../permissions/index';
 import { regenerateSession, saveSession } from '../lib/session-helpers';
+import rateLimit from 'express-rate-limit';
+import { shouldSkipRateLimiting } from '../utils/rate-limit-utils';
 import { z } from 'zod';
+
+// Per-IP throttle for the sensitive enhanced-auth endpoints. These previously
+// had no rate limiting, allowing credential stuffing / reset-token probing that
+// bypassed the protections on the primary /api/auth/* flow.
+const enhancedAuthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 5,
+  message: { success: false, message: 'Too many attempts, please try again in 15 minutes' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) => shouldSkipRateLimiting(req, 'auth'),
+});
 
 const router = Router();
 
 // Enhanced login with MFA support, account lockout, and security logging
-router.post('/login', async (req: Request, res: Response) => {
+router.post('/login', enhancedAuthLimiter, async (req: Request, res: Response) => {
   try {
     const { username, password, mfaToken, rememberMe = false } = req.body;
     const ipAddress = req.ip || req.connection.remoteAddress || '0.0.0.0';
@@ -194,7 +208,7 @@ router.post('/logout', async (req: Request, res: Response) => {
 });
 
 // Password reset request
-router.post('/forgot-password', async (req: Request, res: Response) => {
+router.post('/forgot-password', enhancedAuthLimiter, async (req: Request, res: Response) => {
   try {
     const { email } = req.body;
     const ipAddress = req.ip || req.connection.remoteAddress || '0.0.0.0';
@@ -220,7 +234,7 @@ router.post('/forgot-password', async (req: Request, res: Response) => {
 });
 
 // Validate password reset token
-router.post('/validate-reset-token', async (req: Request, res: Response) => {
+router.post('/validate-reset-token', enhancedAuthLimiter, async (req: Request, res: Response) => {
   try {
     const { token } = req.body;
 
@@ -244,7 +258,7 @@ router.post('/validate-reset-token', async (req: Request, res: Response) => {
 });
 
 // Complete password reset
-router.post('/reset-password', async (req: Request, res: Response) => {
+router.post('/reset-password', enhancedAuthLimiter, async (req: Request, res: Response) => {
   try {
     const { token, newPassword } = req.body;
     const ipAddress = req.ip || req.connection.remoteAddress || '0.0.0.0';
@@ -270,7 +284,7 @@ router.post('/reset-password', async (req: Request, res: Response) => {
 });
 
 // Change password (authenticated users)
-router.post('/change-password', async (req: Request, res: Response) => {
+router.post('/change-password', enhancedAuthLimiter, async (req: Request, res: Response) => {
   try {
     const user = req.session?.user;
     if (!user) {

--- a/packages/api/routes/enhanced-auth.ts
+++ b/packages/api/routes/enhanced-auth.ts
@@ -22,6 +22,18 @@ const enhancedAuthLimiter = rateLimit({
   skip: (req) => shouldSkipRateLimiting(req, 'auth'),
 });
 
+// Looser limiter for /change-password: it's an authenticated, post-login action
+// (not a credential-stuffing/token-probing target), so it shouldn't share the
+// 5/15min budget with unauthenticated login and reset attempts.
+const changePasswordLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  message: { success: false, message: 'Too many attempts, please try again in 15 minutes' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req) => shouldSkipRateLimiting(req, 'auth'),
+});
+
 const router = Router();
 
 // Enhanced login with MFA support, account lockout, and security logging
@@ -284,7 +296,7 @@ router.post('/reset-password', enhancedAuthLimiter, async (req: Request, res: Re
 });
 
 // Change password (authenticated users)
-router.post('/change-password', enhancedAuthLimiter, async (req: Request, res: Response) => {
+router.post('/change-password', changePasswordLimiter, async (req: Request, res: Response) => {
   try {
     const user = req.session?.user;
     if (!user) {

--- a/packages/api/routes/import-export-routes.ts
+++ b/packages/api/routes/import-export-routes.ts
@@ -1733,10 +1733,10 @@ export function registerImportExportRoutes(app: Express) {
       // Determine the effective organization based on permissions so a caller
       // cannot export teams from organizations they do not belong to.
       const { organizationId: requestedOrgId } = req.query;
-      let effectiveOrganizationId: string | undefined;
+      let teams;
       if (currentUser.isSiteAdmin) {
         // Site admins may export a specific org, or all when none is requested.
-        effectiveOrganizationId = requestedOrgId as string | undefined;
+        teams = await storage.getTeams(requestedOrgId as string | undefined);
       } else {
         const userOrgs = await storage.getUserOrganizations(currentUser.id);
         if (requestedOrgId) {
@@ -1746,20 +1746,18 @@ export function registerImportExportRoutes(app: Express) {
               message: "You do not have access to export teams from this organization"
             });
           }
-          effectiveOrganizationId = requestedOrgId as string;
+          teams = await storage.getTeams(requestedOrgId as string);
         } else {
-          effectiveOrganizationId = userOrgs[0]?.organizationId;
-          // A non-site-admin with no organization must not receive every team.
-          if (!effectiveOrganizationId) {
+          // Include teams from ALL of the caller's organizations, not just one.
+          const orgIds = new Set(userOrgs.map(uo => uo.organizationId));
+          if (orgIds.size === 0) {
             res.setHeader('Content-Type', 'text/csv');
             res.setHeader('Content-Disposition', 'attachment; filename="teams.csv"');
             return res.send(csvHeaders.join(','));
           }
+          teams = (await storage.getTeams()).filter(t => t.organizationId && orgIds.has(t.organizationId));
         }
       }
-
-      // Get teams scoped to the effective organization
-      const teams = await storage.getTeams(effectiveOrganizationId);
 
       const csvRows = teams.map(team => {
         return [

--- a/packages/api/routes/import-export-routes.ts
+++ b/packages/api/routes/import-export-routes.ts
@@ -29,6 +29,24 @@ import { DerivedMetricCalculator } from "../services/derived-metric-calculator";
 import { db } from "../db";
 
 /**
+ * Tenant-isolation guard for imports. A client-supplied organizationId must be
+ * one the caller actually belongs to (site admins may target any organization).
+ * Returns an error message when access is denied, or null when allowed. Callers
+ * must run this BEFORE any read/preview or write scoped to that organization.
+ */
+async function checkImportOrgAccess(
+  currentUser: { id: string; isSiteAdmin?: boolean } | undefined,
+  organizationId: string | undefined,
+): Promise<string | null> {
+  if (!organizationId) return null;
+  if (!currentUser?.id) return "User not authenticated";
+  if (currentUser.isSiteAdmin) return null;
+  const userOrgs = await storage.getUserOrganizations(currentUser.id);
+  const allowed = userOrgs.some((o) => o.organizationId === organizationId);
+  return allowed ? null : "You do not have access to import into this organization";
+}
+
+/**
  * After a weight or height measurement is created, sync the value to the user's profile.
  * Uses the measurement's unit to convert to the profile's storage format (lbs / inches).
  */
@@ -250,6 +268,13 @@ export function registerImportExportRoutes(app: Express) {
 
       const measurementMode = options.measurementMode || 'match_only';
       const teamHandling = options.teamHandling || 'auto_create_confirm';
+
+      // Tenant isolation: reject a client-supplied organizationId the caller
+      // does not belong to before any org-scoped read or write.
+      const photoOrgAccessError = await checkImportOrgAccess(currentUser, options.organizationId);
+      if (photoOrgAccessError) {
+        return res.status(403).json({ message: photoOrgAccessError });
+      }
 
       // Debug logging removed for production: Processing OCR for file
 
@@ -545,6 +570,13 @@ export function registerImportExportRoutes(app: Express) {
       } catch (error) {
         console.error('JSON parse error for CSV import options:', error);
         return res.status(400).json({ message: "Invalid options JSON format" });
+      }
+
+      // Tenant isolation: reject a client-supplied organizationId the caller
+      // does not belong to before any org-scoped read/preview or write.
+      const importOrgAccessError = await checkImportOrgAccess(req.session.user, options.organizationId);
+      if (importOrgAccessError) {
+        return res.status(403).json({ message: importOrgAccessError });
       }
 
       const results: any[] = [];
@@ -1025,8 +1057,20 @@ export function registerImportExportRoutes(app: Express) {
         // Load validation context for metric validation
         const validationContext = await importValidationService.loadValidationContext();
 
-        // PERFORMANCE: Load teams once before the loop to avoid N+1 queries
-        const allTeamsForMeasurements = await storage.getTeams();
+        // PERFORMANCE: Load teams once before the loop to avoid N+1 queries.
+        // Tenant isolation: a non-site-admin may only match teams within their
+        // own organizations, so a team name cannot resolve to another tenant's
+        // team (which would attribute measurements to the wrong organization).
+        const measurementImportUser = req.session.user;
+        let allTeamsForMeasurements = await storage.getTeams();
+        if (!measurementImportUser?.isSiteAdmin) {
+          const callerOrgIds = new Set(
+            (await storage.getUserOrganizations(measurementImportUser!.id)).map((o) => o.organizationId)
+          );
+          allTeamsForMeasurements = allTeamsForMeasurements.filter(
+            (t) => t.organization?.id && callerOrgIds.has(t.organization.id)
+          );
+        }
 
         // Process measurements import
         for (let i = 0; i < csvData.length; i++) {
@@ -1681,13 +1725,41 @@ export function registerImportExportRoutes(app: Express) {
         return res.status(401).json({ message: "User not authenticated" });
       }
 
-      // Get all teams with comprehensive data
-      const teams = await storage.getTeams();
-
       // Transform to CSV format with all database fields
       const csvHeaders = [
         'id', 'name', 'organizationId', 'organizationName', 'level', 'notes', 'createdAt'
       ];
+
+      // Determine the effective organization based on permissions so a caller
+      // cannot export teams from organizations they do not belong to.
+      const { organizationId: requestedOrgId } = req.query;
+      let effectiveOrganizationId: string | undefined;
+      if (currentUser.isSiteAdmin) {
+        // Site admins may export a specific org, or all when none is requested.
+        effectiveOrganizationId = requestedOrgId as string | undefined;
+      } else {
+        const userOrgs = await storage.getUserOrganizations(currentUser.id);
+        if (requestedOrgId) {
+          const hasAccess = userOrgs.some(uo => uo.organizationId === requestedOrgId);
+          if (!hasAccess) {
+            return res.status(403).json({
+              message: "You do not have access to export teams from this organization"
+            });
+          }
+          effectiveOrganizationId = requestedOrgId as string;
+        } else {
+          effectiveOrganizationId = userOrgs[0]?.organizationId;
+          // A non-site-admin with no organization must not receive every team.
+          if (!effectiveOrganizationId) {
+            res.setHeader('Content-Type', 'text/csv');
+            res.setHeader('Content-Disposition', 'attachment; filename="teams.csv"');
+            return res.send(csvHeaders.join(','));
+          }
+        }
+      }
+
+      // Get teams scoped to the effective organization
+      const teams = await storage.getTeams(effectiveOrganizationId);
 
       const csvRows = teams.map(team => {
         return [

--- a/packages/api/routes/import-export-routes.ts
+++ b/packages/api/routes/import-export-routes.ts
@@ -1062,10 +1062,13 @@ export function registerImportExportRoutes(app: Express) {
         // own organizations, so a team name cannot resolve to another tenant's
         // team (which would attribute measurements to the wrong organization).
         const measurementImportUser = req.session.user;
+        if (!measurementImportUser?.id) {
+          return res.status(401).json({ message: "User not authenticated" });
+        }
         let allTeamsForMeasurements = await storage.getTeams();
-        if (!measurementImportUser?.isSiteAdmin) {
+        if (!measurementImportUser.isSiteAdmin) {
           const callerOrgIds = new Set(
-            (await storage.getUserOrganizations(measurementImportUser!.id)).map((o) => o.organizationId)
+            (await storage.getUserOrganizations(measurementImportUser.id)).map((o) => o.organizationId)
           );
           allTeamsForMeasurements = allTeamsForMeasurements.filter(
             (t) => t.organization?.id && callerOrgIds.has(t.organization.id)

--- a/packages/api/routes/import-export-routes.ts
+++ b/packages/api/routes/import-export-routes.ts
@@ -1732,11 +1732,15 @@ export function registerImportExportRoutes(app: Express) {
 
       // Determine the effective organization based on permissions so a caller
       // cannot export teams from organizations they do not belong to.
-      const { organizationId: requestedOrgId } = req.query;
+      // Coerce to a single string: a repeated query param (?organizationId=a&organizationId=b)
+      // arrives as an array; treat anything non-string as "no org requested" rather
+      // than passing an array into the org filter and bypassing the access check.
+      const rawRequestedOrgId = req.query.organizationId;
+      const requestedOrgId = typeof rawRequestedOrgId === 'string' ? rawRequestedOrgId : undefined;
       let teams;
       if (currentUser.isSiteAdmin) {
         // Site admins may export a specific org, or all when none is requested.
-        teams = await storage.getTeams(requestedOrgId as string | undefined);
+        teams = await storage.getTeams(requestedOrgId);
       } else {
         const userOrgs = await storage.getUserOrganizations(currentUser.id);
         if (requestedOrgId) {
@@ -1746,7 +1750,7 @@ export function registerImportExportRoutes(app: Express) {
               message: "You do not have access to export teams from this organization"
             });
           }
-          teams = await storage.getTeams(requestedOrgId as string);
+          teams = await storage.getTeams(requestedOrgId);
         } else {
           // Include teams from ALL of the caller's organizations, not just one.
           const orgIds = new Set(userOrgs.map(uo => uo.organizationId));

--- a/packages/api/routes/invitation-routes.ts
+++ b/packages/api/routes/invitation-routes.ts
@@ -23,6 +23,8 @@ import {
 } from "@shared/legal-acceptance";
 import { db } from "../db";
 import { parentAthleteLinks } from "@shared/schema/tables/coppa";
+import crypto from "crypto";
+import { hashToken } from "../lib/token-hash";
 
 // Rate limiting for invitation endpoints
 const invitationLimiter = rateLimit({
@@ -463,17 +465,27 @@ export function registerInvitationRoutes(app: Express) {
         return res.status(400).json({ message: "Invitation has been cancelled" });
       }
 
+      // Rotate the token on resend: the stored token is only a hash and cannot
+      // be reversed to build a working link, so issue a fresh token, store its
+      // hash, and email the raw value. (This invalidates any earlier link.)
+      const newRawToken = crypto.randomUUID();
+
       // Extend expiration regardless of current state (atomic update)
       // Validate and clamp expiry days between 1 and 90 days
       const expiryDays = Math.max(1, Math.min(90, parseInt(process.env.INVITATION_EXPIRY_DAYS || '7', 10)));
       const newExpiration = new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000);
       await storage.updateInvitation(invitationId, {
+        token: hashToken(newRawToken),
         expiresAt: newExpiration,
         status: 'pending'
       });
 
-      // Send invitation email using shared helper
-      const emailSent = await sendInvitationEmailWithTracking(invitation, userId, req);
+      // Send invitation email using shared helper, with the raw token for the link.
+      const emailSent = await sendInvitationEmailWithTracking(
+        { ...invitation, token: newRawToken },
+        userId,
+        req,
+      );
 
       // Audit log
       await storage.createAuditLog({

--- a/packages/api/services/auth-service.ts
+++ b/packages/api/services/auth-service.ts
@@ -10,16 +10,23 @@ import { INVITATION_PENDING_PASSWORD } from "@shared/schema";
 import { db } from "../db";
 import { parentAthleteLinks } from "@shared/schema/tables/coppa";
 import { eq, and } from "drizzle-orm";
+import { AuthSecurity } from "../auth/security";
 
 export interface LoginCredentials {
   username: string;
   password: string;
+  mfaToken?: string;
+  ipAddress?: string;
+  userAgent?: string;
 }
 
 export interface AuthResult {
   success: boolean;
   user?: User;
   error?: string;
+  requiresMFA?: boolean;
+  accountLocked?: boolean;
+  lockUntil?: Date;
 }
 
 export class AuthService extends BaseService {
@@ -28,7 +35,7 @@ export class AuthService extends BaseService {
    */
   async login(credentials: LoginCredentials): Promise<AuthResult> {
     try {
-      const { username, password } = credentials;
+      const { username, password, mfaToken, ipAddress = '0.0.0.0', userAgent } = credentials;
 
       if (!username || !password) {
         return { success: false, error: "Username and password are required" };
@@ -49,6 +56,19 @@ export class AuthService extends BaseService {
         return { success: false, error: "Your account has been deactivated. Please contact your administrator." };
       }
 
+      // Account lockout: block probing an account that has been locked by
+      // repeated failed attempts (brute-force / credential-stuffing protection).
+      const accountEmail = user.emails?.[0] ?? username;
+      const lock = await AuthSecurity.checkAccountLock(accountEmail);
+      if (lock.isLocked) {
+        return {
+          success: false,
+          accountLocked: true,
+          lockUntil: lock.lockUntil,
+          error: "Account temporarily locked due to too many failed attempts. Please try again later.",
+        };
+      }
+
       // Handle invitation pending state
       if (user.password === INVITATION_PENDING_PASSWORD) {
         return { success: false, error: "Please complete your registration first" };
@@ -66,7 +86,20 @@ export class AuthService extends BaseService {
       // Verify password
       const isValidPassword = await bcrypt.compare(password, user.password);
       if (!isValidPassword) {
+        await AuthSecurity.recordFailedLogin(accountEmail, ipAddress, userAgent);
         return { success: false, error: "Invalid credentials" };
+      }
+
+      // MFA: if enabled, a valid TOTP/backup code is required to complete login.
+      if (user.mfaEnabled === true) {
+        if (!mfaToken) {
+          return { success: false, requiresMFA: true, error: "Authentication code required" };
+        }
+        const mfaValid = !!user.mfaSecret && AuthSecurity.verifyMFAToken(user.mfaSecret, mfaToken);
+        if (!mfaValid) {
+          await AuthSecurity.recordFailedLogin(accountEmail, ipAddress, userAgent);
+          return { success: false, error: "Invalid authentication code" };
+        }
       }
 
       // Check organization status for non-site-admin users
@@ -104,6 +137,9 @@ export class AuthService extends BaseService {
           };
         }
       }
+
+      // Reset failed-attempt counter and record the successful login.
+      await AuthSecurity.recordSuccessfulLogin(user.id, ipAddress, userAgent);
 
       return { success: true, user };
     } catch (error) {

--- a/packages/api/services/global-athlete-service.ts
+++ b/packages/api/services/global-athlete-service.ts
@@ -10,6 +10,7 @@ import {
   type GlobalAthlete, type UserGlobalAthleteLink, type GlobalAthleteClaim
 } from "@shared/schema";
 import crypto from "crypto";
+import { hashToken } from "../lib/token-hash";
 import { eq, and, inArray, desc, ne, isNull, isNotNull, count, sql, ilike, or } from "drizzle-orm";
 import { BaseService } from "./base-service";
 import { emailService } from "./email-service";
@@ -1007,7 +1008,7 @@ export class GlobalAthleteService extends BaseService {
     await db.insert(globalAthleteClaims).values({
       globalAthleteId: link.globalAthleteId,
       claimedEmail: emailToClaim,
-      token,
+      token: hashToken(token), // Store only the hash; the raw token is emailed
       status: "pending",
       expiresAt,
     });
@@ -1044,7 +1045,7 @@ export class GlobalAthleteService extends BaseService {
     // Find the claim by token
     const [claim] = await db.select()
       .from(globalAthleteClaims)
-      .where(eq(globalAthleteClaims.token, token));
+      .where(eq(globalAthleteClaims.token, hashToken(token)));
 
     if (!claim) {
       return { success: false, message: invalidTokenMessage };

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -1,5 +1,5 @@
 import {
-  organizations, teams, users, measurements, userOrganizations, userTeams, invitations, auditLogs, emailVerificationTokens, accountLinkingTokens, athleteProfiles,
+  organizations, teams, users, measurements, userOrganizations, userTeams, invitations, auditLogs, emailVerificationTokens, accountLinkingTokens, passwordResetTokens, athleteProfiles,
   siteMetrics, organizationMetrics,
   siteBenchmarks, customBenchmarks, organizationBenchmarks,
   siteSettings, reports,
@@ -4061,18 +4061,33 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createPasswordResetToken(token: any): Promise<void> {
-    // Would need passwordResetTokens table implementation
-    console.log('Creating password reset token for user:', token.userId);
+    // Store only the SHA-256 hash — the raw token lives solely in the emailed link.
+    const tokenHash = crypto.createHash('sha256').update(token.token).digest('hex');
+    await db.insert(passwordResetTokens).values({
+      userId: token.userId,
+      tokenHash,
+      expiresAt: token.expiresAt,
+      ipAddress: token.ipAddress ?? null,
+      userAgent: token.userAgent ?? null,
+    });
   }
 
   async findPasswordResetToken(token: string): Promise<any> {
-    // Would need passwordResetTokens table implementation
-    return null;
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const [row] = await db
+      .select()
+      .from(passwordResetTokens)
+      .where(eq(passwordResetTokens.tokenHash, tokenHash))
+      .limit(1);
+    return row ?? null;
   }
 
   async markPasswordResetTokenUsed(token: string): Promise<void> {
-    // Would need passwordResetTokens table implementation
-    console.log('Marking password reset token as used:', token);
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    await db
+      .update(passwordResetTokens)
+      .set({ isUsed: true })
+      .where(eq(passwordResetTokens.tokenHash, tokenHash));
   }
 
   async updateUserPassword(userId: string, hashedPassword: string): Promise<void> {

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -37,6 +37,7 @@ import { wellnessRepository, type WellnessTrend as RepoWellnessTrend } from "./r
 import { eq, desc, asc, and, gte, lte, gt, inArray, sql, arrayContains, or, isNull, isNotNull, exists, ne, SQL } from "drizzle-orm";
 import bcrypt from "bcrypt";
 import crypto from "crypto";
+import { hashToken } from "./lib/token-hash";
 import { BCRYPT_SALT_ROUNDS } from "@shared/constants";
 import { getPgErrorCode, PG_UNIQUE_VIOLATION } from "./lib/pg-error";
 
@@ -517,14 +518,15 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createAccountLinkingToken(data: any): Promise<void> {
-    await db.insert(accountLinkingTokens).values(data);
+    // Store only the hash — the raw token lives solely in the emailed link.
+    await db.insert(accountLinkingTokens).values({ ...data, token: hashToken(data.token) });
   }
 
   async getAccountLinkingToken(token: string): Promise<any | null> {
     const [linkingToken] = await db
       .select()
       .from(accountLinkingTokens)
-      .where(eq(accountLinkingTokens.token, token))
+      .where(eq(accountLinkingTokens.token, hashToken(token)))
       .limit(1);
     return linkingToken || null;
   }
@@ -533,14 +535,14 @@ export class DatabaseStorage implements IStorage {
     await db
       .update(accountLinkingTokens)
       .set({ usedAt: new Date() })
-      .where(eq(accountLinkingTokens.token, token));
+      .where(eq(accountLinkingTokens.token, hashToken(token)));
   }
 
   async incrementAccountLinkingTokenFailedAttempts(token: string): Promise<void> {
     await db
       .update(accountLinkingTokens)
       .set({ failedAttempts: sql`${accountLinkingTokens.failedAttempts} + 1` })
-      .where(eq(accountLinkingTokens.token, token));
+      .where(eq(accountLinkingTokens.token, hashToken(token)));
   }
 
   async createUser(user: InsertUser | InsertOAuthUser): Promise<User> {
@@ -1640,10 +1642,11 @@ export class DatabaseStorage implements IStorage {
       role: data.role,
       invitedBy: data.invitedBy,
       playerId: data.playerId, // Store athlete ID consistently
-      token,
+      token: hashToken(token), // Store only the hash; the raw token is emailed
       expiresAt,
     }).returning();
-    return invitation;
+    // Return the RAW token so the caller can build the invitation link.
+    return { ...invitation, token };
   }
 
 
@@ -1651,7 +1654,7 @@ export class DatabaseStorage implements IStorage {
   async getInvitation(token: string): Promise<Invitation | undefined> {
     const [invitation] = await db.select().from(invitations)
       .where(and(
-        eq(invitations.token, token),
+        eq(invitations.token, hashToken(token)),
         eq(invitations.isUsed, false),
         gte(invitations.expiresAt, new Date())
       ));
@@ -1660,7 +1663,7 @@ export class DatabaseStorage implements IStorage {
 
   async getInvitationByToken(token: string): Promise<Invitation | undefined> {
     const [invitation] = await db.select().from(invitations)
-      .where(eq(invitations.token, token));
+      .where(eq(invitations.token, hashToken(token)));
     return invitation || undefined;
   }
 
@@ -1699,7 +1702,7 @@ export class DatabaseStorage implements IStorage {
       const [invitation] = await tx.select()
         .from(invitations)
         .where(and(
-          eq(invitations.token, token),
+          eq(invitations.token, hashToken(token)),
           eq(invitations.isUsed, false),
           gte(invitations.expiresAt, new Date())
         ))
@@ -1852,7 +1855,7 @@ export class DatabaseStorage implements IStorage {
           acceptedAt: new Date(),
           acceptedBy: user.id
         })
-        .where(eq(invitations.token, token));
+        .where(eq(invitations.token, hashToken(token)));
 
       // Create audit logs as part of the transaction
       // All audit logs must be inside transaction for atomicity and consistency
@@ -1902,10 +1905,11 @@ export class DatabaseStorage implements IStorage {
     await db.insert(emailVerificationTokens).values({
       userId,
       email,
-      token,
+      token: hashToken(token), // Store only the hash; the raw token is emailed
       expiresAt
     });
 
+    // Return the RAW token so the caller can build the verification link.
     return { token, expiresAt };
   }
 
@@ -1916,7 +1920,7 @@ export class DatabaseStorage implements IStorage {
       const [verificationToken] = await tx.select()
         .from(emailVerificationTokens)
         .where(and(
-          eq(emailVerificationTokens.token, token),
+          eq(emailVerificationTokens.token, hashToken(token)),
           eq(emailVerificationTokens.isUsed, false),
           gte(emailVerificationTokens.expiresAt, new Date())
         ))
@@ -1929,7 +1933,7 @@ export class DatabaseStorage implements IStorage {
       // Mark token as used (within same transaction)
       await tx.update(emailVerificationTokens)
         .set({ isUsed: true })
-        .where(eq(emailVerificationTokens.token, token));
+        .where(eq(emailVerificationTokens.token, hashToken(token)));
 
       // Mark user's email as verified (within same transaction)
       await tx.update(users)
@@ -1948,7 +1952,7 @@ export class DatabaseStorage implements IStorage {
     const [verificationToken] = await db.select()
       .from(emailVerificationTokens)
       .where(and(
-        eq(emailVerificationTokens.token, token),
+        eq(emailVerificationTokens.token, hashToken(token)),
         eq(emailVerificationTokens.isUsed, false),
         gte(emailVerificationTokens.expiresAt, new Date())
       ));

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -4066,10 +4066,9 @@ export class DatabaseStorage implements IStorage {
 
   async createPasswordResetToken(token: any): Promise<void> {
     // Store only the SHA-256 hash — the raw token lives solely in the emailed link.
-    const tokenHash = crypto.createHash('sha256').update(token.token).digest('hex');
     await db.insert(passwordResetTokens).values({
       userId: token.userId,
-      tokenHash,
+      tokenHash: hashToken(token.token),
       expiresAt: token.expiresAt,
       ipAddress: token.ipAddress ?? null,
       userAgent: token.userAgent ?? null,
@@ -4077,21 +4076,19 @@ export class DatabaseStorage implements IStorage {
   }
 
   async findPasswordResetToken(token: string): Promise<any> {
-    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
     const [row] = await db
       .select()
       .from(passwordResetTokens)
-      .where(eq(passwordResetTokens.tokenHash, tokenHash))
+      .where(eq(passwordResetTokens.tokenHash, hashToken(token)))
       .limit(1);
     return row ?? null;
   }
 
   async markPasswordResetTokenUsed(token: string): Promise<void> {
-    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
     await db
       .update(passwordResetTokens)
       .set({ isUsed: true })
-      .where(eq(passwordResetTokens.tokenHash, tokenHash));
+      .where(eq(passwordResetTokens.tokenHash, hashToken(token)));
   }
 
   async updateUserPassword(userId: string, hashedPassword: string): Promise<void> {

--- a/packages/shared/schema/tables/auth.ts
+++ b/packages/shared/schema/tables/auth.ts
@@ -64,6 +64,21 @@ export const emailVerificationTokens = pgTable("email_verification_tokens", {
   tokenIdx: sql`CREATE INDEX IF NOT EXISTS email_verification_tokens_token_idx ON ${table} (${table.token})`,
 }));
 
+export const passwordResetTokens = pgTable("password_reset_tokens", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  // SHA-256 hash of the reset token — the raw token is only ever in the emailed
+  // link, never stored, so a leaked DB row cannot be used to reset a password.
+  tokenHash: text("token_hash").notNull().unique(),
+  isUsed: boolean("is_used").default(false).notNull(),
+  expiresAt: timestamp("expires_at").notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (table) => ({
+  tokenHashIdx: sql`CREATE INDEX IF NOT EXISTS password_reset_tokens_token_hash_idx ON ${table} (${table.tokenHash})`,
+}));
+
 export const securityEvents = pgTable("security_events", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   userId: varchar("user_id").references(() => users.id, { onDelete: 'set null' }),

--- a/tests/integration/athlete-parent-email.test.ts
+++ b/tests/integration/athlete-parent-email.test.ts
@@ -245,6 +245,51 @@ describe("PUT /api/athletes/:id — parentEmail field", () => {
     expect(links[0].isActive).toBe(true);
   });
 
+  it("scopes the parentAthleteLinks row to the authorizing org, not the alphabetically-first org", async () => {
+    // Athlete belongs to two orgs. getUserOrganizations orders by name, so the
+    // "apex" org sorts first — but the requester is org_admin only in the later
+    // "zebra" org. The link must be attributed to the authorizing (zebra) org.
+    const apexOrg = await createOrg(`aaa_${uid()}`);
+    createdOrgIds.push(apexOrg.id);
+    const zebraOrg = await createOrg(`zzz_${uid()}`);
+    createdOrgIds.push(zebraOrg.id);
+
+    const athlete = await createUser('athlete_multiorg', 'athlete', {
+      birthDate: minorBirthDate(),
+      isMinor: true,
+    });
+    createdUserIds.push(athlete.id);
+    await addUserToOrg(athlete.id, apexOrg.id, 'athlete');
+    await addUserToOrg(athlete.id, zebraOrg.id, 'athlete');
+
+    const admin = await createUser('multiorg_admin', 'org_admin');
+    createdUserIds.push(admin.id);
+    await addUserToOrg(admin.id, zebraOrg.id, 'org_admin');
+
+    const cookie = await loginAs(app, admin.username);
+    const parentEmail = `${TEST_PREFIX}parent_multiorg_${uid()}@example.com`;
+
+    const res = await request(app)
+      .put(`/api/athletes/${athlete.id}`)
+      .set('Cookie', cookie)
+      .send({ parentEmail });
+
+    expect(res.status).toBe(200);
+
+    const links = await db
+      .select({ organizationId: parentAthleteLinks.organizationId })
+      .from(parentAthleteLinks)
+      .where(
+        and(
+          eq(parentAthleteLinks.athleteUserId, athlete.id),
+          eq(parentAthleteLinks.parentEmail, parentEmail.toLowerCase()),
+        ),
+      );
+
+    expect(links.length).toBe(1);
+    expect(links[0].organizationId).toBe(zebraOrg.id);
+  });
+
   it("does NOT create a parentAthleteLinks row for an adult athlete", async () => {
     const athlete = await createUser('athlete_adult_nol', 'athlete', {
       birthDate: adultBirthDate(),

--- a/tests/integration/import-export-tenant-isolation.test.ts
+++ b/tests/integration/import-export-tenant-isolation.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tenant-isolation regression tests for import/export.
+ *
+ *  - GET /api/export/teams returned every tenant's teams (no org scoping).
+ *  - CSV import trusted a client-supplied options.organizationId and only
+ *    validated it inside the create-team branch, so a caller could import
+ *    athletes/measurements into an organization they do not belong to.
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { storage } from '../../packages/api/storage';
+import type { Organization, Team, User } from '@shared/schema';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+const PASSWORD = 'TestPass123!';
+
+describe('Import/export tenant isolation', () => {
+  let app: express.Express;
+  let orgA: Organization;
+  let orgB: Organization;
+  let teamA: Team;
+  let teamB: Team;
+  let userA: User;
+  let agentA: ReturnType<typeof request.agent>;
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+
+    const ts = Date.now();
+    orgA = await storage.createOrganization({ name: `Iso Org A ${ts}`, description: 'a' });
+    orgB = await storage.createOrganization({ name: `Iso Org B ${ts}`, description: 'b' });
+    teamA = await storage.createTeam({ name: `Iso Team A ${ts}`, level: 'Club', organizationId: orgA.id });
+    teamB = await storage.createTeam({ name: `Iso Team B ${ts}`, level: 'Club', organizationId: orgB.id });
+
+    userA = await storage.createUser({
+      username: `isousera${ts}`,
+      password: PASSWORD,
+      emails: [`isousera${ts}@test.com`],
+      firstName: 'Iso',
+      lastName: 'UserA',
+    });
+    await storage.addUserToOrganization(userA.id, orgA.id, 'org_admin');
+
+    agentA = request.agent(app);
+    await agentA.post('/api/auth/login').send({ username: userA.username, password: PASSWORD }).expect(200);
+  });
+
+  afterAll(async () => {
+    try { await storage.deleteUser(userA.id); } catch { /* ignore */ }
+    try { await storage.deleteTeam(teamA.id); } catch { /* ignore */ }
+    try { await storage.deleteTeam(teamB.id); } catch { /* ignore */ }
+    try { await storage.deleteOrganization(orgA.id); } catch { /* ignore */ }
+    try { await storage.deleteOrganization(orgB.id); } catch { /* ignore */ }
+  });
+
+  it('GET /api/export/teams returns only the caller\'s organization teams', async () => {
+    const res = await agentA.get('/api/export/teams').expect(200);
+    expect(res.text).toContain(teamA.id);
+    expect(res.text).not.toContain(teamB.id);
+  });
+
+  it('blocks importing athletes into an organization the caller does not belong to', async () => {
+    const res = await agentA
+      .post('/api/import/athletes')
+      .field('options', JSON.stringify({ organizationId: orgB.id, teamHandling: 'leave_teamless' }))
+      .field('preview', 'true')
+      .attach('file', Buffer.from('firstName,lastName\nJohn,Doe'), 'athletes.csv');
+
+    expect(res.status).toBe(403);
+  });
+
+  it('allows importing athletes into the caller\'s own organization', async () => {
+    const res = await agentA
+      .post('/api/import/athletes')
+      .field('options', JSON.stringify({ organizationId: orgA.id, teamHandling: 'leave_teamless' }))
+      .field('preview', 'true')
+      .attach('file', Buffer.from('firstName,lastName\nJane,Roe'), 'athletes.csv');
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/tests/integration/import-export-tenant-isolation.test.ts
+++ b/tests/integration/import-export-tenant-isolation.test.ts
@@ -32,8 +32,10 @@ describe('Import/export tenant isolation', () => {
   let app: express.Express;
   let orgA: Organization;
   let orgB: Organization;
+  let orgC: Organization;
   let teamA: Team;
   let teamB: Team;
+  let teamC: Team;
   let userA: User;
   let agentA: ReturnType<typeof request.agent>;
 
@@ -47,8 +49,10 @@ describe('Import/export tenant isolation', () => {
     const ts = Date.now();
     orgA = await storage.createOrganization({ name: `Iso Org A ${ts}`, description: 'a' });
     orgB = await storage.createOrganization({ name: `Iso Org B ${ts}`, description: 'b' });
+    orgC = await storage.createOrganization({ name: `Iso Org C ${ts}`, description: 'c' });
     teamA = await storage.createTeam({ name: `Iso Team A ${ts}`, level: 'Club', organizationId: orgA.id });
     teamB = await storage.createTeam({ name: `Iso Team B ${ts}`, level: 'Club', organizationId: orgB.id });
+    teamC = await storage.createTeam({ name: `Iso Team C ${ts}`, level: 'Club', organizationId: orgC.id });
 
     userA = await storage.createUser({
       username: `isousera${ts}`,
@@ -57,7 +61,9 @@ describe('Import/export tenant isolation', () => {
       firstName: 'Iso',
       lastName: 'UserA',
     });
+    // userA belongs to TWO orgs (A and C) but not B.
     await storage.addUserToOrganization(userA.id, orgA.id, 'org_admin');
+    await storage.addUserToOrganization(userA.id, orgC.id, 'coach');
 
     agentA = request.agent(app);
     await agentA.post('/api/auth/login').send({ username: userA.username, password: PASSWORD }).expect(200);
@@ -67,13 +73,18 @@ describe('Import/export tenant isolation', () => {
     try { await storage.deleteUser(userA.id); } catch { /* ignore */ }
     try { await storage.deleteTeam(teamA.id); } catch { /* ignore */ }
     try { await storage.deleteTeam(teamB.id); } catch { /* ignore */ }
+    try { await storage.deleteTeam(teamC.id); } catch { /* ignore */ }
     try { await storage.deleteOrganization(orgA.id); } catch { /* ignore */ }
     try { await storage.deleteOrganization(orgB.id); } catch { /* ignore */ }
+    try { await storage.deleteOrganization(orgC.id); } catch { /* ignore */ }
   });
 
-  it('GET /api/export/teams returns only the caller\'s organization teams', async () => {
+  it('GET /api/export/teams returns teams from all the caller\'s orgs, and no others', async () => {
     const res = await agentA.get('/api/export/teams').expect(200);
+    // Both of userA's organizations (A and C) are included...
     expect(res.text).toContain(teamA.id);
+    expect(res.text).toContain(teamC.id);
+    // ...but not an organization they don't belong to.
     expect(res.text).not.toContain(teamB.id);
   });
 

--- a/tests/integration/import-export-tenant-isolation.test.ts
+++ b/tests/integration/import-export-tenant-isolation.test.ts
@@ -88,6 +88,17 @@ describe('Import/export tenant isolation', () => {
     expect(res.text).not.toContain(teamB.id);
   });
 
+  it('a repeated organizationId param (array) cannot bypass team-export scoping', async () => {
+    // ?organizationId=orgB&organizationId=orgB arrives as an array; it must be
+    // treated as "no org requested" (caller's own orgs), never leak orgB.
+    const res = await agentA
+      .get('/api/export/teams')
+      .query({ organizationId: [orgB.id, orgB.id] })
+      .expect(200);
+    expect(res.text).toContain(teamA.id);
+    expect(res.text).not.toContain(teamB.id);
+  });
+
   it('blocks importing athletes into an organization the caller does not belong to', async () => {
     const res = await agentA
       .post('/api/import/athletes')

--- a/tests/integration/invitation-resend.test.ts
+++ b/tests/integration/invitation-resend.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression test: resending an invitation emails a usable link.
+ *
+ * With tokens hashed at rest, the stored token cannot be reversed to build a
+ * link, so resend must rotate to a fresh token (store its hash, email the raw).
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { storage } from '../../packages/api/storage';
+import type { Organization, User } from '@shared/schema';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+// Capture the invitation link (raw token) that would be emailed.
+const sentInviteLinks: string[] = [];
+vi.mock('../../packages/api/services/email-service', () => ({
+  emailService: {
+    sendInvitation: vi.fn(async (_email: string, data: { invitationLink: string }) => {
+      sentInviteLinks.push(data.invitationLink);
+      return true;
+    }),
+    sendParentInvitation: vi.fn().mockResolvedValue(true),
+    sendEmailVerification: vi.fn().mockResolvedValue(true),
+  },
+  EmailService: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+const PASSWORD = 'TestPass123!';
+const tokenOf = (link: string) => new URL(link, 'http://localhost').searchParams.get('token') ?? '';
+
+describe('Invitation resend rotates to a usable token', () => {
+  let app: express.Express;
+  let org: Organization;
+  let admin: User;
+  let agent: ReturnType<typeof request.agent>;
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+
+    const ts = Date.now();
+    org = await storage.createOrganization({ name: `Resend Org ${ts}`, description: 'x' });
+    admin = await storage.createUser({
+      username: `resendadmin${ts}`,
+      password: PASSWORD,
+      emails: [`resendadmin${ts}@test.com`],
+      firstName: 'Re',
+      lastName: 'Send',
+    });
+    await storage.addUserToOrganization(admin.id, org.id, 'org_admin');
+    agent = request.agent(app);
+    await agent.post('/api/auth/login').send({ username: admin.username, password: PASSWORD }).expect(200);
+  });
+
+  afterAll(async () => {
+    try { await storage.deleteUser(admin.id); } catch { /* ignore */ }
+    try { await storage.deleteOrganization(org.id); } catch { /* ignore */ }
+  });
+
+  it('emails a fresh, acceptable token on resend', async () => {
+    const create = await agent.post('/api/invitations').send({
+      firstName: 'New', lastName: 'Invitee',
+      email: `resendinvitee${Date.now()}@test.com`,
+      role: 'athlete',
+      organizationId: org.id,
+    }).expect(201);
+    const firstToken = tokenOf(create.body.inviteLink);
+
+    // Ignore the create email; capture only the resend's emailed link.
+    sentInviteLinks.length = 0;
+    const resend = await agent.post(`/api/invitations/${create.body.id}/resend`).send({});
+    expect(resend.status).toBe(200);
+    expect(sentInviteLinks.length).toBe(1);
+    const resentToken = tokenOf(sentInviteLinks[0]);
+
+    // The token was rotated...
+    expect(resentToken).toBeTruthy();
+    expect(resentToken).not.toBe(firstToken);
+    // ...and the resent token is the one that now validates.
+    expect((await storage.getInvitationByToken(resentToken))?.id).toBe(create.body.id);
+    expect(await storage.getInvitationByToken(firstToken)).toBeUndefined();
+  });
+});

--- a/tests/integration/login-lockout-mfa.test.ts
+++ b/tests/integration/login-lockout-mfa.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for account lockout and MFA on the REAL login path.
+ *
+ * The live login (/api/auth/login -> AuthService.login) enforced neither
+ * account lockout nor MFA — that logic only lived in the unused
+ * /api/enhanced-auth/login handler. This consolidates both onto the path the
+ * web client actually uses.
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { storage } from '../../packages/api/storage';
+import type { User } from '@shared/schema';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+const PASSWORD = 'TestPass123!';
+
+describe('Login account lockout and MFA', () => {
+  let app: express.Express;
+  let seq = 0;
+
+  async function makeUser(): Promise<User> {
+    const uniq = `${Date.now()}${seq++}`;
+    return storage.createUser({
+      username: `wave2lock${uniq}`,
+      password: PASSWORD,
+      emails: [`wave2lock${uniq}@test.com`],
+      firstName: 'Lock',
+      lastName: 'Test',
+    });
+  }
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+  });
+
+  it('locks the account after 5 failed attempts, blocking even a correct password', async () => {
+    const user = await makeUser();
+    for (let i = 0; i < 5; i++) {
+      await request(app).post('/api/auth/login').send({ username: user.username, password: 'wrongpass' });
+    }
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: user.username, password: PASSWORD });
+
+    expect(res.status).toBe(423);
+    expect(res.body.accountLocked).toBe(true);
+
+    await storage.deleteUser(user.id);
+  });
+
+  it('resets failed attempts on a successful login', async () => {
+    const user = await makeUser();
+    for (let i = 0; i < 3; i++) {
+      await request(app).post('/api/auth/login').send({ username: user.username, password: 'wrongpass' });
+    }
+
+    const ok = await request(app)
+      .post('/api/auth/login')
+      .send({ username: user.username, password: PASSWORD });
+    expect(ok.status).toBe(200);
+
+    await storage.deleteUser(user.id);
+  });
+
+  it('requires an MFA code when the user has MFA enabled', async () => {
+    const user = await makeUser();
+    await storage.updateUser(user.id, { mfaEnabled: true, mfaSecret: 'JBSWY3DPEHPK3PXP' });
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ username: user.username, password: PASSWORD });
+
+    expect(res.body.requiresMFA).toBe(true);
+    expect(res.body.user).toBeUndefined();
+
+    await storage.deleteUser(user.id);
+  });
+});

--- a/tests/integration/parent-invitation.test.ts
+++ b/tests/integration/parent-invitation.test.ts
@@ -238,14 +238,16 @@ describe('POST /api/invitations/:token/accept — parent role', () => {
     expect(createRes.status).toBe(201);
     createdInvitationIds.push(createRes.body.id);
 
-    // Get the invitation token
+    // The raw token is only in the emailed link (the DB stores its hash), so
+    // extract it from the invite link in the creation response.
     const [inv] = await db.select().from(invitations).where(eq(invitations.id, createRes.body.id));
     expect(inv).toBeDefined();
+    const rawToken = new URL(createRes.body.inviteLink).searchParams.get('token')!;
 
     // Accept the invitation
     const newParentUsername = `${TEST_PREFIX}acc_par_${uniqueId()}`;
     const acceptRes = await request(app)
-      .post(`/api/invitations/${inv.token}/accept`)
+      .post(`/api/invitations/${rawToken}/accept`)
       .send({
         username: newParentUsername,
         password: VALID_PASSWORD,

--- a/tests/integration/password-reset.test.ts
+++ b/tests/integration/password-reset.test.ts
@@ -38,6 +38,8 @@ vi.mock('../../packages/api/services/email-service', () => ({
 }));
 
 import { registerRoutes } from '../../packages/api/routes';
+import { emailService } from '../../packages/api/services/email-service';
+import { PasswordResetService } from '../../packages/api/auth/password-reset';
 
 const OLD_PASSWORD = 'OldPass123!';
 const NEW_PASSWORD = 'BrandNewPass456!';
@@ -137,6 +139,20 @@ describe('Password reset flow', () => {
     expect(found?.userId).toBe(user.id);
     // ...but the raw token value must not appear as a stored column value.
     expect((found as any).token).toBeUndefined();
+
+    await storage.deleteUser(user.id);
+  });
+
+  it('requestEmailVerification actually sends a verification email with a token link', async () => {
+    (emailService.sendEmailVerification as any).mockClear();
+
+    const result = await PasswordResetService.requestEmailVerification(user.id, email, '127.0.0.1');
+    expect(result.success).toBe(true);
+
+    expect(emailService.sendEmailVerification).toHaveBeenCalledTimes(1);
+    const [toEmail, data] = (emailService.sendEmailVerification as any).mock.calls.at(-1);
+    expect(toEmail).toBe(email);
+    expect(data.verificationLink).toMatch(/verify-email\?token=/);
 
     await storage.deleteUser(user.id);
   });

--- a/tests/integration/password-reset.test.ts
+++ b/tests/integration/password-reset.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration tests for the password reset flow.
+ *
+ * The flow was non-functional: the frontend calls /api/auth/forgot-password and
+ * /api/auth/reset-password (unmounted), and the storage layer was stubbed with
+ * no passwordResetTokens table. These tests drive the working end-to-end flow.
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { storage } from '../../packages/api/storage';
+import type { User } from '@shared/schema';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+// Capture the reset link (and therefore the raw token) that would be emailed.
+const sentResetEmails: Array<{ email: string; resetLink: string }> = [];
+vi.mock('../../packages/api/services/email-service', () => ({
+  emailService: {
+    sendPasswordReset: vi.fn(async (email: string, data: { userName: string; resetLink: string }) => {
+      sentResetEmails.push({ email, resetLink: data.resetLink });
+      return true;
+    }),
+    sendEmailVerification: vi.fn().mockResolvedValue(true),
+    sendInvitation: vi.fn().mockResolvedValue(true),
+  },
+  EmailService: vi.fn(),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+const OLD_PASSWORD = 'OldPass123!';
+const NEW_PASSWORD = 'BrandNewPass456!';
+
+function tokenFromLink(link: string): string {
+  return new URL(link, 'http://localhost').searchParams.get('token') ?? '';
+}
+
+describe('Password reset flow', () => {
+  let app: express.Express;
+  let user: User;
+  let email: string;
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: false }));
+    await registerRoutes(app);
+  });
+
+  beforeEach(async () => {
+    sentResetEmails.length = 0;
+    const ts = `${Date.now()}${Math.floor(performance.now())}`;
+    email = `wave2reset${ts}@test.com`;
+    user = await storage.createUser({
+      username: `wave2reset${ts}`,
+      password: OLD_PASSWORD,
+      emails: [email],
+      firstName: 'Reset',
+      lastName: 'User',
+    });
+  });
+
+  afterAll(async () => {
+    // beforeEach users are cleaned up individually below via afterAll sweep not
+    // needed; each test deletes its own user.
+  });
+
+  it('completes request -> reset -> login with the new password', async () => {
+    const forgot = await request(app).post('/api/auth/forgot-password').send({ email });
+    expect(forgot.status).toBe(200);
+
+    // A reset link (with the raw token) was emailed.
+    expect(sentResetEmails.length).toBe(1);
+    const token = tokenFromLink(sentResetEmails[0].resetLink);
+    expect(token.length).toBeGreaterThan(20);
+
+    const reset = await request(app)
+      .post('/api/auth/reset-password')
+      .send({ token, newPassword: NEW_PASSWORD });
+    expect(reset.status).toBe(200);
+    expect(reset.body.success).toBe(true);
+
+    // Old password no longer works; new password does.
+    const oldLogin = await request(app)
+      .post('/api/auth/login')
+      .send({ username: user.username, password: OLD_PASSWORD });
+    expect(oldLogin.status).toBe(401);
+
+    const newLogin = await request(app)
+      .post('/api/auth/login')
+      .send({ username: user.username, password: NEW_PASSWORD });
+    expect(newLogin.status).toBe(200);
+
+    await storage.deleteUser(user.id);
+  });
+
+  it('returns 200 for an unknown email (no account enumeration) and sends nothing', async () => {
+    const res = await request(app)
+      .post('/api/auth/forgot-password')
+      .send({ email: `nobody${Date.now()}@test.com` });
+    expect(res.status).toBe(200);
+    expect(sentResetEmails.length).toBe(0);
+    await storage.deleteUser(user.id);
+  });
+
+  it('rejects a reused reset token', async () => {
+    await request(app).post('/api/auth/forgot-password').send({ email }).expect(200);
+    const token = tokenFromLink(sentResetEmails[0].resetLink);
+
+    await request(app).post('/api/auth/reset-password').send({ token, newPassword: NEW_PASSWORD }).expect(200);
+    const second = await request(app)
+      .post('/api/auth/reset-password')
+      .send({ token, newPassword: 'AnotherPass789!' });
+    expect(second.body.success).toBe(false);
+
+    await storage.deleteUser(user.id);
+  });
+
+  it('does not persist the raw token (stored value is hashed)', async () => {
+    await request(app).post('/api/auth/forgot-password').send({ email }).expect(200);
+    const token = tokenFromLink(sentResetEmails[0].resetLink);
+
+    // Looking up by the raw token must succeed (storage hashes internally)...
+    const found = await storage.findPasswordResetToken(token);
+    expect(found?.userId).toBe(user.id);
+    // ...but the raw token value must not appear as a stored column value.
+    expect((found as any).token).toBeUndefined();
+
+    await storage.deleteUser(user.id);
+  });
+});

--- a/tests/integration/token-hashing.test.ts
+++ b/tests/integration/token-hashing.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression tests: single-use bearer tokens are stored hashed, not in plaintext.
+ *
+ * For each token type, creating via the production path stores only the SHA-256
+ * hash: a direct lookup by the raw token finds nothing, while the production
+ * lookup (which hashes) finds the row.
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { db } from '../../packages/api/db';
+import { storage } from '../../packages/api/storage';
+import { invitations, emailVerificationTokens, accountLinkingTokens } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import { hashToken } from '../../packages/api/lib/token-hash';
+import type { Organization, User } from '@shared/schema';
+
+describe('Bearer tokens are hashed at rest', () => {
+  let org: Organization;
+  let user: User;
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    const ts = Date.now();
+    org = await storage.createOrganization({ name: `TokenHash Org ${ts}`, description: 'x' });
+    user = await storage.createUser({
+      username: `tokhash${ts}`,
+      password: 'TestPass123!',
+      emails: [`tokhash${ts}@test.com`],
+      firstName: 'Tok',
+      lastName: 'Hash',
+    });
+  });
+
+  afterAll(async () => {
+    try { await storage.deleteUser(user.id); } catch { /* ignore */ }
+    try { await storage.deleteOrganization(org.id); } catch { /* ignore */ }
+  });
+
+  it('invitation token is stored as a hash', async () => {
+    const invitation = await storage.createInvitation({
+      email: `inv${Date.now()}@test.com`,
+      firstName: 'In',
+      lastName: 'Vitee',
+      organizationId: org.id,
+      role: 'athlete',
+      invitedBy: user.id,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
+    const raw = invitation.token;
+
+    const byRaw = await db.select().from(invitations).where(eq(invitations.token, raw));
+    expect(byRaw.length).toBe(0);
+    const byHash = await db.select().from(invitations).where(eq(invitations.token, hashToken(raw)));
+    expect(byHash.length).toBe(1);
+    // Production lookup accepts the raw token.
+    expect((await storage.getInvitationByToken(raw))?.id).toBe(invitation.id);
+  });
+
+  it('email verification token is stored as a hash', async () => {
+    const { token: raw } = await storage.createEmailVerificationToken(user.id, user.emails![0]);
+
+    const byRaw = await db.select().from(emailVerificationTokens).where(eq(emailVerificationTokens.token, raw));
+    expect(byRaw.length).toBe(0);
+    const byHash = await db.select().from(emailVerificationTokens).where(eq(emailVerificationTokens.token, hashToken(raw)));
+    expect(byHash.length).toBe(1);
+    expect((await storage.getEmailVerificationToken(raw))?.userId).toBe(user.id);
+  });
+
+  it('account linking token is stored as a hash', async () => {
+    const raw = `linktok_${Date.now()}`;
+    await storage.createAccountLinkingToken({
+      userId: user.id,
+      token: raw,
+      provider: 'google',
+      providerId: 'g-123',
+      providerEmail: user.emails![0],
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      failedAttempts: 0,
+    });
+
+    const byRaw = await db.select().from(accountLinkingTokens).where(eq(accountLinkingTokens.token, raw));
+    expect(byRaw.length).toBe(0);
+    expect((await storage.getAccountLinkingToken(raw))?.userId).toBe(user.id);
+  });
+});


### PR DESCRIPTION
## Wave 2 — Security fixes (tenant isolation, password reset, auth hardening, COPPA, token hashing)

All five Wave 2 items, implemented test-first with atomic per-item commits.

### Fixes

| # | Severity | Fix | Commit |
|---|----------|-----|--------|
| 3 | 🔴 Critical | **Cross-tenant IDOR in import/export.** `GET /api/export/teams` returned every tenant's teams; CSV/OCR import trusted a client-supplied `options.organizationId` (validated only inside the create-team branch); measurement import matched team names across all orgs. Now scoped to the caller's organizations, with an upfront `checkImportOrgAccess` guard. | `f1c0f937` |
| 9b | 🟠 High | **COPPA parentAthleteLinks mis-attribution.** The parent-email update persisted the athlete's alphabetically-first org instead of the org the requester administers. Now uses the authorizing org. | `8c1ea7b7` |
| 6 | 🟠 High | **Password reset was non-functional.** Frontend called unmounted `/api/auth/*` paths; storage was stubbed with no table and logged the raw token. Added `password_reset_tokens` table (migration 0138, hashed token), implemented the storage methods, wired the reset email, removed the token log, and mounted the routes where the client calls them. | `92f919a9` |
| 7 | 🟠 High | **Login enforced neither lockout nor MFA.** That logic lived only in the unused enhanced-auth handler. Wired account lockout (5 attempts / 15 min) + MFA into `AuthService.login` (the real path), and rate-limited the previously unthrottled enhanced-auth endpoints. | `578080ef` |
| 9a | 🟠 High | **Bearer tokens stored in plaintext.** Invitation / email-verification / OAuth account-linking / global-athlete-claim tokens are now stored as SHA-256 hashes; the raw token lives only in the emailed link, and lookups hash the value from the URL. Emailed links are unchanged. | `b51424eb` |

### ⚠️ Reviewer notes

- **Migration 0138** (`password_reset_tokens`) must be applied on deploy. CI provisions the schema via `db:push`, so the table is picked up from `schema.ts` automatically; the numbered SQL migration is included for the production runner.
- **Item 9a is a code-only change** (no data migration) — safe because there are no pending invitations, so no plaintext tokens need backfilling; any short-lived outstanding tokens simply expire. The OAuth account-linking unit tests are `describe.skip`ped, so item 9a's hashing is covered by a new executing `token-hashing.test.ts` plus the (running) invitation, registration, and global-athlete-claim suites.
- **Deploy note (item 9a):** on the deploy that ships this, any *already-issued* email-verification (24h) or OAuth account-linking (1h) links stop working, since only their hash is now compared. These are short-lived and re-requestable (resend-verification / re-initiate linking); invitations are unaffected (none pending). If a zero-disruption cutover is ever required, add a one-time backfill (`UPDATE ... SET token = encode(digest(token,'sha256'),'hex')`).
- **Reviewed** with a high-effort multi-agent pass; 3 confirmed correctness findings fixed here (invitation-resend token, verification-token log leak, multi-org team export). Three lower-priority items deferred by design: login helper re-queries (needs `AuthSecurity` signature changes outside this diff) and the duplicate `/api/enhanced-auth/*` reset routes (belongs to the larger auth-stack consolidation).
- **Item 7 touches the primary login path** and item 6 adds a migration — worth a staging smoke-test of login (including a deliberately-locked account) and a password-reset round-trip.

### Testing

- New regression tests: import/export tenant isolation, COPPA authorizing-org attribution, full password-reset flow, login lockout + MFA prompt, and tokens-hashed-at-rest.
- Full integration suite: **1153 passed, 0 failed**; unit suite green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
