### PR TITLE
fix(security): Wave 3 — make acceptInvitation atomic

### DIFF
--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -56,15 +56,16 @@ export interface IStorage {
   authenticateUser(username: string, password: string): Promise<User | null>;
   authenticateUserByEmail(email: string, password: string): Promise<User | null>;
   getUserByEmail(email: string): Promise<User | undefined>;
-  getUsersByEmail(email: string): Promise<User[]>;
+  // executor?: pass a transaction handle to run within an existing db.transaction.
+  getUsersByEmail(email: string, executor?: any): Promise<User[]>;
   getUserByUsername(username: string): Promise<User | undefined>;
   getUserByGoogleId(googleId: string): Promise<User | null>;
   getUserByAppleId(appleId: string): Promise<User | null>;
-  createUser(user: InsertUser | InsertOAuthUser): Promise<User>;
+  createUser(user: InsertUser | InsertOAuthUser, executor?: any): Promise<User>;
   getUsers(): Promise<User[]>;
-  getUser(id: string): Promise<User | undefined>;
+  getUser(id: string, executor?: any): Promise<User | undefined>;
   getUsersBatch(ids: string[]): Promise<Map<string, User>>;
-  updateUser(id: string, user: Partial<InsertUser>): Promise<User>;
+  updateUser(id: string, user: Partial<InsertUser>, executor?: any): Promise<User>;
   deleteUser(id: string): Promise<void>;
   hardDeleteUser(id: string): Promise<void>;
   getUserOrganizations(userId: string): Promise<(UserOrganization & { organization: Organization })[]>;
@@ -100,7 +101,7 @@ export interface IStorage {
   updateTeamMembership(teamId: string, userId: string, membershipData: { leftAt?: Date; season?: string }): Promise<any>;
 
   // User Management
-  addUserToOrganization(userId: string, organizationId: string, role: string): Promise<UserOrganization>;
+  addUserToOrganization(userId: string, organizationId: string, role: string, executor?: any): Promise<UserOrganization>;
   addUserToTeam(userId: string, teamId: string): Promise<UserTeam>;
   removeUserFromOrganization(userId: string, organizationId: string, validateLastAdmin?: boolean): Promise<void>;
   removeUserFromTeam(userId: string, teamId: string): Promise<void>;

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -467,10 +467,10 @@ export class DatabaseStorage implements IStorage {
     return user || undefined;
   }
 
-  async getUsersByEmail(email: string): Promise<User[]> {
+  async getUsersByEmail(email: string, executor: any = db): Promise<User[]> {
     // Use PostgreSQL array search with ANY operator to find ALL users with the email
     // Order by createdAt ASC for deterministic results (oldest user first)
-    const matchingUsers = await db.select().from(users).where(
+    const matchingUsers = await executor.select().from(users).where(
       and(
         sql`${email} = ANY(${users.emails})`,
         whereUserNotDeleted() // Exclude soft-deleted users
@@ -1726,7 +1726,7 @@ export class DatabaseStorage implements IStorage {
         console.log("Invitation linked to existing athlete:", invitation.playerId);
 
         // Get the existing athlete/user
-        const existingUser = await this.getUser(invitation.playerId);
+        const existingUser = await this.getUser(invitation.playerId, tx);
 
         if (!existingUser) {
           throw new Error("Linked athlete not found");
@@ -1744,7 +1744,7 @@ export class DatabaseStorage implements IStorage {
         console.log("Updated existing athlete with credentials:", user.id);
       } else {
         // Check if a user with this email already exists
-        const existingUsers = await this.getUsersByEmail(invitation.email);
+        const existingUsers = await this.getUsersByEmail(invitation.email, tx);
 
         if (existingUsers.length > 0) {
           // Warn if multiple users found (should be rare after migration)
@@ -1893,11 +1893,13 @@ export class DatabaseStorage implements IStorage {
     // user row is visible on a fresh connection and a failure here cannot roll
     // back the accepted invitation (it is intentionally non-critical).
     if (invitation.teamIds && invitation.teamIds.length > 0) {
-      // Independent inserts — run concurrently. Best-effort: the invitation is
-      // already accepted, so a genuine failure (e.g. the team was deleted between
-      // invite and acceptance) is logged at error level for remediation but must
-      // not block the user from logging in.
-      await Promise.all(invitation.teamIds.map(async (teamId: string) => {
+      // Sequential (not Promise.all): addUserToTeam is a non-atomic
+      // check-then-insert, so concurrent calls for a duplicated team id would
+      // race and create duplicate roster rows. De-duplicate and process one at a
+      // time. Best-effort: the invitation is already accepted, so a genuine
+      // failure (e.g. the team was deleted between invite and acceptance) is
+      // logged at error level for remediation but must not block the user.
+      for (const teamId of [...new Set(invitation.teamIds)] as string[]) {
         try {
           await this.addUserToTeam(user.id, teamId);
         } catch (error) {
@@ -1907,7 +1909,7 @@ export class DatabaseStorage implements IStorage {
             error
           );
         }
-      }));
+      }
     }
 
     return { user, invitation };
@@ -2131,8 +2133,14 @@ export class DatabaseStorage implements IStorage {
         .where(eq(membershipRequests.id, id))
         .returning();
 
-      // Add user to organization (within the transaction for atomicity)
-      await this.addUserToOrganization(request.userId, request.organizationId, 'athlete', tx);
+      // Add user to organization.
+      // NOTE: full atomicity of approval is NOT yet achieved here — linkAthleteAccounts
+      // above transfers measurements/roster and deactivates the old athlete on the
+      // pooled db handle, outside this transaction. Rather than thread tx through only
+      // this call (a mixed state that could partially roll back and corrupt data), keep
+      // it consistent with those writes (no tx). Threading tx through linkAthleteAccounts
+      // to make the whole approval atomic is a separate, larger change.
+      await this.addUserToOrganization(request.userId, request.organizationId, 'athlete');
 
       return updated;
     });

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -545,7 +545,7 @@ export class DatabaseStorage implements IStorage {
       .where(eq(accountLinkingTokens.token, hashToken(token)));
   }
 
-  async createUser(user: InsertUser | InsertOAuthUser): Promise<User> {
+  async createUser(user: InsertUser | InsertOAuthUser, executor: any = db): Promise<User> {
     // Check if this is an OAuth user (has googleId or appleId but no password)
     const isOAuthUser = ((user as any).googleId || (user as any).appleId) && !user.password;
 
@@ -605,7 +605,7 @@ export class DatabaseStorage implements IStorage {
       }
     });
 
-    const [newUser] = await db.insert(users).values(finalData).returning();
+    const [newUser] = await executor.insert(users).values(finalData).returning();
     return newUser;
   }
 
@@ -669,7 +669,7 @@ export class DatabaseStorage implements IStorage {
       );
   }
 
-  async updateUser(id: string, user: Partial<InsertUser>): Promise<User> {
+  async updateUser(id: string, user: Partial<InsertUser>, executor: any = db): Promise<User> {
     // List of valid database columns that can be updated
     const validUserColumns = [
       'username', 'emails', 'password', 'firstName', 'lastName',
@@ -711,7 +711,7 @@ export class DatabaseStorage implements IStorage {
       updateData.birthYear = new Date(user.birthDate).getFullYear();
     }
 
-    const [updatedUser] = await db.update(users)
+    const [updatedUser] = await executor.update(users)
       .set(updateData)
       .where(eq(users.id, id))
       .returning();
@@ -1442,21 +1442,21 @@ export class DatabaseStorage implements IStorage {
   }
 
   // User Management
-  async addUserToOrganization(userId: string, organizationId: string, role: string): Promise<UserOrganization> {
+  async addUserToOrganization(userId: string, organizationId: string, role: string, executor: any = db): Promise<UserOrganization> {
     // Validate that role is organization-specific only
     if (!['org_admin', 'coach', 'athlete'].includes(role)) {
       throw new Error(`Invalid organization role: ${role}. Must be org_admin, coach, or athlete`);
     }
 
     // First remove any existing roles for this user in this organization
-    await db.delete(userOrganizations)
+    await executor.delete(userOrganizations)
       .where(and(
         eq(userOrganizations.userId, userId),
         eq(userOrganizations.organizationId, organizationId)
       ));
 
     // Then insert the new single role
-    const [userOrg] = await db.insert(userOrganizations).values({
+    const [userOrg] = await executor.insert(userOrganizations).values({
       userId,
       organizationId,
       role
@@ -1696,7 +1696,7 @@ export class DatabaseStorage implements IStorage {
     }
   ): Promise<{ user: User; invitation: Invitation }> {
     // Use database transaction with row-level locking to prevent race conditions
-    return await db.transaction(async (tx: any) => {
+    const { user, invitation } = await db.transaction(async (tx: any) => {
       // Lock the invitation row with SELECT FOR UPDATE
       // This prevents concurrent acceptance attempts
       const [invitation] = await tx.select()
@@ -1739,7 +1739,7 @@ export class DatabaseStorage implements IStorage {
           password: userInfo.password,
           isActive: true,
           ...legalData
-        });
+        }, tx);
 
         console.log("Updated existing athlete with credentials:", user.id);
       } else {
@@ -1785,7 +1785,7 @@ export class DatabaseStorage implements IStorage {
 
           // Only update if there's something to update
           if (Object.keys(updateData).length > 0) {
-            user = await this.updateUser(existingUser.id, updateData);
+            user = await this.updateUser(existingUser.id, updateData, tx);
             console.log("[Invitation] Updated existing user for invitation:", user.id);
           } else {
             user = existingUser;
@@ -1814,7 +1814,7 @@ export class DatabaseStorage implements IStorage {
           }
 
           try {
-            user = await this.createUser(createUserData);
+            user = await this.createUser(createUserData, tx);
             console.log("User created successfully:", user.id);
           } catch (error) {
             console.error("Error creating user:", error);
@@ -1833,19 +1833,12 @@ export class DatabaseStorage implements IStorage {
         organizationId: invitation.organizationId,
         role: orgRole
       });
-      await this.addUserToOrganization(user.id, invitation.organizationId, orgRole);
+      await this.addUserToOrganization(user.id, invitation.organizationId, orgRole, tx);
 
-      // Add user to teams if specified
-      if (invitation.teamIds && invitation.teamIds.length > 0) {
-        for (const teamId of invitation.teamIds) {
-          try {
-            await this.addUserToTeam(user.id, teamId);
-          } catch (error) {
-            // May already be in team - that's okay
-            console.log("User may already be in team:", error);
-          }
-        }
-      }
+      // NOTE: team membership is added AFTER the transaction commits (see below).
+      // It is best-effort (errors are swallowed) and must not run inside the
+      // transaction: a swallowed failure would poison the transaction, and a
+      // separate-connection insert cannot see the not-yet-committed user.
 
       // Mark the invitation as used and accepted (using transaction connection)
       await tx.update(invitations)
@@ -1895,6 +1888,22 @@ export class DatabaseStorage implements IStorage {
 
       return { user, invitation };
     });
+
+    // Best-effort team membership, AFTER the transaction has committed so the
+    // user row is visible on a fresh connection and a failure here cannot roll
+    // back the accepted invitation (it is intentionally non-critical).
+    if (invitation.teamIds && invitation.teamIds.length > 0) {
+      for (const teamId of invitation.teamIds) {
+        try {
+          await this.addUserToTeam(user.id, teamId);
+        } catch (error) {
+          // May already be in team, or the team no longer exists — non-critical.
+          console.log("User may already be in team:", error);
+        }
+      }
+    }
+
+    return { user, invitation };
   }
 
   // Email Verification

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -636,8 +636,8 @@ export class DatabaseStorage implements IStorage {
       .orderBy(asc(invitations.createdAt));
   }
 
-  async getUser(id: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(
+  async getUser(id: string, executor: any = db): Promise<User | undefined> {
+    const [user] = await executor.select().from(users).where(
       and(
         eq(users.id, id),
         whereUserNotDeleted() // Exclude soft-deleted users
@@ -699,7 +699,7 @@ export class DatabaseStorage implements IStorage {
 
     // Update computed fields if relevant data changed
     if (user.firstName || user.lastName) {
-      const currentUser = await this.getUser(id);
+      const currentUser = await this.getUser(id, executor);
       if (currentUser) {
         const firstName = user.firstName || currentUser.firstName;
         const lastName = user.lastName || currentUser.lastName;
@@ -1893,14 +1893,21 @@ export class DatabaseStorage implements IStorage {
     // user row is visible on a fresh connection and a failure here cannot roll
     // back the accepted invitation (it is intentionally non-critical).
     if (invitation.teamIds && invitation.teamIds.length > 0) {
-      for (const teamId of invitation.teamIds) {
+      // Independent inserts — run concurrently. Best-effort: the invitation is
+      // already accepted, so a genuine failure (e.g. the team was deleted between
+      // invite and acceptance) is logged at error level for remediation but must
+      // not block the user from logging in.
+      await Promise.all(invitation.teamIds.map(async (teamId: string) => {
         try {
           await this.addUserToTeam(user.id, teamId);
         } catch (error) {
-          // May already be in team, or the team no longer exists — non-critical.
-          console.log("User may already be in team:", error);
+          console.error(
+            `[Invitation] Failed to add user ${user.id} to team ${teamId} after acceptance; ` +
+            `roster membership was NOT created and may need manual remediation:`,
+            error
+          );
         }
-      }
+      }));
     }
 
     return { user, invitation };
@@ -2124,8 +2131,8 @@ export class DatabaseStorage implements IStorage {
         .where(eq(membershipRequests.id, id))
         .returning();
 
-      // Add user to organization
-      await this.addUserToOrganization(request.userId, request.organizationId, 'athlete');
+      // Add user to organization (within the transaction for atomicity)
+      await this.addUserToOrganization(request.userId, request.organizationId, 'athlete', tx);
 
       return updated;
     });

--- a/tests/integration/invitation-transaction.test.ts
+++ b/tests/integration/invitation-transaction.test.ts
@@ -24,6 +24,7 @@ describe('acceptInvitation transaction atomicity', () => {
   let org: Organization;
   let inviter: User;
   const trackedUserIds: string[] = [];
+  const createdInvitationIds: string[] = [];
 
   beforeAll(async () => {
     if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
@@ -40,6 +41,10 @@ describe('acceptInvitation transaction atomicity', () => {
   });
 
   afterAll(async () => {
+    // Delete invitations first (they reference the org and inviter).
+    for (const id of createdInvitationIds) {
+      try { await storage.deleteInvitation(id); } catch { /* ignore */ }
+    }
     for (const id of trackedUserIds) {
       try { await storage.deleteUser(id); } catch { /* ignore */ }
     }
@@ -47,7 +52,7 @@ describe('acceptInvitation transaction atomicity', () => {
   });
 
   async function makeInvitation(email: string) {
-    return storage.createInvitation({
+    const inv = await storage.createInvitation({
       email,
       firstName: 'Tx',
       lastName: 'Invitee',
@@ -56,6 +61,8 @@ describe('acceptInvitation transaction atomicity', () => {
       invitedBy: inviter.id,
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     });
+    createdInvitationIds.push(inv.id);
+    return inv;
   }
 
   it('rolls back the created user when a later step fails', async () => {
@@ -78,6 +85,42 @@ describe('acceptInvitation transaction atomicity', () => {
     // No orphaned user, and the invitation is still acceptable (not marked used).
     expect(await storage.getUserByUsername(username)).toBeFalsy();
     const invAfter = await storage.getInvitationByToken(rawToken);
+    expect(invAfter?.isUsed).toBe(false);
+  });
+
+  it('rolls back an existing user\'s update when a later step fails', async () => {
+    const ts = `${Date.now()}c`;
+    const email = `txexisting${ts}@test.com`;
+    // Pre-create a user with the invitation email → the existing-account accept
+    // path (updateUser), which the fix also threads the transaction into.
+    const existing = await storage.createUser({
+      username: `txexisting${ts}`,
+      password: PASSWORD,
+      emails: [email],
+      firstName: 'Ex',
+      lastName: 'Isting',
+    });
+    trackedUserIds.push(existing.id);
+    const inv = await makeInvitation(email);
+
+    // Inject a failure after updateUser (addUserToOrganization runs after it).
+    const spy = vi.spyOn(storage, 'addUserToOrganization').mockRejectedValueOnce(new Error('injected failure'));
+    try {
+      await expect(
+        storage.acceptInvitation(inv.token, {
+          email, username: `ignored${ts}`, password: PASSWORD, firstName: 'Ex', lastName: 'Isting',
+          legalAcceptedAt: new Date().toISOString(),
+        })
+      ).rejects.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+
+    // The legal-acceptance update on the existing user was rolled back, and the
+    // invitation is still acceptable.
+    const after = await storage.getUser(existing.id);
+    expect(after?.legalAcceptedAt).toBeFalsy();
+    const invAfter = await storage.getInvitationByToken(inv.token);
     expect(invAfter?.isUsed).toBe(false);
   });
 

--- a/tests/integration/invitation-transaction.test.ts
+++ b/tests/integration/invitation-transaction.test.ts
@@ -85,7 +85,8 @@ describe('acceptInvitation transaction atomicity', () => {
     // No orphaned user, and the invitation is still acceptable (not marked used).
     expect(await storage.getUserByUsername(username)).toBeFalsy();
     const invAfter = await storage.getInvitationByToken(rawToken);
-    expect(invAfter?.isUsed).toBe(false);
+    expect(invAfter).not.toBeUndefined();
+    expect(invAfter!.isUsed).toBe(false);
   });
 
   it('rolls back an existing user\'s update when a later step fails', async () => {
@@ -121,7 +122,8 @@ describe('acceptInvitation transaction atomicity', () => {
     const after = await storage.getUser(existing.id);
     expect(after?.legalAcceptedAt).toBeFalsy();
     const invAfter = await storage.getInvitationByToken(inv.token);
-    expect(invAfter?.isUsed).toBe(false);
+    expect(invAfter).not.toBeUndefined();
+    expect(invAfter!.isUsed).toBe(false);
   });
 
   it('accepts the invitation and creates the user + membership on success', async () => {

--- a/tests/integration/invitation-transaction.test.ts
+++ b/tests/integration/invitation-transaction.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression test: acceptInvitation is atomic.
+ *
+ * The user-creation, org-membership, invitation-status and audit-log writes must
+ * all live in the same transaction. Previously createUser/updateUser/
+ * addUserToOrganization used the module-level db handle instead of the tx, so a
+ * failure after the user was created left an orphaned user + a still-"pending"
+ * invitation (re-acceptable → duplicate accounts).
+ */
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || 'test-secret-key-for-integration-tests-only';
+process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
+process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@test.com';
+process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'TestPassword123!';
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { storage } from '../../packages/api/storage';
+import type { Organization, User } from '@shared/schema';
+
+const PASSWORD = 'TestPass123!';
+
+describe('acceptInvitation transaction atomicity', () => {
+  let org: Organization;
+  let inviter: User;
+  const trackedUserIds: string[] = [];
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set.');
+    const ts = Date.now();
+    org = await storage.createOrganization({ name: `Tx Inv Org ${ts}`, description: 'x' });
+    inviter = await storage.createUser({
+      username: `txinviter${ts}`,
+      password: PASSWORD,
+      emails: [`txinviter${ts}@test.com`],
+      firstName: 'In',
+      lastName: 'Viter',
+    });
+    trackedUserIds.push(inviter.id);
+  });
+
+  afterAll(async () => {
+    for (const id of trackedUserIds) {
+      try { await storage.deleteUser(id); } catch { /* ignore */ }
+    }
+    try { await storage.deleteOrganization(org.id); } catch { /* ignore */ }
+  });
+
+  async function makeInvitation(email: string) {
+    return storage.createInvitation({
+      email,
+      firstName: 'Tx',
+      lastName: 'Invitee',
+      organizationId: org.id,
+      role: 'athlete',
+      invitedBy: inviter.id,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
+  }
+
+  it('rolls back the created user when a later step fails', async () => {
+    const ts = `${Date.now()}a`;
+    const email = `txinvitee${ts}@test.com`;
+    const username = `txinvitee${ts}`;
+    const inv = await makeInvitation(email);
+    const rawToken = inv.token;
+
+    // Inject a failure AFTER createUser (addUserToOrganization runs after it).
+    const spy = vi.spyOn(storage, 'addUserToOrganization').mockRejectedValueOnce(new Error('injected failure'));
+    try {
+      await expect(
+        storage.acceptInvitation(rawToken, { email, username, password: PASSWORD, firstName: 'Tx', lastName: 'Invitee' })
+      ).rejects.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+
+    // No orphaned user, and the invitation is still acceptable (not marked used).
+    expect(await storage.getUserByUsername(username)).toBeFalsy();
+    const invAfter = await storage.getInvitationByToken(rawToken);
+    expect(invAfter?.isUsed).toBe(false);
+  });
+
+  it('accepts the invitation and creates the user + membership on success', async () => {
+    const ts = `${Date.now()}b`;
+    const email = `txinvitee${ts}@test.com`;
+    const username = `txinvitee${ts}`;
+    const inv = await makeInvitation(email);
+
+    const { user } = await storage.acceptInvitation(inv.token, {
+      email, username, password: PASSWORD, firstName: 'Tx', lastName: 'Invitee',
+    });
+    trackedUserIds.push(user.id);
+
+    expect(user.username).toBe(username);
+    const roles = await storage.getUserRoles(user.id, org.id);
+    expect(roles).toContain('athlete');
+    const invAfter = await storage.getInvitationByToken(inv.token);
+    expect(invAfter?.isUsed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Item 5 — transaction-boundary safety in `acceptInvitation`

### The bug
Inside `acceptInvitation`'s `db.transaction(async (tx) => …)`, the writes that create/update the user and add org membership called `this.createUser` / `this.updateUser` / `this.addUserToOrganization` — all of which used the **module-level `db` handle, not the `tx`**. So those writes committed immediately and would **not roll back** if a later step in the transaction (audit-log insert, invitation update) failed.

Failure mode: an orphaned `users` row is left behind, the invitation stays `pending` (rolled back), and it can be re-accepted → **duplicate accounts**. For COPPA registrations it also breaks the documented "legalAcceptedAt set ⟺ audit log written" invariant.

### The fix
- Threaded an optional `executor` param (default `db`, so **every other caller is unaffected**) through `createUser`, `updateUser`, and `addUserToOrganization`; `acceptInvitation` passes `tx`.
- Moved the best-effort `addUserToTeam` loop to **after** the transaction commits. With the user now living in the uncommitted `tx`, a separate-connection team insert couldn't see it, and its intentionally-swallowed errors would otherwise poison the transaction.

### Testing
New `invitation-transaction.test.ts`:
- Injects a failure right after user creation (spy on `addUserToOrganization`) → asserts **no orphaned user** and the invitation is **still acceptable** (not marked used). Verified it **fails without the fix** (orphan persists).
- Happy path: accept succeeds, user created + in org, invitation marked used.

Full integration suite: **1157 passing** (the single failure is the pre-existing `exactlyAge` date flake, fixed separately on the Wave-3 authorization PR #462); `tsc` clean.

### Note
This is the general pattern flagged by the audit ("any storage method calling sibling `this.*` methods inside a `db.transaction` silently escapes it"). This PR fixes the `acceptInvitation` instance; a broader `executor`-param convention + audit of other `db.transaction` blocks is worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure invitation acceptance is atomic by keeping user creation, organization membership, and invitation updates within a single transaction, and moving non-critical team membership updates out of the transaction.

Bug Fixes:
- Prevent orphaned user records and re-acceptable invitations when a failure occurs after user creation during invitation acceptance.

Enhancements:
- Add an optional executor parameter to user and organization membership write methods so they can participate in caller-managed transactions without affecting existing callers.

Tests:
- Add integration tests to verify that acceptInvitation rolls back user creation on downstream failure and successfully creates user, membership, and marks the invitation as used on success.