### PR TITLE
feat(reports): show only best measurement per day in individual trend charts

### DIFF
--- a/packages/api/services/report-trends.test.ts
+++ b/packages/api/services/report-trends.test.ts
@@ -50,6 +50,45 @@ describe('assembleTrends', () => {
     expect(Number.isNaN(trends.VJ.delta.pct)).toBe(false);
   });
 
+  it('keeps only the best (max) same-day measurement for a higher-is-better metric', () => {
+    const rows = [
+      m('VJ', '2025-09-01', 18),
+      m('VJ', '2026-02-01', 24),   // same day, worse
+      m('VJ', '2026-02-01', 25.5), // same day, best
+      m('VJ', '2026-02-01', 23),   // same day, worse
+    ];
+    const trends = assembleTrends(rows, ['VJ'], { VJ: 'higher' }, { VJ: [] });
+    expect(trends.VJ.series).toEqual([
+      { date: '2025-09-01', value: 18 },
+      { date: '2026-02-01', value: 25.5 },
+    ]);
+    expect(trends.VJ.delta.to).toBe(25.5);
+  });
+
+  it('keeps only the best (min) same-day measurement for a lower-is-better metric', () => {
+    const rows = [
+      m('DASH', '2025-09-01', 5.6),
+      m('DASH', '2025-09-01', 5.4),  // same day, best
+      m('DASH', '2026-02-01', 4.92),
+    ];
+    const trends = assembleTrends(rows, ['DASH'], { DASH: 'lower' }, { DASH: [] });
+    expect(trends.DASH.series).toEqual([
+      { date: '2025-09-01', value: 5.4 },
+      { date: '2026-02-01', value: 4.92 },
+    ]);
+    expect(trends.DASH.delta.from).toBe(5.4);
+  });
+
+  it('omits a metric whose measurements all fall on a single day (fewer than 2 points after dedup)', () => {
+    const rows = [
+      m('VJ', '2025-09-01', 18),
+      m('VJ', '2025-09-01', 19),
+      m('VJ', '2025-09-01', 20),
+    ];
+    const trends = assembleTrends(rows, ['VJ'], { VJ: 'higher' }, { VJ: [] });
+    expect(trends.VJ).toBeUndefined();
+  });
+
   it('derives tier zones when comparisons carry allTiers', () => {
     const overlay = deriveOverlay([
       {

--- a/packages/api/services/report-trends.ts
+++ b/packages/api/services/report-trends.ts
@@ -60,6 +60,27 @@ export function deriveOverlay(comparisons: ComparisonLike[] | undefined): Benchm
 }
 
 /**
+ * Collapse a date-ascending series to at most one point per day, keeping the
+ * best value for that day. "Best" is direction-aware: 'lower' means
+ * lower-is-better (sprint times), 'higher' means higher-is-better (jumps).
+ */
+export function bestPerDay(
+  series: Array<{ date: string; value: number }>,
+  direction: 'higher' | 'lower',
+): Array<{ date: string; value: number }> {
+  const deduped: Array<{ date: string; value: number }> = [];
+  for (const point of series) {
+    const last = deduped[deduped.length - 1];
+    if (last?.date !== point.date) {
+      deduped.push({ ...point });
+    } else if (direction === 'lower' ? point.value < last.value : point.value > last.value) {
+      last.value = point.value;
+    }
+  }
+  return deduped;
+}
+
+/**
  * Build the per-metric trend map. Pure: no DB access.
  * @param rows           all in-window measurements for the athlete (any order)
  * @param metrics        metric codes selected on the report
@@ -75,17 +96,20 @@ export function assembleTrends(
   const trends: ReportTrends = {};
 
   for (const metric of metrics) {
-    const series = rows
-      .filter(r => r.metric === metric)
-      .map(r => ({ date: r.date, value: parseFloat(r.value) }))
-      // Drop non-numeric measurement values: a malformed `value` would parse to
-      // NaN and poison `from`/`to`/`pct` and the rendered chart line.
-      .filter(p => !Number.isNaN(p.value))
-      .sort((a, b) => a.date.localeCompare(b.date));
+    const direction = directions[metric] ?? 'higher';
+    const series = bestPerDay(
+      rows
+        .filter(r => r.metric === metric)
+        .map(r => ({ date: r.date, value: parseFloat(r.value) }))
+        // Drop non-numeric measurement values: a malformed `value` would parse to
+        // NaN and poison `from`/`to`/`pct` and the rendered chart line.
+        .filter(p => !Number.isNaN(p.value))
+        .sort((a, b) => a.date.localeCompare(b.date)),
+      direction,
+    );
 
     if (series.length < 2) continue;
 
-    const direction = directions[metric] ?? 'higher';
     const delta = computeTrendDelta(direction, series[0].value, series[series.length - 1].value);
 
     const trend: MetricTrend = {


### PR DESCRIPTION
## Summary
- Individual report trend charts plotted every in-window measurement, so multiple tests on the same day produced multiple points on that day
- Each day now collapses to its single best value via a new pure `bestPerDay` helper in `packages/api/services/report-trends.ts`, applied inside `assembleTrends`
- "Best" is direction-aware, mirroring the MIN/MAX semantics `analytics-service` already uses for weekly dashboard trends: min for lower-is-better metrics (sprint times), max otherwise (jumps)
- A metric whose measurements all fall on a single day now yields no trend chart (fewer than 2 points after dedup), consistent with the existing minimum-points rule

## Scope
Only the individual report path (`assembleTrends`) is touched. Team trends (`assembleTeamTrends`) are unchanged.

## Test plan
- [x] TDD: 3 new unit tests written first (max kept for higher-is-better, min kept for lower-is-better, single-day metric omitted), then implementation
- [x] All 10 `report-trends.test.ts` tests green
- [x] `npm run check` clean
- [x] Full API service suite: 782 passed (1 pre-existing unrelated failure in `import-validation-service.test.ts` — truncated warning-message assertion, fails on develop too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Summarize individual report trends to use only the best daily measurement per metric and align charted deltas with direction-aware best values.

New Features:
- Add a helper to collapse metric time series to a single best measurement per day based on whether higher or lower values are better.

Bug Fixes:
- Ensure individual trend charts no longer show multiple points for multiple measurements on the same day and omit charts that lack enough distinct days after deduplication.

Tests:
- Add unit tests covering max-selection for higher-is-better metrics, min-selection for lower-is-better metrics, and omission of single-day-only metrics from trends.