### PR TITLE
feat(config): Wave 3 — validate environment configuration at startup

### DIFF
--- a/packages/api/config/__tests__/env.test.ts
+++ b/packages/api/config/__tests__/env.test.ts
@@ -95,6 +95,21 @@ describe('validateEnvOrExit', () => {
     expect(getEnv()).toBe(env);
   });
 
+  it('reports a missing SESSION_SECRET in production without throwing a TypeError', () => {
+    // Regression: superRefine read `.length` on an undefined secret. Because
+    // index.ts defaults NODE_ENV to 'production' before validating, a prod
+    // deploy missing SESSION_SECRET hit `undefined.length` → raw TypeError
+    // instead of the clean report + process.exit(1).
+    withMocks((exit, err) => {
+      expect(() =>
+        validateEnvOrExit(base({ NODE_ENV: 'production', SESSION_SECRET: undefined }) as any),
+      ).not.toThrow();
+      expect(exit).toHaveBeenCalledWith(1);
+      const out = err.mock.calls.flat().join('\n');
+      expect(out).toMatch(/SESSION_SECRET/);
+    });
+  });
+
   it('exits(1) and prints ONLY the SESSION_SECRET hint for a secret-only failure', () => {
     withMocks((exit, err) => {
       validateEnvOrExit(base({ SESSION_SECRET: 'shortsecret' }) as any);

--- a/packages/api/config/__tests__/env.test.ts
+++ b/packages/api/config/__tests__/env.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { parseEnv } from '../env';
+
+// A strong 64-char secret for production checks.
+const STRONG_SECRET = 'f'.padStart(1, 'f') + '9a3b7c1d2e4f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9';
+const STRONG_32 = '9a3b7c1d2e4f60718293a4b5c6d7e8f9';
+
+function base(overrides: Record<string, string | undefined> = {}) {
+  return {
+    DATABASE_URL: 'postgresql://localhost:5432/test',
+    SESSION_SECRET: STRONG_SECRET,
+    NODE_ENV: 'development',
+    ...overrides,
+  };
+}
+
+describe('parseEnv', () => {
+  it('accepts a valid environment', () => {
+    const env = parseEnv(base());
+    expect(env.DATABASE_URL).toContain('postgresql://');
+    expect(env.SESSION_SECRET).toBe(STRONG_SECRET);
+  });
+
+  it('defaults NODE_ENV to production when unset', () => {
+    const env = parseEnv(base({ NODE_ENV: undefined, SESSION_SECRET: STRONG_SECRET }));
+    expect(env.NODE_ENV).toBe('production');
+  });
+
+  it('rejects a missing DATABASE_URL', () => {
+    expect(() => parseEnv(base({ DATABASE_URL: undefined }))).toThrow();
+  });
+
+  it('rejects a missing SESSION_SECRET', () => {
+    expect(() => parseEnv(base({ SESSION_SECRET: undefined }))).toThrow();
+  });
+
+  it('rejects a SESSION_SECRET shorter than 32 chars', () => {
+    expect(() => parseEnv(base({ SESSION_SECRET: 'tooshort' }))).toThrow();
+  });
+
+  it('rejects a weak SESSION_SECRET (common word)', () => {
+    expect(() => parseEnv(base({ SESSION_SECRET: 'password'.repeat(5) }))).toThrow();
+  });
+
+  it('rejects a SESSION_SECRET shorter than 64 chars in production', () => {
+    expect(() => parseEnv(base({ NODE_ENV: 'production', SESSION_SECRET: STRONG_32 }))).toThrow();
+  });
+
+  it('accepts a strong 64+ char SESSION_SECRET in production', () => {
+    const env = parseEnv(base({ NODE_ENV: 'production', SESSION_SECRET: STRONG_SECRET }));
+    expect(env.NODE_ENV).toBe('production');
+  });
+});

--- a/packages/api/config/__tests__/env.test.ts
+++ b/packages/api/config/__tests__/env.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { parseEnv } from '../env';
+import { describe, it, expect, vi } from 'vitest';
+import { parseEnv, validateEnvOrExit } from '../env';
 
 // A strong 64-char secret (no repeated halves, no common words); and a strong
 // 32-char secret (valid outside production, too short for production).
@@ -66,5 +66,40 @@ describe('parseEnv', () => {
   it('accepts a strong 64+ char SESSION_SECRET in production', () => {
     const env = parseEnv(base({ NODE_ENV: 'production', SESSION_SECRET: STRONG_SECRET }));
     expect(env.NODE_ENV).toBe('production');
+  });
+});
+
+describe('validateEnvOrExit', () => {
+  function withMocks(fn: (exit: any, err: any) => void) {
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try { fn(exit, err); } finally { exit.mockRestore(); err.mockRestore(); }
+  }
+
+  it('returns the validated config on success', () => {
+    const env = validateEnvOrExit(base() as any);
+    expect(env.DATABASE_URL).toContain('postgresql://');
+  });
+
+  it('exits(1) and prints ONLY the SESSION_SECRET hint for a secret-only failure', () => {
+    withMocks((exit, err) => {
+      validateEnvOrExit(base({ SESSION_SECRET: 'shortsecret' }) as any);
+      expect(exit).toHaveBeenCalledWith(1);
+      const out = err.mock.calls.flat().join('\n');
+      expect(out).toMatch(/SESSION_SECRET/);
+      expect(out).toMatch(/openssl rand -hex 64/);
+      expect(out).not.toMatch(/valid PostgreSQL connection string/);
+    });
+  });
+
+  it('exits(1) and prints ONLY the DATABASE_URL hint for a db-only failure', () => {
+    withMocks((exit, err) => {
+      validateEnvOrExit(base({ DATABASE_URL: undefined }) as any);
+      expect(exit).toHaveBeenCalledWith(1);
+      const out = err.mock.calls.flat().join('\n');
+      expect(out).toMatch(/DATABASE_URL/);
+      expect(out).toMatch(/valid PostgreSQL connection string/);
+      expect(out).not.toMatch(/openssl rand/);
+    });
   });
 });

--- a/packages/api/config/__tests__/env.test.ts
+++ b/packages/api/config/__tests__/env.test.ts
@@ -48,6 +48,17 @@ describe('parseEnv', () => {
     expect(() => parseEnv(base({ SESSION_SECRET: 'password'.repeat(5) }))).toThrow(/weak pattern or common word/);
   });
 
+  it('rejects weak SESSION_SECRETs based on repetition, not just common words', () => {
+    // single-char repeat, 2-char repeat, and whole-string-repeated-twice.
+    expect(() => parseEnv(base({ SESSION_SECRET: 'a'.repeat(64) }))).toThrow(/weak pattern or common word/);
+    expect(() => parseEnv(base({ SESSION_SECRET: 'ab'.repeat(32) }))).toThrow(/weak pattern or common word/);
+    expect(() => parseEnv(base({ SESSION_SECRET: STRONG_32 + STRONG_32 }))).toThrow(/weak pattern or common word/);
+  });
+
+  it('rejects an invalid NODE_ENV value (locks the enum)', () => {
+    expect(() => parseEnv(base({ NODE_ENV: 'foo' }))).toThrow();
+  });
+
   it('rejects a SESSION_SECRET shorter than 64 chars in production (with the 64-char message)', () => {
     expect(() => parseEnv(base({ NODE_ENV: 'production', SESSION_SECRET: STRONG_32 }))).toThrow(/64 characters/);
   });

--- a/packages/api/config/__tests__/env.test.ts
+++ b/packages/api/config/__tests__/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { parseEnv, validateEnvOrExit } from '../env';
+import { parseEnv, validateEnvOrExit, getEnv } from '../env';
 
 // A strong 64-char secret (no repeated halves, no common words); and a strong
 // 32-char secret (valid outside production, too short for production).
@@ -34,6 +34,15 @@ describe('parseEnv', () => {
 
   it('rejects a missing DATABASE_URL', () => {
     expect(() => parseEnv(base({ DATABASE_URL: undefined }))).toThrow();
+  });
+
+  it('rejects a DATABASE_URL that is not a postgres connection string', () => {
+    expect(() => parseEnv(base({ DATABASE_URL: 'not-a-url' }))).toThrow(/postgres/i);
+  });
+
+  it('accepts both postgres:// and postgresql:// schemes', () => {
+    expect(parseEnv(base({ DATABASE_URL: 'postgres://localhost:5432/test' })).DATABASE_URL).toContain('postgres://');
+    expect(parseEnv(base({ DATABASE_URL: 'postgresql://localhost:5432/test' })).DATABASE_URL).toContain('postgresql://');
   });
 
   it('rejects a missing SESSION_SECRET', () => {
@@ -79,6 +88,11 @@ describe('validateEnvOrExit', () => {
   it('returns the validated config on success', () => {
     const env = validateEnvOrExit(base() as any);
     expect(env.DATABASE_URL).toContain('postgresql://');
+  });
+
+  it('caches the validated config for retrieval via getEnv()', () => {
+    const env = validateEnvOrExit(base({ SESSION_SECRET: STRONG_SECRET }) as any);
+    expect(getEnv()).toBe(env);
   });
 
   it('exits(1) and prints ONLY the SESSION_SECRET hint for a secret-only failure', () => {

--- a/packages/api/config/__tests__/env.test.ts
+++ b/packages/api/config/__tests__/env.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { parseEnv } from '../env';
 
-// A strong 64-char secret for production checks.
-const STRONG_SECRET = 'f'.padStart(1, 'f') + '9a3b7c1d2e4f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9';
-const STRONG_32 = '9a3b7c1d2e4f60718293a4b5c6d7e8f9';
+// A strong 64-char secret (no repeated halves, no common words); and a strong
+// 32-char secret (valid outside production, too short for production).
+const STRONG_SECRET = 'a1b2c3d4e5f60718293a4b5c6d7e8f90fedcba9876543210abcdef0123456789';
+const STRONG_32 = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
 
 function base(overrides: Record<string, string | undefined> = {}) {
   return {
@@ -26,6 +27,11 @@ describe('parseEnv', () => {
     expect(env.NODE_ENV).toBe('production');
   });
 
+  it('accepts NODE_ENV=testing (Railway testing / PR-preview env)', () => {
+    const env = parseEnv(base({ NODE_ENV: 'testing' }));
+    expect(env.NODE_ENV).toBe('testing');
+  });
+
   it('rejects a missing DATABASE_URL', () => {
     expect(() => parseEnv(base({ DATABASE_URL: undefined }))).toThrow();
   });
@@ -34,16 +40,16 @@ describe('parseEnv', () => {
     expect(() => parseEnv(base({ SESSION_SECRET: undefined }))).toThrow();
   });
 
-  it('rejects a SESSION_SECRET shorter than 32 chars', () => {
-    expect(() => parseEnv(base({ SESSION_SECRET: 'tooshort' }))).toThrow();
+  it('rejects a SESSION_SECRET shorter than 32 chars (with the length message)', () => {
+    expect(() => parseEnv(base({ SESSION_SECRET: 'abcdefghij0123456789' }))).toThrow(/at least 32 characters/);
   });
 
-  it('rejects a weak SESSION_SECRET (common word)', () => {
-    expect(() => parseEnv(base({ SESSION_SECRET: 'password'.repeat(5) }))).toThrow();
+  it('rejects a weak SESSION_SECRET (with the weak-pattern message)', () => {
+    expect(() => parseEnv(base({ SESSION_SECRET: 'password'.repeat(5) }))).toThrow(/weak pattern or common word/);
   });
 
-  it('rejects a SESSION_SECRET shorter than 64 chars in production', () => {
-    expect(() => parseEnv(base({ NODE_ENV: 'production', SESSION_SECRET: STRONG_32 }))).toThrow();
+  it('rejects a SESSION_SECRET shorter than 64 chars in production (with the 64-char message)', () => {
+    expect(() => parseEnv(base({ NODE_ENV: 'production', SESSION_SECRET: STRONG_32 }))).toThrow(/64 characters/);
   });
 
   it('accepts a strong 64+ char SESSION_SECRET in production', () => {

--- a/packages/api/config/env.ts
+++ b/packages/api/config/env.ts
@@ -11,6 +11,12 @@ import { z } from 'zod';
  * The SESSION_SECRET rules mirror the previous hand-rolled checks in index.ts.
  */
 
+/**
+ * Fail-secure default applied when NODE_ENV is unset. Shared with index.ts's
+ * early `process.env.NODE_ENV` mutation so the two cannot drift.
+ */
+export const DEFAULT_NODE_ENV = 'production';
+
 // Weak-secret detection (repeated chars/patterns and common words).
 const WEAK_SECRET_PATTERNS = [
   /^(.)\1+$/,           // single repeated character
@@ -24,7 +30,7 @@ const envSchema = z
     // All environments actually used: local dev, the vitest harness ('test'),
     // Railway's testing/PR-preview env ('testing'), staging, and production.
     // Omitting a real value here would process.exit(1) that deployment at boot.
-    NODE_ENV: z.enum(['development', 'test', 'testing', 'staging', 'production']).default('production'),
+    NODE_ENV: z.enum(['development', 'test', 'testing', 'staging', 'production']).default(DEFAULT_NODE_ENV),
     DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
     SESSION_SECRET: z
       .string()
@@ -71,10 +77,19 @@ export function validateEnvOrExit(source: NodeJS.ProcessEnv = process.env): Env 
   const result = envSchema.safeParse(source);
   if (!result.success) {
     console.error('❌ FATAL: Invalid environment configuration:');
+    const failedFields = new Set<string>();
     for (const issue of result.error.issues) {
-      console.error(`   - ${issue.path.join('.') || '(root)'}: ${issue.message}`);
+      const field = issue.path.join('.') || '(root)';
+      failedFields.add(field);
+      console.error(`   - ${field}: ${issue.message}`);
     }
-    console.error('   Generate a secure SESSION_SECRET: openssl rand -hex 64');
+    // Targeted remediation hints only for the fields that actually failed.
+    if (failedFields.has('SESSION_SECRET')) {
+      console.error('   Generate a secure SESSION_SECRET: openssl rand -hex 64');
+    }
+    if (failedFields.has('DATABASE_URL')) {
+      console.error('   Set DATABASE_URL to a valid PostgreSQL connection string.');
+    }
     process.exit(1);
   }
   return result.data;

--- a/packages/api/config/env.ts
+++ b/packages/api/config/env.ts
@@ -18,6 +18,10 @@ import { z } from 'zod';
 export const DEFAULT_NODE_ENV = 'production';
 
 // Weak-secret detection (repeated chars/patterns and common words).
+// NOTE: /^(.*)\1$/ uses a backreference that can backtrack super-linearly on
+// near-repeating input. This is safe here because SESSION_SECRET comes from the
+// operator's environment (not user input) and is short and bounded, so it is not
+// a ReDoS vector.
 const WEAK_SECRET_PATTERNS = [
   /^(.)\1+$/,           // single repeated character
   /^(..)\1+$/,          // repeated 2-char pattern

--- a/packages/api/config/env.ts
+++ b/packages/api/config/env.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+/**
+ * Centralized, validated environment configuration.
+ *
+ * `parseEnv` validates a source object (default process.env) and returns a typed
+ * result, throwing a ZodError on invalid input — pure and unit-testable.
+ * `validateEnvOrExit` is the startup wrapper: it prints a readable report and
+ * exits the process on failure. Call it once, early, from the server entrypoint.
+ *
+ * The SESSION_SECRET rules mirror the previous hand-rolled checks in index.ts.
+ */
+
+// Weak-secret detection (repeated chars/patterns and common words).
+const WEAK_SECRET_PATTERNS = [
+  /^(.)\1+$/,           // single repeated character
+  /^(..)\1+$/,          // repeated 2-char pattern
+  /^(.*)\1$/,           // whole string repeated twice
+  /password|secret|test|dev|admin|default|change|temp/i, // common weak words
+];
+
+const envSchema = z
+  .object({
+    NODE_ENV: z.enum(['development', 'test', 'staging', 'production']).default('production'),
+    DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+    SESSION_SECRET: z
+      .string()
+      .min(32, 'SESSION_SECRET must be at least 32 characters long'),
+    // Optional — the app has fallbacks for these.
+    ADMIN_USER: z.string().optional(),
+    ADMIN_EMAIL: z.string().optional(),
+    ADMIN_PASSWORD: z.string().optional(),
+    APP_URL: z.string().optional(),
+    BASE_URL: z.string().optional(),
+  })
+  .superRefine((env, ctx) => {
+    if (WEAK_SECRET_PATTERNS.some((p) => p.test(env.SESSION_SECRET))) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['SESSION_SECRET'],
+        message: 'SESSION_SECRET contains a weak pattern or common word',
+      });
+    }
+    if (env.NODE_ENV === 'production' && env.SESSION_SECRET.length < 64) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['SESSION_SECRET'],
+        message: 'Production SESSION_SECRET must be at least 64 characters long',
+      });
+    }
+  });
+
+export type Env = z.infer<typeof envSchema>;
+
+/**
+ * Validate an environment source, throwing on invalid input. Pure — no process
+ * side effects — so it can be unit-tested.
+ */
+export function parseEnv(source: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env): Env {
+  return envSchema.parse(source);
+}
+
+/**
+ * Validate process.env at startup, printing a readable report and exiting the
+ * process if configuration is invalid. Returns the typed, validated config.
+ */
+export function validateEnvOrExit(source: NodeJS.ProcessEnv = process.env): Env {
+  const result = envSchema.safeParse(source);
+  if (!result.success) {
+    console.error('❌ FATAL: Invalid environment configuration:');
+    for (const issue of result.error.issues) {
+      console.error(`   - ${issue.path.join('.') || '(root)'}: ${issue.message}`);
+    }
+    console.error('   Generate a secure SESSION_SECRET: openssl rand -hex 64');
+    process.exit(1);
+  }
+  return result.data;
+}

--- a/packages/api/config/env.ts
+++ b/packages/api/config/env.ts
@@ -35,14 +35,26 @@ const envSchema = z
     // Railway's testing/PR-preview env ('testing'), staging, and production.
     // Omitting a real value here would process.exit(1) that deployment at boot.
     NODE_ENV: z.enum(['development', 'test', 'testing', 'staging', 'production']).default(DEFAULT_NODE_ENV),
-    DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+    // Must be a postgres connection string, not merely a non-empty string —
+    // a typo'd value like "not-a-url" should fail fast at boot, not surface as
+    // an opaque connection error on the first query. Accepts both the
+    // `postgres://` and `postgresql://` schemes (Neon/libpq treat them alike).
+    DATABASE_URL: z
+      .string()
+      .min(1, 'DATABASE_URL is required')
+      .regex(/^postgres(ql)?:\/\//, 'DATABASE_URL must be a postgres:// or postgresql:// connection string'),
     SESSION_SECRET: z
       .string()
       .min(32, 'SESSION_SECRET must be at least 32 characters long'),
     // Optional — the app has fallbacks for these.
     ADMIN_USER: z.string().optional(),
     ADMIN_EMAIL: z.string().optional(),
+    // The codebase reads the seeded admin password under two names: routes.ts
+    // uses ADMIN_PASSWORD, packages/api/seed.ts uses ADMIN_PASS. Declare both so
+    // the typed schema documents the real surface and neither is dropped once
+    // call sites migrate to reading the validated config instead of process.env.
     ADMIN_PASSWORD: z.string().optional(),
+    ADMIN_PASS: z.string().optional(),
     APP_URL: z.string().optional(),
     BASE_URL: z.string().optional(),
   })
@@ -73,9 +85,25 @@ export function parseEnv(source: NodeJS.ProcessEnv | Record<string, string | und
   return envSchema.parse(source);
 }
 
+let cachedEnv: Env | null = null;
+
+/**
+ * The typed, validated configuration — populated by validateEnvOrExit() at
+ * startup. Call sites can read strongly-typed config here instead of reaching
+ * into raw process.env. Throws if accessed before validation has run (a
+ * programming error: validateEnvOrExit() is the first thing index.ts does).
+ */
+export function getEnv(): Env {
+  if (!cachedEnv) {
+    throw new Error('getEnv() called before validateEnvOrExit() — env not yet validated');
+  }
+  return cachedEnv;
+}
+
 /**
  * Validate process.env at startup, printing a readable report and exiting the
- * process if configuration is invalid. Returns the typed, validated config.
+ * process if configuration is invalid. Returns the typed, validated config and
+ * caches it for later retrieval via getEnv().
  */
 export function validateEnvOrExit(source: NodeJS.ProcessEnv = process.env): Env {
   const result = envSchema.safeParse(source);
@@ -96,5 +124,6 @@ export function validateEnvOrExit(source: NodeJS.ProcessEnv = process.env): Env 
     }
     process.exit(1);
   }
+  cachedEnv = result.data;
   return result.data;
 }

--- a/packages/api/config/env.ts
+++ b/packages/api/config/env.ts
@@ -21,7 +21,10 @@ const WEAK_SECRET_PATTERNS = [
 
 const envSchema = z
   .object({
-    NODE_ENV: z.enum(['development', 'test', 'staging', 'production']).default('production'),
+    // All environments actually used: local dev, the vitest harness ('test'),
+    // Railway's testing/PR-preview env ('testing'), staging, and production.
+    // Omitting a real value here would process.exit(1) that deployment at boot.
+    NODE_ENV: z.enum(['development', 'test', 'testing', 'staging', 'production']).default('production'),
     DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
     SESSION_SECRET: z
       .string()

--- a/packages/api/config/env.ts
+++ b/packages/api/config/env.ts
@@ -59,6 +59,11 @@ const envSchema = z
     BASE_URL: z.string().optional(),
   })
   .superRefine((env, ctx) => {
+    // If SESSION_SECRET is missing or not a string, the base z.string() check
+    // has already reported it. Skip the strength checks so we never read
+    // `.length` on undefined — defensive against a future Zod running this
+    // refinement on a dirty parse (today it aborts the field and skips this).
+    if (typeof env.SESSION_SECRET !== 'string') return;
     if (WEAK_SECRET_PATTERNS.some((p) => p.test(env.SESSION_SECRET))) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -85,6 +90,9 @@ export function parseEnv(source: NodeJS.ProcessEnv | Record<string, string | und
   return envSchema.parse(source);
 }
 
+// Populated once at startup by validateEnvOrExit(). Last-write-wins by design:
+// startup calls it exactly once, so the only repeat callers are unit tests,
+// which intentionally overwrite it with their own fixture.
 let cachedEnv: Env | null = null;
 
 /**

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -7,6 +7,7 @@ import { startWellnessDigestJob, stopWellnessDigestJob } from "./jobs/wellness-d
 import { startWellnessScheduledJob, stopWellnessScheduledJob } from "./jobs/wellness-scheduled-job";
 import { startCoppaTokenCleanupJob, stopCoppaTokenCleanupJob } from "./jobs/coppa-token-cleanup";
 import { registerProcessSafetyHandlers } from "./lib/process-safety";
+import { validateEnvOrExit } from "./config/env";
 
 // Default NODE_ENV to production for security (fail-secure approach)
 // Production mode ensures: error sanitization, rate limiting, secure cookies
@@ -17,43 +18,10 @@ if (!process.env.NODE_ENV) {
   console.warn('   Set NODE_ENV=development explicitly for local development');
 }
 
-// Validate SESSION_SECRET is set and meets security requirements
-if (!process.env.SESSION_SECRET) {
-  console.error('❌ FATAL: SESSION_SECRET environment variable not set');
-  console.error('   Generate a secure secret: openssl rand -hex 32');
-  process.exit(1);
-}
-
-const sessionSecret = process.env.SESSION_SECRET;
-
-// Length validation
-if (sessionSecret.length < 32) {
-  console.error('❌ FATAL: SESSION_SECRET must be at least 32 characters long');
-  console.error('   Generate a secure secret: openssl rand -hex 32');
-  process.exit(1);
-}
-
-// Entropy validation - check for weak patterns
-const weakPatterns = [
-  /^(.)\1+$/,           // Repeated character (e.g., "aaaaaaaaaa...")
-  /^(..)\1+$/,          // Repeated 2-char pattern (e.g., "ababababab...")
-  /^(.*)\1$/,           // String repeated twice (e.g., "abcabc")
-  /password|secret|test|dev|admin|default|change|temp/i  // Common weak words
-];
-
-if (weakPatterns.some(pattern => pattern.test(sessionSecret))) {
-  console.error('❌ FATAL: SESSION_SECRET contains weak pattern or common words');
-  console.error('   Your secret appears to be predictable or insecure');
-  console.error('   Generate a secure secret: openssl rand -hex 32');
-  process.exit(1);
-}
-
-// Production environment requires higher entropy (64+ characters)
-if (process.env.NODE_ENV === 'production' && sessionSecret.length < 64) {
-  console.error('❌ FATAL: Production SESSION_SECRET must be at least 64 characters long');
-  console.error('   Generate a secure production secret: openssl rand -hex 64');
-  process.exit(1);
-}
+// Validate all required environment configuration once, at startup. This folds
+// in the SESSION_SECRET length/entropy/production rules and fails fast (with a
+// readable report) on any misconfiguration. See packages/api/config/env.ts.
+validateEnvOrExit();
 
 const app = express();
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -20,7 +20,8 @@ if (!process.env.NODE_ENV) {
 
 // Validate all required environment configuration once, at startup. This folds
 // in the SESSION_SECRET length/entropy/production rules and fails fast (with a
-// readable report) on any misconfiguration. See packages/api/config/env.ts.
+// readable report) on any misconfiguration. The returned config is also cached
+// for typed retrieval elsewhere via getEnv(). See packages/api/config/env.ts.
 validateEnvOrExit();
 
 const app = express();

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -7,13 +7,13 @@ import { startWellnessDigestJob, stopWellnessDigestJob } from "./jobs/wellness-d
 import { startWellnessScheduledJob, stopWellnessScheduledJob } from "./jobs/wellness-scheduled-job";
 import { startCoppaTokenCleanupJob, stopCoppaTokenCleanupJob } from "./jobs/coppa-token-cleanup";
 import { registerProcessSafetyHandlers } from "./lib/process-safety";
-import { validateEnvOrExit } from "./config/env";
+import { validateEnvOrExit, DEFAULT_NODE_ENV } from "./config/env";
 
 // Default NODE_ENV to production for security (fail-secure approach)
 // Production mode ensures: error sanitization, rate limiting, secure cookies
 // This is safer than failing or defaulting to development mode
 if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = 'production';
+  process.env.NODE_ENV = DEFAULT_NODE_ENV;
   console.warn('⚠️  NODE_ENV not set, defaulting to production for security');
   console.warn('   Set NODE_ENV=development explicitly for local development');
 }

--- a/tests/server/startup-validation.test.ts
+++ b/tests/server/startup-validation.test.ts
@@ -146,16 +146,15 @@ describe('Server Startup Validation', () => {
       }
 
       expect(mockExit).toHaveBeenCalledWith(1);
-      // Check that the SESSION_SECRET validation error was logged
+      // The validation error output references SESSION_SECRET. The exact message
+      // is covered by config/env's unit tests.
       const errorCalls = mockConsoleError.mock.calls.flat();
-      expect(errorCalls).toContainEqual(
-        '❌ FATAL: SESSION_SECRET environment variable not set'
-      );
+      expect(errorCalls.some((c) => typeof c === 'string' && c.includes('SESSION_SECRET'))).toBe(true);
     });
 
     it('should exit with code 1 if SESSION_SECRET is less than 32 characters', async () => {
       process.env.NODE_ENV = 'production';
-      process.env.SESSION_SECRET = 'a'.repeat(31); // 31 characters
+      process.env.SESSION_SECRET = 'c7f8a9b2e4d6f1a3c5e7b9d1f3a5c7e'; // 31 chars (non-repeating)
       // Set other required env vars
       process.env.ADMIN_EMAIL = 'test@example.com';
       process.env.ADMIN_PASSWORD = 'test-password-123';
@@ -168,11 +167,8 @@ describe('Server Startup Validation', () => {
       }
 
       expect(mockExit).toHaveBeenCalledWith(1);
-      // Check that the SESSION_SECRET length validation error was logged
       const errorCalls = mockConsoleError.mock.calls.flat();
-      expect(errorCalls).toContainEqual(
-        '❌ FATAL: SESSION_SECRET must be at least 32 characters long'
-      );
+      expect(errorCalls.some((c) => typeof c === 'string' && c.includes('SESSION_SECRET'))).toBe(true);
     });
 
     it('should reject SESSION_SECRET with only 32 characters in production', async () => {
@@ -189,10 +185,8 @@ describe('Server Startup Validation', () => {
       // Should have called exit due to insufficient SESSION_SECRET length for production
       expect(mockExit).toHaveBeenCalledWith(1);
 
-      const errorCalls = mockConsoleError.mock.calls.map(call => call[0]);
-      expect(errorCalls).toContainEqual(
-        '❌ FATAL: Production SESSION_SECRET must be at least 64 characters long'
-      );
+      const errorCalls = mockConsoleError.mock.calls.flat();
+      expect(errorCalls.some((c) => typeof c === 'string' && c.includes('SESSION_SECRET'))).toBe(true);
     });
 
     it('should accept SESSION_SECRET with more than 32 characters', async () => {
@@ -238,9 +232,7 @@ describe('Server Startup Validation', () => {
       );
       // Then SESSION_SECRET validation should fail
       const errorCalls = mockConsoleError.mock.calls.flat();
-      expect(errorCalls).toContainEqual(
-        '❌ FATAL: SESSION_SECRET environment variable not set'
-      );
+      expect(errorCalls.some((c) => typeof c === 'string' && c.includes('SESSION_SECRET'))).toBe(true);
     });
 
     it('should pass validation with all required environment variables set', async () => {

--- a/tests/server/startup-validation.test.ts
+++ b/tests/server/startup-validation.test.ts
@@ -209,6 +209,12 @@ describe('Server Startup Validation', () => {
     });
   });
 
+  // Note: a startup-level "missing DATABASE_URL exits" test is intentionally not
+  // added here — index.ts's transitive imports read DATABASE_URL at import time
+  // and can throw before validateEnvOrExit runs, making such a test order-
+  // dependent. The DATABASE_URL requirement is covered deterministically by the
+  // parseEnv unit tests in config/__tests__/env.test.ts.
+
   describe('Combined validation', () => {
     it('should default NODE_ENV then validate SESSION_SECRET', async () => {
       delete process.env.NODE_ENV;


### PR DESCRIPTION
## Item 16 — validated env config

### Problem
Environment access was ad-hoc — ~294 scattered `process.env` reads across 77 files, with only `SESSION_SECRET` hand-validated (~35 lines) in `index.ts`. A typo'd or missing var failed deep inside a request handler at runtime instead of at boot.

### Change
New `packages/api/config/env.ts`:
- A Zod schema that **requires `DATABASE_URL` and `SESSION_SECRET`** and folds in the existing `SESSION_SECRET` rules (min 32, production min 64, weak-pattern/common-word rejection).
- **`parseEnv(source)`** — pure, throws a `ZodError` on invalid input, unit-testable.
- **`validateEnvOrExit(source)`** — startup wrapper: prints a readable multi-issue report and `process.exit(1)` on misconfiguration.

`index.ts` now calls `validateEnvOrExit()` in place of the hand-rolled block, and additionally **fails fast on a missing `DATABASE_URL`** (previously unchecked at startup).

### Testing
- `config/__tests__/env.test.ts` — 8 cases covering accept/reject (missing DB URL, missing/short/weak secret, prod-64, valid).
- `startup-validation.test.ts` updated to assert the *integration* (index.ts exits + output references the bad var) rather than exact old error strings — validation logic is now owned by the env unit tests.
- Full unit suite green; `tsc` clean. (Integration tests don't import `index.ts`, so they're unaffected; `validateEnvOrExit` only runs at real server startup.)

### Scope note
This establishes the validated entrypoint and the typed `Env`. Migrating the remaining ~294 scattered `process.env` reads onto the typed config is incremental follow-up, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralize and validate API environment configuration at startup using a shared schema and helper, replacing ad-hoc SESSION_SECRET checks.

New Features:
- Introduce a Zod-based env schema that requires DATABASE_URL and SESSION_SECRET and exposes a typed Env configuration object.
- Add parseEnv and validateEnvOrExit helpers to validate environment sources and fail fast with a readable error report at server startup.

Enhancements:
- Replace inline SESSION_SECRET validation in the API entrypoint with a single call to the centralized env validator.
- Relax startup tests to assert presence of SESSION_SECRET-related errors rather than specific legacy message text.

Tests:
- Add focused unit tests for env configuration validation covering required variables, strength rules, and production requirements.