### PR TITLE
test(coppa): extract exactlyAge into a shared helper

### DIFF
--- a/tests/integration/athlete-parent-email.test.ts
+++ b/tests/integration/athlete-parent-email.test.ts
@@ -60,28 +60,8 @@ function uid() {
   return crypto.randomBytes(4).toString('hex');
 }
 
-/** Build a YYYY-MM-DD date string for someone exactly `years` years old today */
-function exactlyAge(years: number): string {
-  // Use LOCAL date components (not toISOString, which is UTC): calculateAge
-  // parses YYYY-MM-DD as local midnight, so a UTC-formatted date shifts a day at
-  // the boundary and makes an exactly-N-year-old read as N-1.
-  const d = new Date();
-  d.setFullYear(d.getFullYear() - years);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-
-/** Build a YYYY-MM-DD date string for a minor (14 years old by default) */
-function minorBirthDate(): string {
-  return exactlyAge(14);
-}
-
-/** Build a YYYY-MM-DD date string for an adult (25 years old) */
-function adultBirthDate(): string {
-  return exactlyAge(25);
-}
+// Date-of-birth helpers are shared to keep the timezone-safe logic in one place.
+import { exactlyAge, minorBirthDate, adultBirthDate } from '../shared/age-helpers';
 
 async function createUser(
   suffix: string,

--- a/tests/integration/profile-parent-email.test.ts
+++ b/tests/integration/profile-parent-email.test.ts
@@ -58,18 +58,8 @@ function uid() {
   return crypto.randomBytes(4).toString('hex');
 }
 
-/** Build a YYYY-MM-DD date string for someone exactly `years` years old today */
-function exactlyAge(years: number): string {
-  // Use LOCAL date components (not toISOString, which is UTC): calculateAge
-  // parses YYYY-MM-DD as local midnight, so a UTC-formatted date shifts a day at
-  // the boundary and makes an exactly-N-year-old read as N-1.
-  const d = new Date();
-  d.setFullYear(d.getFullYear() - years);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
+// Shared timezone-safe date-of-birth helper.
+import { exactlyAge } from '../shared/age-helpers';
 
 async function createAthlete(
   suffix: string,

--- a/tests/integration/registration-minor.test.ts
+++ b/tests/integration/registration-minor.test.ts
@@ -39,18 +39,8 @@ import { registerRoutes } from '../../packages/api/routes';
 // Helpers
 // ============================================================================
 
-/** Build a YYYY-MM-DD date string for someone who is exactly `years` years old today */
-function exactlyAge(years: number): string {
-  // Use LOCAL date components (not toISOString, which is UTC): calculateAge
-  // parses YYYY-MM-DD as local midnight, so a UTC-formatted date shifts a day at
-  // the boundary and makes an exactly-N-year-old read as N-1.
-  const d = new Date();
-  d.setFullYear(d.getFullYear() - years);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
+// Shared timezone-safe date-of-birth helper.
+import { exactlyAge } from '../shared/age-helpers';
 
 /** Build a YYYY-MM-DD date string for someone whose birthday is `days` days from now,
  *  but was born `years` years ago minus those days.

--- a/tests/shared/age-helpers.ts
+++ b/tests/shared/age-helpers.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared date-of-birth helpers for COPPA age-boundary tests.
+ *
+ * IMPORTANT: use LOCAL date components (not toISOString, which is UTC). The
+ * server's calculateAge parses YYYY-MM-DD as local midnight, so a UTC-formatted
+ * date shifts a day at the boundary and makes an exactly-N-year-old read as N-1.
+ */
+
+/** A YYYY-MM-DD string for someone exactly `years` years old today (local time). */
+export function exactlyAge(years: number): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - years);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** A YYYY-MM-DD string for a minor (14 years old by default). */
+export function minorBirthDate(): string {
+  return exactlyAge(14);
+}
+
+/** A YYYY-MM-DD string for an adult (25 years old). */
+export function adultBirthDate(): string {
+  return exactlyAge(25);
+}


### PR DESCRIPTION
Follow-up cleanup from the code review of the (now-merged) authorization PR #462: the timezone-safe `exactlyAge` helper was copy-pasted verbatim into three integration test files. A future correction would have to touch all three, and missing one silently reintroduces the UTC off-by-one bug. Extracted into `tests/shared/age-helpers.ts` (with `minorBirthDate`/`adultBirthDate`) and imported.

tsc clean; the three affected suites pass (29 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract shared timezone-safe date-of-birth helpers for COPPA-related tests and update integration suites to use them.

Enhancements:
- Deduplicate the timezone-safe exactlyAge helper by moving it into a shared tests/shared/age-helpers module.
- Introduce reusable minorBirthDate and adultBirthDate helpers for age-boundary test scenarios.

Tests:
- Update COPPA-related integration tests to import and use the shared age helper functions instead of local implementations.