### PR TITLE
fix(coppa): enforce parental-consent age gate on the invitation path (P0-11)

### DIFF
--- a/migrations/0139_add_invitation_coppa_fields.sql
+++ b/migrations/0139_add_invitation_coppa_fields.sql
@@ -1,0 +1,11 @@
+-- Migration 0139: Add COPPA fields to invitations
+--
+-- Coach-side age capture at invite-create time (coppa-compliance-spec,
+-- "Invitation flow modification"): an athlete invitation with an under-13
+-- birth_date cannot be created without a parent_email, so the VPC flow can
+-- fire at accept time even if the athlete's form omits the parent email.
+-- Both columns are nullable — the coach may not know the athlete's DOB, in
+-- which case the accept-time age gate remains the backstop.
+
+ALTER TABLE invitations ADD COLUMN IF NOT EXISTS birth_date DATE;
+ALTER TABLE invitations ADD COLUMN IF NOT EXISTS parent_email TEXT;

--- a/migrations/0139_add_invitation_coppa_fields_down.sql
+++ b/migrations/0139_add_invitation_coppa_fields_down.sql
@@ -1,0 +1,6 @@
+-- Down Migration 0139: Remove COPPA fields from invitations
+--
+-- Safe to drop: the columns only pre-fill the accept-time age gate; the
+-- authoritative COPPA state lives on users/parental_consents.
+ALTER TABLE invitations DROP COLUMN IF EXISTS birth_date;
+ALTER TABLE invitations DROP COLUMN IF EXISTS parent_email;

--- a/packages/api/routes/invitation-routes.ts
+++ b/packages/api/routes/invitation-routes.ts
@@ -991,19 +991,28 @@ export function registerInvitationRoutes(app: Express) {
       }
 
       // ── COPPA age classification (P0-11) ────────────────────────────────
-      // Effective birthDate precedence: linked player record (server-known,
-      // coach-entered) wins over the form value — a form entry cannot
+      // Effective birthDate precedence: linked player record > invitation
+      // (coach-entered at invite-create) > form value — a form entry cannot
       // reclassify someone the server already knows the age of.
       // All validation failures below early-return 400 BEFORE acceptInvitation:
       // the catch block increments attemptCount and locks the invitation.
       let effectiveBirthDate: string | undefined =
         typeof birthDate === 'string' && birthDate !== '' ? birthDate : undefined;
+      if (invitation.birthDate) {
+        effectiveBirthDate = String(invitation.birthDate);
+      }
       if (invitation.playerId) {
         const linkedPlayer = await storage.getUser(invitation.playerId);
         if (linkedPlayer?.birthDate) {
           effectiveBirthDate = String(linkedPlayer.birthDate);
         }
       }
+
+      // Parent email: the form value wins (fresher), falling back to the
+      // coach-provided value stored on the invitation.
+      const effectiveParentEmail: string | undefined =
+        normalizedParentEmail
+        ?? (invitation.parentEmail ? String(invitation.parentEmail).toLowerCase() : undefined);
 
       if (invitation.role === 'athlete' && !effectiveBirthDate) {
         return res.status(400).json({ message: "Date of birth is required to accept an athlete invitation." });
@@ -1024,10 +1033,10 @@ export function registerInvitationRoutes(app: Express) {
       if (under13 && invitation.role !== 'athlete') {
         return res.status(400).json({ message: "This invitation role requires an adult. Please contact your organization." });
       }
-      if (under13 && !normalizedParentEmail) {
+      if (under13 && !effectiveParentEmail) {
         return res.status(400).json({ message: "A parent or guardian email is required for athletes under 13." });
       }
-      if (normalizedParentEmail && normalizedParentEmail === invitation.email.toLowerCase()) {
+      if (effectiveParentEmail && effectiveParentEmail === invitation.email.toLowerCase()) {
         return res.status(400).json({ message: "Parent email must be different from the athlete's email." });
       }
 
@@ -1046,7 +1055,7 @@ export function registerInvitationRoutes(app: Express) {
               birthDate: effectiveBirthDate,
               isMinor: minor,
               under13,
-              parentEmail: minor ? normalizedParentEmail : undefined,
+              parentEmail: minor ? effectiveParentEmail : undefined,
             }
           } : {}),
         },
@@ -1094,7 +1103,7 @@ export function registerInvitationRoutes(app: Express) {
         // (initiateConsent runs its own transaction and sends the parent
         // email). No session, no welcome email — confirmConsent notifies
         // the athlete when the parent approves.
-        const consentParentEmail = normalizedParentEmail || result.user.parentEmail;
+        const consentParentEmail = effectiveParentEmail || result.user.parentEmail;
         let consentEmailSent: boolean | undefined;
         if (consentParentEmail) {
           const coppaResult = await coppaService.initiateConsent({
@@ -1123,10 +1132,10 @@ export function registerInvitationRoutes(app: Express) {
       // the parent (informational, not a consent request), then continue to
       // the normal session flow. Conflict-safe: Path A/B users may already
       // have a link row for this parent.
-      if (teenMinor && normalizedParentEmail) {
+      if (teenMinor && effectiveParentEmail) {
         try {
           await db.insert(parentAthleteLinks).values({
-            parentEmail: normalizedParentEmail,
+            parentEmail: effectiveParentEmail,
             athleteUserId: result.user.id,
             organizationId: invitation.organizationId,
             isActive: true,
@@ -1136,7 +1145,7 @@ export function registerInvitationRoutes(app: Express) {
           // Non-fatal: account creation already succeeded
         }
         emailService.sendParentNotification({
-          parentEmail: normalizedParentEmail,
+          parentEmail: effectiveParentEmail,
           athleteFirstName: result.user.firstName,
         }).catch((err: unknown) => {
           console.error('[InvitationAcceptance] Failed to send parent notification email:', err);

--- a/packages/api/routes/invitation-routes.ts
+++ b/packages/api/routes/invitation-routes.ts
@@ -23,6 +23,8 @@ import {
 } from "@shared/legal-acceptance";
 import { db } from "../db";
 import { parentAthleteLinks } from "@shared/schema/tables/coppa";
+import { isUnder13, isMinorAge } from "@shared/coppa-utils";
+import { coppaService } from "../services/coppa-service";
 import crypto from "crypto";
 import { hashToken } from "../lib/token-hash";
 
@@ -820,11 +822,25 @@ export function registerInvitationRoutes(app: Express) {
   app.post("/api/invitations/:token/accept", authLimiter, async (req, res) => {
     try {
       const { token } = req.params;
-      const { password, firstName, lastName, username, legalAcceptedAt } = req.body;
+      const { password, firstName, lastName, username, legalAcceptedAt, birthDate, parentEmail } = req.body;
 
       // Validate legal acceptance is provided and valid
       if (!legalAcceptedAt) {
         return res.status(400).json({ message: MISSING_ACCEPTANCE_MESSAGE });
+      }
+
+      // COPPA format checks (role/age-dependent rules run after the invitation
+      // is fetched, since requiredness depends on invitation.role).
+      // Note: the frontend requires birthDate for every role; the server only
+      // requires it for athletes — intentional belt-and-suspenders.
+      if (birthDate !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(String(birthDate))) {
+        return res.status(400).json({ message: "birthDate must be in YYYY-MM-DD format" });
+      }
+      const normalizedParentEmail: string | undefined = typeof parentEmail === 'string' && parentEmail.trim() !== ''
+        ? parentEmail.trim().toLowerCase()
+        : undefined;
+      if (normalizedParentEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedParentEmail)) {
+        return res.status(400).json({ message: "parentEmail must be a valid email address" });
       }
 
       if (!validateLegalAcceptanceTimestamp(legalAcceptedAt)) {
@@ -911,6 +927,47 @@ export function registerInvitationRoutes(app: Express) {
         return res.status(429).json({ message: "Too many failed attempts. This invitation has been locked." });
       }
 
+      // ── COPPA age classification (P0-11) ────────────────────────────────
+      // Effective birthDate precedence: linked player record (server-known,
+      // coach-entered) wins over the form value — a form entry cannot
+      // reclassify someone the server already knows the age of.
+      // All validation failures below early-return 400 BEFORE acceptInvitation:
+      // the catch block increments attemptCount and locks the invitation.
+      let effectiveBirthDate: string | undefined =
+        typeof birthDate === 'string' && birthDate !== '' ? birthDate : undefined;
+      if (invitation.playerId) {
+        const linkedPlayer = await storage.getUser(invitation.playerId);
+        if (linkedPlayer?.birthDate) {
+          effectiveBirthDate = String(linkedPlayer.birthDate);
+        }
+      }
+
+      if (invitation.role === 'athlete' && !effectiveBirthDate) {
+        return res.status(400).json({ message: "Date of birth is required to accept an athlete invitation." });
+      }
+
+      let under13 = false;
+      let minor = false;
+      if (effectiveBirthDate) {
+        try {
+          under13 = isUnder13(effectiveBirthDate);
+          minor = isMinorAge(effectiveBirthDate);
+        } catch {
+          return res.status(400).json({ message: "Invalid date of birth." });
+        }
+      }
+      const teenMinor = minor && !under13;
+
+      if (under13 && invitation.role !== 'athlete') {
+        return res.status(400).json({ message: "This invitation role requires an adult. Please contact your organization." });
+      }
+      if (under13 && !normalizedParentEmail) {
+        return res.status(400).json({ message: "A parent or guardian email is required for athletes under 13." });
+      }
+      if (normalizedParentEmail && normalizedParentEmail === invitation.email.toLowerCase()) {
+        return res.status(400).json({ message: "Parent email must be different from the athlete's email." });
+      }
+
       const result = await storage.acceptInvitation(
         token,
         {
@@ -921,6 +978,14 @@ export function registerInvitationRoutes(app: Express) {
           lastName,
           legalAcceptedAt,
           legalAcceptedVersion: getLegalAcceptanceTimestamp(), // Format: "2024-12-13"
+          ...(effectiveBirthDate ? {
+            coppa: {
+              birthDate: effectiveBirthDate,
+              isMinor: minor,
+              under13,
+              parentEmail: minor ? normalizedParentEmail : undefined,
+            }
+          } : {}),
         },
         {
           ipAddress: req.ip,
@@ -948,6 +1013,71 @@ export function registerInvitationRoutes(app: Express) {
           console.error('[InvitationAcceptance] Failed to create parent athlete link:', linkError);
           // Non-fatal: user account and org membership already created
         }
+      }
+
+      // ── COPPA session gate ──────────────────────────────────────────────
+      // Gate on the FINAL user row, not just the form-derived classification:
+      // an existing account joining a new org may already be pending_consent
+      // or consent_revoked, and must not receive a session here that the
+      // login route would refuse.
+      if (result.user.coppaStatus === 'consent_revoked') {
+        return res.status(403).json({
+          message: "Parental consent for this account was revoked. Please contact your organization or support to re-initiate consent."
+        });
+      }
+
+      if (result.user.coppaStatus === 'pending_consent') {
+        // Under-13: initiate VPC AFTER the accept transaction committed
+        // (initiateConsent runs its own transaction and sends the parent
+        // email). No session, no welcome email — confirmConsent notifies
+        // the athlete when the parent approves.
+        const consentParentEmail = normalizedParentEmail || result.user.parentEmail;
+        let consentEmailSent: boolean | undefined;
+        if (consentParentEmail) {
+          const coppaResult = await coppaService.initiateConsent({
+            athleteUserId: result.user.id,
+            parentEmail: consentParentEmail,
+            organizationId: invitation.organizationId,
+            ip: req.ip,
+            userAgent: req.get('User-Agent'),
+          });
+          consentEmailSent = coppaResult.emailSent;
+          console.log(`[InvitationAcceptance] Minor accepted invite: ${result.user.id}, VPC initiated: ${coppaResult.success}, emailSent: ${coppaResult.emailSent}`);
+        }
+
+        const consentMessage = consentEmailSent === false
+          ? "Your account has been created. We were unable to send the consent email to your parent. Please ask them to visit the consent page directly, or try again later."
+          : "Your account has been created. A consent email has been sent to your parent or guardian. You'll be able to log in once they approve your account.";
+
+        return res.json({
+          success: true,
+          requiresParentalConsent: true,
+          message: consentMessage,
+        });
+      }
+
+      // Teen minor (13-17) with a parent email: record the link and notify
+      // the parent (informational, not a consent request), then continue to
+      // the normal session flow. Conflict-safe: Path A/B users may already
+      // have a link row for this parent.
+      if (teenMinor && normalizedParentEmail) {
+        try {
+          await db.insert(parentAthleteLinks).values({
+            parentEmail: normalizedParentEmail,
+            athleteUserId: result.user.id,
+            organizationId: invitation.organizationId,
+            isActive: true,
+          }).onConflictDoNothing();
+        } catch (linkError) {
+          console.error('[InvitationAcceptance] Failed to create teen parent link:', linkError);
+          // Non-fatal: account creation already succeeded
+        }
+        emailService.sendParentNotification({
+          parentEmail: normalizedParentEmail,
+          athleteFirstName: result.user.firstName,
+        }).catch((err: unknown) => {
+          console.error('[InvitationAcceptance] Failed to send parent notification email:', err);
+        });
       }
 
       // Send welcome email

--- a/packages/api/routes/invitation-routes.ts
+++ b/packages/api/routes/invitation-routes.ts
@@ -193,8 +193,8 @@ export function registerInvitationRoutes(app: Express) {
         return res.status(400).json({ message: "parentEmail must be a valid email address" });
       }
 
-      /** Under-13/parent-email rules for one effective birthDate + invitee email. */
-      const validateInviteCoppa = (effectiveBirthDate: string | undefined | null, inviteeEmail: string, effectiveParentEmail: string | undefined): string | null => {
+      /** Under-13/parent-email rules for one effective birthDate + ALL invitee emails. */
+      const validateInviteCoppa = (effectiveBirthDate: string | undefined | null, inviteeEmails: string[], effectiveParentEmail: string | undefined): string | null => {
         if (!effectiveBirthDate) return null;
         let under13: boolean;
         try {
@@ -209,7 +209,9 @@ export function registerInvitationRoutes(app: Express) {
         if (!effectiveParentEmail) {
           return "A parent or guardian email is required to invite an athlete under 13 (COPPA).";
         }
-        if (effectiveParentEmail === inviteeEmail.toLowerCase()) {
+        // Check against EVERY athlete email — invitations are created for each
+        // one, and a match would strand that invitation at accept time.
+        if (inviteeEmails.some(e => effectiveParentEmail === e.toLowerCase())) {
           return "Parent email must be different from the athlete's email.";
         }
         return null;
@@ -260,7 +262,7 @@ export function registerInvitationRoutes(app: Express) {
         const recordBirthDate = athlete.birthDate ? String(athlete.birthDate) : (birthDate ?? undefined);
         const recordParentEmail = normalizedInviteParentEmail
           ?? (athlete.parentEmail ? String(athlete.parentEmail).toLowerCase() : undefined);
-        const athleteCoppaError = validateInviteCoppa(recordBirthDate, athleteEmails[0] ?? '', recordParentEmail);
+        const athleteCoppaError = validateInviteCoppa(recordBirthDate, athleteEmails, recordParentEmail);
         if (athleteCoppaError) {
           return res.status(400).json({ message: athleteCoppaError });
         }
@@ -398,7 +400,7 @@ export function registerInvitationRoutes(app: Express) {
       }
 
       // COPPA: an under-13 athlete invitation requires a parent email
-      const coppaError = validateInviteCoppa(birthDate ?? undefined, String(email), normalizedInviteParentEmail);
+      const coppaError = validateInviteCoppa(birthDate ?? undefined, [String(email)], normalizedInviteParentEmail);
       if (coppaError) {
         return res.status(400).json({ message: coppaError });
       }
@@ -820,10 +822,11 @@ export function registerInvitationRoutes(app: Express) {
         organizationId: invitation.organizationId,
         teamIds: invitation.teamIds,
         playerId: invitation.playerId, // Include player/user ID if this is for an existing athlete
-        // COPPA prefill for the accept form. Exposed to any token bearer —
-        // the same trust level as the invitee email already returned above.
-        birthDate: invitation.birthDate,
-        parentEmail: invitation.parentEmail
+        // COPPA: never expose the child's birthDate or the parent's email to
+        // a token bearer (links get forwarded). The accept endpoint applies
+        // the stored values server-side; the form only needs to know whether
+        // a parent email is on file so it can relax its required field.
+        parentEmailOnFile: Boolean(invitation.parentEmail)
       };
 
       res.json(responseData);
@@ -991,21 +994,38 @@ export function registerInvitationRoutes(app: Express) {
       }
 
       // ── COPPA age classification (P0-11) ────────────────────────────────
-      // Effective birthDate precedence: linked player record > invitation
-      // (coach-entered at invite-create) > form value — a form entry cannot
-      // reclassify someone the server already knows the age of.
+      // Effective birthDate precedence: the accepting user's own server-known
+      // record > invitation (coach-entered at invite-create) > form value — a
+      // form entry cannot reclassify someone the server already knows the age
+      // of. The accepting user's record is the playerId-linked row for athlete
+      // invitations (for parent invitations playerId stores the CHILD, whose
+      // birthDate must not classify the parent), otherwise the existing user
+      // matched by the invitation email (storage Path B joins that account).
       // All validation failures below early-return 400 BEFORE acceptInvitation:
       // the catch block increments attemptCount and locks the invitation.
       let effectiveBirthDate: string | undefined =
         typeof birthDate === 'string' && birthDate !== '' ? birthDate : undefined;
-      if (invitation.birthDate) {
+      if (invitation.role === 'athlete' && invitation.birthDate) {
         effectiveBirthDate = String(invitation.birthDate);
       }
-      if (invitation.playerId) {
-        const linkedPlayer = await storage.getUser(invitation.playerId);
-        if (linkedPlayer?.birthDate) {
-          effectiveBirthDate = String(linkedPlayer.birthDate);
-        }
+      let acceptingUser: Awaited<ReturnType<typeof storage.getUser>> | undefined;
+      if (invitation.role === 'athlete' && invitation.playerId) {
+        acceptingUser = await storage.getUser(invitation.playerId);
+      } else {
+        const usersByEmail = await storage.getUsersByEmail(invitation.email);
+        acceptingUser = usersByEmail[0]; // oldest — same choice acceptInvitation makes
+      }
+      if (acceptingUser?.birthDate) {
+        effectiveBirthDate = String(acceptingUser.birthDate);
+      }
+
+      // Consent revocation must be resolved through support/org channels, and
+      // it must be checked BEFORE acceptInvitation so the token is not
+      // consumed and credentials are not overwritten by a doomed accept.
+      if (acceptingUser?.coppaStatus === 'consent_revoked') {
+        return res.status(403).json({
+          message: "Parental consent for this account was revoked. Please contact your organization or support to re-initiate consent."
+        });
       }
 
       // Parent email: the form value wins (fresher), falling back to the
@@ -1089,20 +1109,23 @@ export function registerInvitationRoutes(app: Express) {
 
       // ── COPPA session gate ──────────────────────────────────────────────
       // Gate on the FINAL user row, not just the form-derived classification:
-      // an existing account joining a new org may already be pending_consent
-      // or consent_revoked, and must not receive a session here that the
-      // login route would refuse.
+      // an existing account joining a new org may already carry a blocking
+      // status, and must not receive a session here that the login route
+      // would refuse. consent_revoked is also checked pre-transaction (above,
+      // without consuming the token); this is defense in depth against races.
       if (result.user.coppaStatus === 'consent_revoked') {
         return res.status(403).json({
           message: "Parental consent for this account was revoked. Please contact your organization or support to re-initiate consent."
         });
       }
 
-      if (result.user.coppaStatus === 'pending_consent') {
+      if (result.user.coppaStatus === 'pending_consent' || result.user.coppaStatus === 'needs_parent_email') {
         // Under-13: initiate VPC AFTER the accept transaction committed
         // (initiateConsent runs its own transaction and sends the parent
         // email). No session, no welcome email — confirmConsent notifies
-        // the athlete when the parent approves.
+        // the athlete when the parent approves. needs_parent_email is also
+        // login-blocked; a parent email supplied here remediates it (VPC
+        // moves the row to pending_consent).
         const consentParentEmail = effectiveParentEmail || result.user.parentEmail;
         let consentEmailSent: boolean | undefined;
         if (consentParentEmail) {
@@ -1117,9 +1140,12 @@ export function registerInvitationRoutes(app: Express) {
           console.log(`[InvitationAcceptance] Minor accepted invite: ${result.user.id}, VPC initiated: ${coppaResult.success}, emailSent: ${coppaResult.emailSent}`);
         }
 
-        const consentMessage = consentEmailSent === false
-          ? "Your account has been created. We were unable to send the consent email to your parent. Please ask them to visit the consent page directly, or try again later."
-          : "Your account has been created. A consent email has been sent to your parent or guardian. You'll be able to log in once they approve your account.";
+        // Be honest when no consent email could be sent at all
+        const consentMessage = consentParentEmail === undefined || consentParentEmail === null
+          ? "Your account requires parental consent, but no parent or guardian email is on file. Please log in later to provide one, or contact your organization."
+          : consentEmailSent === false
+            ? "Your account has been created. We were unable to send the consent email to your parent. Please ask them to visit the consent page directly, or try again later."
+            : "Your account has been created. A consent email has been sent to your parent or guardian. You'll be able to log in once they approve your account.";
 
         return res.json({
           success: true,

--- a/packages/api/routes/invitation-routes.ts
+++ b/packages/api/routes/invitation-routes.ts
@@ -167,7 +167,7 @@ export function registerInvitationRoutes(app: Express) {
    */
   app.post("/api/invitations", createLimiter, requireAuth, async (req, res) => {
     try {
-      const { email, firstName, lastName, role, organizationId, teamIds, athleteId } = req.body;
+      const { email, firstName, lastName, role, organizationId, teamIds, athleteId, birthDate, parentEmail } = req.body;
 
       // Get current user info for invitedBy
       const invitedById = req.session.user?.id;
@@ -175,6 +175,45 @@ export function registerInvitationRoutes(app: Express) {
       if (!invitedById) {
         return res.status(401).json({ message: "Authentication required" });
       }
+
+      // ── COPPA invite-create validation (coppa-compliance-spec, "Invitation
+      // flow modification") ─────────────────────────────────────────────────
+      // birthDate is optional (the coach may not know it; the accept-time age
+      // gate is the backstop), but an under-13 athlete invitation cannot be
+      // created without a parentEmail — the VPC email must be able to fire at
+      // accept even if the athlete's form omits it.
+      if (birthDate !== undefined && birthDate !== null && !/^\d{4}-\d{2}-\d{2}$/.test(String(birthDate))) {
+        return res.status(400).json({ message: "birthDate must be in YYYY-MM-DD format" });
+      }
+      const normalizedInviteParentEmail: string | undefined =
+        typeof parentEmail === 'string' && parentEmail.trim() !== ''
+          ? parentEmail.trim().toLowerCase()
+          : undefined;
+      if (normalizedInviteParentEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedInviteParentEmail)) {
+        return res.status(400).json({ message: "parentEmail must be a valid email address" });
+      }
+
+      /** Under-13/parent-email rules for one effective birthDate + invitee email. */
+      const validateInviteCoppa = (effectiveBirthDate: string | undefined | null, inviteeEmail: string, effectiveParentEmail: string | undefined): string | null => {
+        if (!effectiveBirthDate) return null;
+        let under13: boolean;
+        try {
+          under13 = isUnder13(effectiveBirthDate);
+        } catch {
+          return "Invalid birthDate.";
+        }
+        if (!under13) return null;
+        if (role !== 'athlete') {
+          return "This invitation role requires an adult. Remove the under-13 birth date or invite as an athlete.";
+        }
+        if (!effectiveParentEmail) {
+          return "A parent or guardian email is required to invite an athlete under 13 (COPPA).";
+        }
+        if (effectiveParentEmail === inviteeEmail.toLowerCase()) {
+          return "Parent email must be different from the athlete's email.";
+        }
+        return null;
+      };
 
       // Handle athlete invitation (send to all their emails)
       if (athleteId && role === "athlete") {
@@ -216,6 +255,16 @@ export function registerInvitationRoutes(app: Express) {
           return res.status(400).json({ message: "Athlete has no email addresses on file" });
         }
 
+        // COPPA: the linked athlete record is the server-known source of age
+        // truth; a request-provided parentEmail overrides the record's.
+        const recordBirthDate = athlete.birthDate ? String(athlete.birthDate) : (birthDate ?? undefined);
+        const recordParentEmail = normalizedInviteParentEmail
+          ?? (athlete.parentEmail ? String(athlete.parentEmail).toLowerCase() : undefined);
+        const athleteCoppaError = validateInviteCoppa(recordBirthDate, athleteEmails[0] ?? '', recordParentEmail);
+        if (athleteCoppaError) {
+          return res.status(400).json({ message: athleteCoppaError });
+        }
+
         // Fetch invitations for this organization to avoid N+1 query
         const existingInvitations = await storage.getInvitationsByOrganization(organizationId);
 
@@ -245,6 +294,8 @@ export function registerInvitationRoutes(app: Express) {
               role,
               invitedBy: invitedById,
               playerId: athlete.id,
+              birthDate: recordBirthDate,
+              parentEmail: recordParentEmail,
               expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // Expires in 7 days
             });
             invitations.push(invitation);
@@ -346,6 +397,12 @@ export function registerInvitationRoutes(app: Express) {
         }
       }
 
+      // COPPA: an under-13 athlete invitation requires a parent email
+      const coppaError = validateInviteCoppa(birthDate ?? undefined, String(email), normalizedInviteParentEmail);
+      if (coppaError) {
+        return res.status(400).json({ message: coppaError });
+      }
+
       // Validate and clamp expiry days between 1 and 90 days
       const expiryDays = Math.max(1, Math.min(90, parseInt(process.env.INVITATION_EXPIRY_DAYS || '7', 10)));
       const invitation = await storage.createInvitation({
@@ -358,6 +415,8 @@ export function registerInvitationRoutes(app: Express) {
         invitedBy: invitedById,
         // For parent invitations, store athleteId in playerId field to preserve the link
         playerId: (role === 'parent' && athleteId) ? athleteId : undefined,
+        birthDate: birthDate ?? undefined,
+        parentEmail: normalizedInviteParentEmail,
         expiresAt: new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000)
       });
 
@@ -760,7 +819,11 @@ export function registerInvitationRoutes(app: Express) {
         role: invitation.role,
         organizationId: invitation.organizationId,
         teamIds: invitation.teamIds,
-        playerId: invitation.playerId // Include player/user ID if this is for an existing athlete
+        playerId: invitation.playerId, // Include player/user ID if this is for an existing athlete
+        // COPPA prefill for the accept form. Exposed to any token bearer —
+        // the same trust level as the invitee email already returned above.
+        birthDate: invitation.birthDate,
+        parentEmail: invitation.parentEmail
       };
 
       res.json(responseData);

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -1628,6 +1628,8 @@ export class DatabaseStorage implements IStorage {
     role: string;
     invitedBy: string;
     playerId?: string;
+    birthDate?: string | null;
+    parentEmail?: string | null;
     expiresAt: Date;
   }): Promise<Invitation> {
     const token = crypto.randomUUID();
@@ -1643,6 +1645,8 @@ export class DatabaseStorage implements IStorage {
       role: data.role,
       invitedBy: data.invitedBy,
       playerId: data.playerId, // Store athlete ID consistently
+      birthDate: data.birthDate,
+      parentEmail: data.parentEmail,
       token: hashToken(token), // Store only the hash; the raw token is emailed
       expiresAt,
     }).returning();

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -1735,8 +1735,11 @@ export class DatabaseStorage implements IStorage {
         legalAcceptedVersion: userInfo.legalAcceptedVersion || getLegalAcceptanceTimestamp()
       } : {};
 
-      // Check if invitation is linked to an existing athlete (playerId)
-      if (invitation.playerId) {
+      // Check if invitation is linked to an existing athlete (playerId).
+      // For PARENT invitations playerId stores the CHILD the parent should be
+      // linked to — the parent needs their own account (email-match/create
+      // below), not a credential takeover of the child's row.
+      if (invitation.playerId && invitation.role !== 'parent') {
         console.log("Invitation linked to existing athlete:", invitation.playerId);
 
         // Get the existing athlete/user
@@ -1757,8 +1760,12 @@ export class DatabaseStorage implements IStorage {
           if (userInfo.coppa.isMinor && userInfo.coppa.parentEmail && !existingUser.parentEmail) {
             coppaUpdate.parentEmail = userInfo.coppa.parentEmail;
           }
-          // Never downgrade a confirmed consent
-          if (userInfo.coppa.under13 && existingUser.coppaStatus !== 'consented') {
+          // Never override a resolved consent state: 'consented' must not be
+          // downgraded, and 'consent_revoked' must not be silently re-opened
+          // (revocation is resolved through support, not by re-accepting).
+          if (userInfo.coppa.under13
+            && existingUser.coppaStatus !== 'consented'
+            && existingUser.coppaStatus !== 'consent_revoked') {
             coppaUpdate.coppaStatus = 'pending_consent';
           }
         }
@@ -1812,17 +1819,27 @@ export class DatabaseStorage implements IStorage {
             console.log("[Invitation] Updating OAuth-only user with password");
           }
 
-          // COPPA: non-destructive — only classify users who have no birthDate
-          // on record; never overwrite an existing birthDate or a confirmed
-          // consent, and only fill parentEmail when currently empty.
-          if (userInfo.coppa && !existingUser.birthDate) {
-            updateData.birthDate = userInfo.coppa.birthDate;
-            updateData.isMinor = userInfo.coppa.isMinor;
+          // COPPA: non-destructive for identity data — never overwrite an
+          // existing birthDate, only fill parentEmail when currently empty.
+          // The STATUS update, however, must apply regardless of whether the
+          // row already has a birthDate: an under-13 row can exist with the
+          // 'not_applicable' column default (e.g. backfill or roster import),
+          // and skipping the status here would hand it a session.
+          if (userInfo.coppa) {
+            if (!existingUser.birthDate) {
+              updateData.birthDate = userInfo.coppa.birthDate;
+              updateData.isMinor = userInfo.coppa.isMinor;
+            }
             if (userInfo.coppa.isMinor && userInfo.coppa.parentEmail && !existingUser.parentEmail) {
               updateData.parentEmail = userInfo.coppa.parentEmail;
             }
-            if (userInfo.coppa.under13 && existingUser.coppaStatus !== 'consented') {
+            // Never override a resolved consent state ('consented' or
+            // 'consent_revoked' — the latter is resolved via support).
+            if (userInfo.coppa.under13
+              && existingUser.coppaStatus !== 'consented'
+              && existingUser.coppaStatus !== 'consent_revoked') {
               updateData.coppaStatus = 'pending_consent';
+              updateData.isMinor = true;
             }
           }
 

--- a/packages/api/storage.ts
+++ b/packages/api/storage.ts
@@ -1690,6 +1690,15 @@ export class DatabaseStorage implements IStorage {
       lastName: string;
       legalAcceptedAt?: string;
       legalAcceptedVersion?: string;
+      // COPPA classification computed by the route (age checks live there).
+      // Persisted fail-closed inside this transaction so a crash after commit
+      // but before VPC initiation still leaves under-13 users login-blocked.
+      coppa?: {
+        birthDate: string;
+        isMinor: boolean;
+        under13: boolean;
+        parentEmail?: string;
+      };
     },
     auditContext?: {
       ipAddress?: string;
@@ -1735,10 +1744,25 @@ export class DatabaseStorage implements IStorage {
 
         // Update the existing user with credentials
         // Note: updateUser will hash the password, so pass the plain password
+        const coppaUpdate: Partial<InsertUser> = {};
+        if (userInfo.coppa) {
+          if (!existingUser.birthDate) {
+            coppaUpdate.birthDate = userInfo.coppa.birthDate;
+          }
+          coppaUpdate.isMinor = userInfo.coppa.isMinor;
+          if (userInfo.coppa.isMinor && userInfo.coppa.parentEmail && !existingUser.parentEmail) {
+            coppaUpdate.parentEmail = userInfo.coppa.parentEmail;
+          }
+          // Never downgrade a confirmed consent
+          if (userInfo.coppa.under13 && existingUser.coppaStatus !== 'consented') {
+            coppaUpdate.coppaStatus = 'pending_consent';
+          }
+        }
         user = await this.updateUser(invitation.playerId, {
           username: userInfo.username,
           password: userInfo.password,
           isActive: true,
+          ...coppaUpdate,
           ...legalData
         }, tx);
 
@@ -1784,6 +1808,20 @@ export class DatabaseStorage implements IStorage {
             console.log("[Invitation] Updating OAuth-only user with password");
           }
 
+          // COPPA: non-destructive — only classify users who have no birthDate
+          // on record; never overwrite an existing birthDate or a confirmed
+          // consent, and only fill parentEmail when currently empty.
+          if (userInfo.coppa && !existingUser.birthDate) {
+            updateData.birthDate = userInfo.coppa.birthDate;
+            updateData.isMinor = userInfo.coppa.isMinor;
+            if (userInfo.coppa.isMinor && userInfo.coppa.parentEmail && !existingUser.parentEmail) {
+              updateData.parentEmail = userInfo.coppa.parentEmail;
+            }
+            if (userInfo.coppa.under13 && existingUser.coppaStatus !== 'consented') {
+              updateData.coppaStatus = 'pending_consent';
+            }
+          }
+
           // Only update if there's something to update
           if (Object.keys(updateData).length > 0) {
             user = await this.updateUser(existingUser.id, updateData, tx);
@@ -1801,6 +1839,15 @@ export class DatabaseStorage implements IStorage {
             firstName: userInfo.firstName,
             lastName: userInfo.lastName,
             role: invitation.role as "site_admin" | "org_admin" | "coach" | "athlete" | "parent",
+            // COPPA: mirror registration (registration-routes.ts) — under-13 is
+            // created pending_consent so a failed VPC initiation still leaves
+            // the account login-blocked (fail-closed).
+            ...(userInfo.coppa ? {
+              birthDate: userInfo.coppa.birthDate,
+              isMinor: userInfo.coppa.isMinor,
+              parentEmail: userInfo.coppa.isMinor ? userInfo.coppa.parentEmail : undefined,
+              coppaStatus: (userInfo.coppa.under13 ? 'pending_consent' : 'not_applicable') as 'pending_consent' | 'not_applicable',
+            } : {}),
             ...legalData
           };
 

--- a/packages/shared/schema-original.ts
+++ b/packages/shared/schema-original.ts
@@ -1605,6 +1605,9 @@ export const insertInvitationSchema = createInsertSchema(invitations).omit({
   email: z.string().email("Invalid email format"),
   role: z.enum(["athlete", "coach", "org_admin", "parent"]), // Removed site_admin from invitations
   teamIds: z.array(z.string()).optional(),
+  // COPPA: coach-provided age data captured at invite-create time
+  birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "birthDate must be in YYYY-MM-DD format").optional().nullable(),
+  parentEmail: z.string().email("Invalid parent email format").trim().toLowerCase().optional().nullable(),
 });
 
 export const insertMeasurementSchema = createInsertSchema(measurements).omit({

--- a/packages/shared/schema/tables/membership.ts
+++ b/packages/shared/schema/tables/membership.ts
@@ -30,6 +30,10 @@ export const invitations = pgTable("invitations", {
   playerId: varchar("player_id").references(() => users.id, { onDelete: 'set null' }), // Reference to existing athlete (kept as playerId for DB compatibility). NULL if user was deleted (preserves invitation history)
   role: text("role").notNull(), // "athlete", "coach", "org_admin"
   invitedBy: varchar("invited_by").references(() => users.id, { onDelete: 'set null' }), // User who sent invitation. NULL if user was deleted (preserves invitation history)
+  // COPPA: coach-provided age data captured at invite-create time. An athlete
+  // invitation with an under-13 birthDate cannot be created without parentEmail.
+  birthDate: date("birth_date"),
+  parentEmail: text("parent_email"),
   token: text("token").notNull().unique(),
   // Enhanced tracking fields
   status: text("status").default("pending"), // "pending", "accepted", "expired", "cancelled" - made nullable for backward compatibility

--- a/packages/web/src/components/invitation-modal.tsx
+++ b/packages/web/src/components/invitation-modal.tsx
@@ -11,11 +11,39 @@ import { useToast } from "@/hooks/use-toast";
 import { queryClient } from "@/lib/queryClient";
 import { mutations } from "@/lib/api";
 import { getInvitationStatusMessage } from "@/lib/invitation-helpers";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+import { isUnder13 } from "@shared/coppa-utils";
+
+/** Guarded age check — an incomplete date string must not throw mid-typing. */
+function dobIsUnder13(birthDate: string | undefined): boolean {
+  if (!birthDate) return false;
+  try { return isUnder13(birthDate); } catch { return false; }
+}
 
 const invitationSchema = z.object({
   email: z.string().email("Invalid email format"),
   firstName: z.string().min(1, "First name is required"),
   lastName: z.string().min(1, "Last name is required"),
+  birthDate: z.string().optional(),
+  parentEmail: z.string().email("Invalid parent email format").optional().or(z.literal("")),
+}).superRefine((data, ctx) => {
+  // COPPA: an under-13 athlete invitation cannot be sent without a parent email
+  if (dobIsUnder13(data.birthDate)) {
+    if (!data.parentEmail) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["parentEmail"],
+        message: "A parent or guardian email is required for athletes under 13 (COPPA).",
+      });
+    } else if (data.parentEmail === data.email) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["parentEmail"],
+        message: "Parent email must be different from the athlete's email.",
+      });
+    }
+  }
 });
 
 type InvitationForm = z.infer<typeof invitationSchema>;
@@ -43,13 +71,22 @@ export function InvitationModal({
       email: "",
       firstName: "",
       lastName: "",
+      birthDate: "",
+      parentEmail: "",
     },
   });
+
+  const watchedBirthDate = form.watch("birthDate");
+  const showParentEmail = role === "athlete" && dobIsUnder13(watchedBirthDate);
 
   const invitationMutation = useMutation({
     mutationFn: async (data: InvitationForm) => {
       return mutations.createInvitation({
-        ...data,
+        email: data.email,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        birthDate: role === "athlete" && data.birthDate ? data.birthDate : undefined,
+        parentEmail: showParentEmail && data.parentEmail ? data.parentEmail.trim().toLowerCase() : undefined,
         role,
         organizationId,
         teamIds: []
@@ -158,6 +195,60 @@ export function InvitationModal({
                 </FormItem>
               )}
             />
+
+            {role === "athlete" && (
+              <FormField
+                control={form.control}
+                name="birthDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date of Birth (optional)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="date"
+                        max={new Date().toISOString().split("T")[0]}
+                        {...field}
+                        data-testid="input-invite-birth-date"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {showParentEmail && (
+              <>
+                <Alert className="border-amber-200 bg-amber-50">
+                  <AlertCircle className="h-4 w-4 text-amber-600" />
+                  <AlertDescription className="text-amber-800 text-sm">
+                    Federal law (COPPA) requires parental consent for athletes under 13.
+                    A consent request will be sent to the parent or guardian when the
+                    athlete accepts this invitation.
+                  </AlertDescription>
+                </Alert>
+                <FormField
+                  control={form.control}
+                  name="parentEmail"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Parent or Guardian Email <span className="text-red-500">*</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          type="email"
+                          placeholder="parent@example.com"
+                          {...field}
+                          data-testid="input-invite-parent-email"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
 
             <Button
               type="submit"

--- a/packages/web/src/pages/accept-invitation.tsx
+++ b/packages/web/src/pages/accept-invitation.tsx
@@ -118,6 +118,17 @@ export default function AcceptInvitation() {
           lastName: data.athleteData.lastName
         }));
       }
+
+      // COPPA prefill: coach-provided birthDate/parentEmail captured at
+      // invite-create time. Fields stay editable — the accepter may correct
+      // them, and the server re-validates either way.
+      if (data.birthDate || data.parentEmail) {
+        setFormData(prev => ({
+          ...prev,
+          birthDate: prev.birthDate || (data.birthDate ?? ''),
+          parentEmail: prev.parentEmail || (data.parentEmail ?? ''),
+        }));
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load invitation');
     } finally {

--- a/packages/web/src/pages/accept-invitation.tsx
+++ b/packages/web/src/pages/accept-invitation.tsx
@@ -19,6 +19,7 @@ interface InvitationData {
   organizationId: string;
   playerId?: string; // ID of existing athlete/user if updating
   athleteId?: string;
+  parentEmailOnFile?: boolean; // COPPA: coach provided a parent email at invite-create
   athleteData?: {
     id: string;
     firstName: string;
@@ -119,16 +120,10 @@ export default function AcceptInvitation() {
         }));
       }
 
-      // COPPA prefill: coach-provided birthDate/parentEmail captured at
-      // invite-create time. Fields stay editable — the accepter may correct
-      // them, and the server re-validates either way.
-      if (data.birthDate || data.parentEmail) {
-        setFormData(prev => ({
-          ...prev,
-          birthDate: prev.birthDate || (data.birthDate ?? ''),
-          parentEmail: prev.parentEmail || (data.parentEmail ?? ''),
-        }));
-      }
+      // COPPA: the raw coach-provided birthDate/parentEmail are intentionally
+      // NOT returned to token bearers (minor PII). The server applies the
+      // stored values at accept time; data.parentEmailOnFile only relaxes the
+      // required parent-email field below.
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load invitation');
     } finally {
@@ -439,11 +434,13 @@ export default function AcceptInvitation() {
               />
             </div>
 
-            {/* Parent/Guardian Email — shown for all minor athletes (under-18) */}
+            {/* Parent/Guardian Email — shown for all minor athletes (under-18).
+                Not required when the coach already provided one at invite
+                creation (server uses the on-file value as fallback). */}
             {minor && (
               <div>
                 <Label htmlFor="parentEmail">
-                  Parent or Guardian Email {under13 && <span className="text-red-500">*</span>}
+                  Parent or Guardian Email {under13 && !invitation?.parentEmailOnFile && <span className="text-red-500">*</span>}
                 </Label>
                 {under13 && (
                   <Alert className="mb-2 border-amber-200 bg-amber-50">
@@ -452,6 +449,11 @@ export default function AcceptInvitation() {
                       Federal law (COPPA) requires parental consent for users under 13. A parent or guardian must approve before you can log in.
                     </AlertDescription>
                   </Alert>
+                )}
+                {under13 && invitation?.parentEmailOnFile && (
+                  <p className="text-sm text-muted-foreground mb-2">
+                    Your coach already provided a parent/guardian email. Leave this blank to use it, or enter a different one.
+                  </p>
                 )}
                 {teenMinor && (
                   <p className="text-sm text-muted-foreground mb-2">
@@ -464,7 +466,7 @@ export default function AcceptInvitation() {
                   value={formData.parentEmail}
                   onChange={handleInputChange('parentEmail')}
                   placeholder="parent@example.com"
-                  required={under13}
+                  required={under13 && !invitation?.parentEmailOnFile}
                 />
               </div>
             )}

--- a/tests/e2e/invitation-coppa-accept.spec.ts
+++ b/tests/e2e/invitation-coppa-accept.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { getUserByRole } from './fixtures/test-users';
+
+/**
+ * COPPA E2E — Invitation Accept Age Gate (P0-11)
+ *
+ * Verifies the legally critical invite-accept journey:
+ * 1. An under-13 date of birth on the accept-invitation page reveals the
+ *    parent email field with the COPPA warning, and submitting leads to the
+ *    consent-sent holding screen with NO authenticated session.
+ * 2. An adult date of birth completes account creation and redirects into
+ *    the app as before.
+ *
+ * Invitations are created through the real API with an org-admin session,
+ * using the inviteLink returned by POST /api/invitations.
+ *
+ * Test isolation: storageState is cleared so no shared auth state leaks in.
+ */
+
+const BASE_URL = process.env.STAGING_URL || 'http://localhost:5000';
+const RUN_ID = Date.now().toString(36);
+
+function dobForAge(age: number): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - age);
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().split('T')[0];
+}
+
+/** Login as org admin and create an athlete invitation; returns the invite link. */
+async function createAthleteInvitation(
+  request: APIRequestContext,
+  suffix: string
+): Promise<{ inviteLink: string; email: string }> {
+  const admin = getUserByRole('org_admin');
+
+  const loginRes = await request.post(`${BASE_URL}/api/auth/login`, {
+    data: { username: admin.username, password: admin.password },
+  });
+  expect(loginRes.ok(), 'org admin login should succeed').toBeTruthy();
+
+  const orgsRes = await request.get(`${BASE_URL}/api/auth/me/organizations`);
+  expect(orgsRes.ok(), 'should fetch admin organizations').toBeTruthy();
+  const orgs = await orgsRes.json();
+  const organizationId = Array.isArray(orgs) ? orgs[0]?.id ?? orgs[0]?.organizationId : orgs.organizations?.[0]?.id;
+  expect(organizationId, 'org admin should belong to at least one organization').toBeTruthy();
+
+  const email = `e2e_coppa_inv_${suffix}@example.com`;
+  const createRes = await request.post(`${BASE_URL}/api/invitations`, {
+    data: {
+      email,
+      firstName: `CoppaInvite${suffix}`,
+      lastName: 'E2E',
+      role: 'athlete',
+      organizationId,
+      teamIds: [],
+    },
+  });
+  expect(createRes.status(), 'invitation creation should return 201').toBe(201);
+  const body = await createRes.json();
+  expect(body.inviteLink, 'response should include inviteLink').toBeTruthy();
+
+  return { inviteLink: body.inviteLink as string, email };
+}
+
+/** Fill the common accept-invitation form fields (except birthDate/parentEmail). */
+async function fillBaseFields(page: import('@playwright/test').Page, suffix: string) {
+  await page.locator('#username').fill(`e2ecoppainv${suffix}`);
+  await page.locator('#password').fill('ValidPass1!!');
+  await page.locator('#confirmPassword').fill('ValidPass1!!');
+  await page.locator('#termsAccepted').check();
+}
+
+test.describe('COPPA: invitation accept age gate', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('under-13 DOB reveals parent email + submits to consent holding screen (no session)', async ({ page, request }) => {
+    const suffix = `${RUN_ID}u13`;
+    const { inviteLink } = await createAthleteInvitation(request, suffix);
+
+    await page.goto(inviteLink.replace(/^https?:\/\/[^/]+/, BASE_URL));
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('#birthDate'), 'DOB field should be on the accept page').toBeVisible();
+
+    // Parent email hidden until a minor DOB is entered
+    await expect(page.locator('#parentEmail')).toBeHidden();
+
+    await page.locator('#birthDate').fill(dobForAge(12));
+
+    // Under-13 → parent email field + COPPA warning appear
+    await expect(page.locator('#parentEmail'), 'parent email should appear for under-13').toBeVisible();
+    await expect(page.getByText(/COPPA/i).first(), 'COPPA warning should be shown').toBeVisible();
+
+    await page.locator('#parentEmail').fill(`e2e_coppa_parent_${suffix}@example.com`);
+    await fillBaseFields(page, suffix);
+    await page.locator('button[type="submit"]').click();
+
+    // Consent-sent holding screen — NOT logged in, no redirect into the app
+    await expect(
+      page.getByText(/consent request has been sent/i),
+      'holding screen should confirm the consent request was sent'
+    ).toBeVisible({ timeout: 10000 });
+    expect(page.url()).not.toMatch(/\/athletes\//);
+
+    // No authenticated session: /api/auth/me should not return this new user
+    const meRes = await page.request.get(`${BASE_URL}/api/auth/me`);
+    if (meRes.ok()) {
+      const me = await meRes.json();
+      expect(me?.username ?? me?.user?.username).not.toBe(`e2ecoppainv${suffix}`);
+    }
+  });
+
+  test('adult DOB completes account creation and enters the app', async ({ page, request }) => {
+    const suffix = `${RUN_ID}adult`;
+    const { inviteLink } = await createAthleteInvitation(request, suffix);
+
+    await page.goto(inviteLink.replace(/^https?:\/\/[^/]+/, BASE_URL));
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('#birthDate').fill(dobForAge(25));
+
+    // Adult → no required parent email gate
+    await fillBaseFields(page, suffix);
+    await page.locator('button[type="submit"]').click();
+
+    // Successful accept redirects the athlete into the app
+    await page.waitForURL(/\/athletes\//, { timeout: 15000 });
+    expect(page.url()).toMatch(/\/athletes\//);
+  });
+});

--- a/tests/e2e/invitation-coppa-accept.spec.ts
+++ b/tests/e2e/invitation-coppa-accept.spec.ts
@@ -24,7 +24,11 @@ function dobForAge(age: number): string {
   const d = new Date();
   d.setFullYear(d.getFullYear() - age);
   d.setDate(d.getDate() - 1);
-  return d.toISOString().split('T')[0];
+  // Local-time formatting — toISOString() can shift a day in non-UTC timezones
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 /** Login as org admin and create an athlete invitation; returns the invite link. */

--- a/tests/e2e/invitation-create-coppa.spec.ts
+++ b/tests/e2e/invitation-create-coppa.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+import { getUserByRole } from './fixtures/test-users';
+
+/**
+ * COPPA E2E — Invite-Create Age Capture (coach-side)
+ *
+ * Verifies the coach-side COPPA gate in the invitation modal:
+ * 1. The athlete invite modal shows an optional Date of Birth field.
+ * 2. Entering an under-13 DOB reveals a required parent-email field with the
+ *    COPPA alert, and submit is blocked without it.
+ * 3. An invitation created with coach-provided birthDate/parentEmail prefills
+ *    the accept page and completes to the consent holding screen.
+ *
+ * Requires an E2E environment with seeded role users (org_admin) — like the
+ * other invitation specs, this cannot run against a bare local dev DB.
+ */
+
+const BASE_URL = process.env.STAGING_URL || 'http://localhost:5000';
+const RUN_ID = Date.now().toString(36);
+
+function dobForAge(age: number): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - age);
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().split('T')[0];
+}
+
+test.describe('COPPA: invite-create age capture', () => {
+  test('under-13 DOB in invite modal reveals required parent email and blocks send without it', async ({ page }) => {
+    const admin = getUserByRole('org_admin');
+
+    // Login through the UI so the app shell (and modal) is reachable
+    await page.goto(`${BASE_URL}/login`);
+    await page.fill('input[name="username"], #username', admin.username);
+    await page.fill('input[name="password"], #password', admin.password);
+    await page.click('button[type="submit"]');
+    await page.waitForLoadState('networkidle');
+
+    // Open the athlete invite modal from the athletes page
+    await page.goto(`${BASE_URL}/athletes`);
+    await page.waitForLoadState('networkidle');
+    const inviteButton = page.getByRole('button', { name: /invite/i }).first();
+    await expect(inviteButton, 'an Invite button should exist on the athletes page').toBeVisible();
+    await inviteButton.click();
+
+    // DOB field is present for athlete invitations
+    const dobInput = page.locator('[data-testid="input-invite-birth-date"]');
+    await expect(dobInput, 'DOB field should be in the athlete invite modal').toBeVisible();
+
+    // Parent email hidden until an under-13 DOB is entered
+    await expect(page.locator('[data-testid="input-invite-parent-email"]')).toBeHidden();
+
+    await page.locator('[data-testid="input-invite-first-name"]').fill(`CoppaModal${RUN_ID}`);
+    await page.locator('[data-testid="input-invite-last-name"]').fill('E2E');
+    await page.locator('[data-testid="input-invite-email"]').fill(`e2e_coppa_modal_${RUN_ID}@example.com`);
+    await dobInput.fill(dobForAge(12));
+
+    // COPPA alert + required parent email appear
+    await expect(page.locator('[data-testid="input-invite-parent-email"]')).toBeVisible();
+    await expect(page.getByText(/COPPA/i).first()).toBeVisible();
+
+    // Submitting without a parent email is blocked by validation
+    await page.locator('[data-testid="button-send-invitation"]').click();
+    await expect(
+      page.getByText(/parent or guardian email is required/i),
+      'validation should block an under-13 invite without parent email'
+    ).toBeVisible();
+
+    // Providing the parent email allows the invite to send
+    await page.locator('[data-testid="input-invite-parent-email"]').fill(`e2e_coppa_modal_parent_${RUN_ID}@example.com`);
+    await page.locator('[data-testid="button-send-invitation"]').click();
+    await expect(page.locator('[data-testid="button-send-invitation"]')).toBeHidden({ timeout: 10000 });
+  });
+
+  test('coach-provided DOB/parent email prefill the accept page and reach the consent holding screen', async ({ page, request }) => {
+    const admin = getUserByRole('org_admin');
+
+    const loginRes = await request.post(`${BASE_URL}/api/auth/login`, {
+      data: { username: admin.username, password: admin.password },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+
+    const orgsRes = await request.get(`${BASE_URL}/api/auth/me/organizations`);
+    const orgs = await orgsRes.json();
+    const organizationId = Array.isArray(orgs) ? orgs[0]?.id ?? orgs[0]?.organizationId : orgs.organizations?.[0]?.id;
+    expect(organizationId).toBeTruthy();
+
+    const parentEmail = `e2e_coppa_prefill_parent_${RUN_ID}@example.com`;
+    const createRes = await request.post(`${BASE_URL}/api/invitations`, {
+      data: {
+        email: `e2e_coppa_prefill_${RUN_ID}@example.com`,
+        firstName: `CoppaPrefill${RUN_ID}`,
+        lastName: 'E2E',
+        role: 'athlete',
+        organizationId,
+        teamIds: [],
+        birthDate: dobForAge(12),
+        parentEmail,
+      },
+    });
+    expect(createRes.status()).toBe(201);
+    const { inviteLink } = await createRes.json();
+
+    await page.context().clearCookies();
+    await page.goto((inviteLink as string).replace(/^https?:\/\/[^/]+/, BASE_URL));
+    await page.waitForLoadState('networkidle');
+
+    // Prefill: DOB and parent email arrive from the invitation
+    await expect(page.locator('#birthDate')).toHaveValue(dobForAge(12));
+    await expect(page.locator('#parentEmail')).toHaveValue(parentEmail);
+
+    // Complete the rest and land on the consent holding screen
+    await page.locator('#username').fill(`e2ecoppapre${RUN_ID}`);
+    await page.locator('#password').fill('ValidPass1!!');
+    await page.locator('#confirmPassword').fill('ValidPass1!!');
+    await page.locator('#termsAccepted').check();
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.getByText(/consent request has been sent/i)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/e2e/invitation-create-coppa.spec.ts
+++ b/tests/e2e/invitation-create-coppa.spec.ts
@@ -8,8 +8,9 @@ import { getUserByRole } from './fixtures/test-users';
  * 1. The athlete invite modal shows an optional Date of Birth field.
  * 2. Entering an under-13 DOB reveals a required parent-email field with the
  *    COPPA alert, and submit is blocked without it.
- * 3. An invitation created with coach-provided birthDate/parentEmail prefills
- *    the accept page and completes to the consent holding screen.
+ * 3. An invitation created with coach-provided birthDate/parentEmail keeps
+ *    that PII server-side (token bearers only see parentEmailOnFile) and the
+ *    accept completes to the consent holding screen without re-entering it.
  *
  * Requires an E2E environment with seeded role users (org_admin) — like the
  * other invitation specs, this cannot run against a bare local dev DB.
@@ -22,7 +23,11 @@ function dobForAge(age: number): string {
   const d = new Date();
   d.setFullYear(d.getFullYear() - age);
   d.setDate(d.getDate() - 1);
-  return d.toISOString().split('T')[0];
+  // Local-time formatting — toISOString() can shift a day in non-UTC timezones
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 test.describe('COPPA: invite-create age capture', () => {
@@ -72,7 +77,7 @@ test.describe('COPPA: invite-create age capture', () => {
     await expect(page.locator('[data-testid="button-send-invitation"]')).toBeHidden({ timeout: 10000 });
   });
 
-  test('coach-provided DOB/parent email prefill the accept page and reach the consent holding screen', async ({ page, request }) => {
+  test('coach-provided parent email is applied server-side (never exposed) and the accept reaches the consent holding screen', async ({ page, request }) => {
     const admin = getUserByRole('org_admin');
 
     const loginRes = await request.post(`${BASE_URL}/api/auth/login`, {
@@ -105,11 +110,21 @@ test.describe('COPPA: invite-create age capture', () => {
     await page.goto((inviteLink as string).replace(/^https?:\/\/[^/]+/, BASE_URL));
     await page.waitForLoadState('networkidle');
 
-    // Prefill: DOB and parent email arrive from the invitation
-    await expect(page.locator('#birthDate')).toHaveValue(dobForAge(12));
-    await expect(page.locator('#parentEmail')).toHaveValue(parentEmail);
+    // PII must NOT be prefilled — the raw DOB/parent email never leave the
+    // server. The child enters their own DOB; the coach-provided parent
+    // email is applied server-side as a fallback.
+    await expect(page.locator('#birthDate')).toHaveValue('');
+    await page.locator('#birthDate').fill(dobForAge(12));
 
-    // Complete the rest and land on the consent holding screen
+    // Under-13 + parent email on file → field visible but NOT required
+    const parentField = page.locator('#parentEmail');
+    await expect(parentField).toBeVisible();
+    await expect(parentField).toHaveValue('');
+    await expect(parentField).not.toHaveAttribute('required', '');
+    await expect(page.getByText(/coach already provided a parent\/guardian email/i)).toBeVisible();
+
+    // Complete the rest, leaving parent email blank → server falls back to
+    // the coach-provided value and the consent holding screen appears
     await page.locator('#username').fill(`e2ecoppapre${RUN_ID}`);
     await page.locator('#password').fill('ValidPass1!!');
     await page.locator('#confirmPassword').fill('ValidPass1!!');

--- a/tests/integration/invitation-coppa-accept.test.ts
+++ b/tests/integration/invitation-coppa-accept.test.ts
@@ -93,6 +93,8 @@ async function seedInvitation(params: {
   playerId?: string;
   firstName?: string;
   lastName?: string;
+  birthDate?: string;
+  parentEmail?: string;
 }): Promise<string> {
   const rawToken = crypto.randomUUID();
   const expiresAt = new Date();
@@ -107,6 +109,8 @@ async function seedInvitation(params: {
     role: params.role ?? 'athlete',
     invitedBy: inviterUserId,
     playerId: params.playerId,
+    birthDate: params.birthDate,
+    parentEmail: params.parentEmail,
     token: hashToken(rawToken),
     expiresAt,
   });
@@ -562,5 +566,91 @@ describe('POST /api/invitations/:token/accept — COPPA age gate', () => {
       .send(payload);
 
     expect(res.status).toBe(400);
+  });
+});
+
+// ============================================================================
+// Phase 2 — coach-provided birthDate/parentEmail on the invitation itself
+// ============================================================================
+
+describe('POST /api/invitations/:token/accept — coach-provided COPPA data', () => {
+  it('[LEGAL] invitation carries under-13 DOB + parentEmail; form omits both → VPC to coach-provided email, no session', async () => {
+    const ts = Date.now();
+    const coachParentEmail = `coach-parent-${ts}@testinvcoppa.local`;
+    const token = await seedInvitation({
+      email: `invdata-${ts}@testinvcoppa.local`,
+      birthDate: under13Dob(),
+      parentEmail: coachParentEmail,
+    });
+    const payload = acceptPayload(); // no birthDate, no parentEmail
+
+    vi.mocked(emailMocks.sendParentalConsentRequest).mockClear();
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBe(true);
+    expect(hasSessionCookie(res)).toBe(false);
+
+    const dbUser = await getUserByUsername(payload.username as string);
+    expect(dbUser).toBeDefined();
+    createdUserIds.push(dbUser.id);
+    expect(dbUser.coppaStatus).toBe('pending_consent');
+
+    // Consent email went to the coach-provided parent email
+    expect(emailMocks.sendParentalConsentRequest).toHaveBeenCalledWith(
+      coachParentEmail,
+      expect.anything()
+    );
+  });
+
+  it('invitation under-13 DOB wins over adult form DOB → VPC path', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({
+      email: `invdob-${ts}@testinvcoppa.local`,
+      birthDate: under13Dob(),
+      parentEmail: `coach-parent2-${ts}@testinvcoppa.local`,
+    });
+    // Form lies: says adult
+    const payload = acceptPayload({ birthDate: exactlyAge(20) });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBe(true);
+    expect(hasSessionCookie(res)).toBe(false);
+  });
+
+  it('form parentEmail differing from the invitation parentEmail → form value used for consent', async () => {
+    const ts = Date.now();
+    const formParentEmail = `form-parent-${ts}@testinvcoppa.local`;
+    const token = await seedInvitation({
+      email: `invpe-${ts}@testinvcoppa.local`,
+      birthDate: under13Dob(),
+      parentEmail: `coach-parent3-${ts}@testinvcoppa.local`,
+    });
+    const payload = acceptPayload({ birthDate: under13Dob(), parentEmail: formParentEmail });
+
+    vi.mocked(emailMocks.sendParentalConsentRequest).mockClear();
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBe(true);
+
+    const dbUser = await getUserByUsername(payload.username as string);
+    createdUserIds.push(dbUser.id);
+
+    // Fresher form value wins over the coach-provided one
+    expect(emailMocks.sendParentalConsentRequest).toHaveBeenCalledWith(
+      formParentEmail,
+      expect.anything()
+    );
   });
 });

--- a/tests/integration/invitation-coppa-accept.test.ts
+++ b/tests/integration/invitation-coppa-accept.test.ts
@@ -67,7 +67,12 @@ function ageWithOffset(years: number, daysOffset: number): string {
   const d = new Date();
   d.setFullYear(d.getFullYear() - years);
   d.setDate(d.getDate() + daysOffset);
-  return d.toISOString().split('T')[0];
+  // Format in LOCAL time — toISOString() (UTC) can shift a day across the
+  // 13th-birthday boundary in non-UTC timezones (see tests/shared/age-helpers.ts).
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 /** Under-13 date of birth (12 years old — 13th birthday is tomorrow) */
@@ -622,6 +627,174 @@ describe('POST /api/invitations/:token/accept — coach-provided COPPA data', ()
 
     expect(res.status).toBe(200);
     expect(res.body.requiresParentalConsent).toBe(true);
+    expect(hasSessionCookie(res)).toBe(false);
+  });
+
+  it('parent invitation is NOT age-classified by the linked child: parent of an under-13 athlete can accept', async () => {
+    const ts = Date.now();
+    // Under-13 athlete already in the system (the linked child)
+    const [child] = await db.insert(users).values({
+      username: `invexistchild${ts}`,
+      firstName: 'Linked',
+      lastName: 'Child',
+      fullName: 'Linked Child',
+      password: 'placeholder-hash',
+      emails: [`child-${ts}@testinvcoppa.local`],
+      birthDate: under13Dob(),
+      isMinor: true,
+      role: 'athlete',
+      coppaStatus: 'pending_consent',
+    }).returning({ id: users.id });
+    createdUserIds.push(child.id);
+
+    // Parent invitation: playerId stores the CHILD's id
+    const token = await seedInvitation({
+      email: `parent-role-${ts}@testinvcoppa.local`,
+      role: 'parent',
+      playerId: child.id,
+    });
+    // Parent enters their own adult DOB
+    const payload = acceptPayload({ birthDate: exactlyAge(40) });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    // Must NOT be blocked as "role requires an adult" (child's DOB must not classify the parent)
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBeFalsy();
+    expect(hasSessionCookie(res)).toBe(true);
+
+    // Parent's row must not have inherited the child's minor status
+    const parentRow = await getUserByUsername(payload.username as string);
+    // Parent-role invites with playerId reuse the parent-link path; the account row is new
+    if (parentRow) {
+      createdUserIds.push(parentRow.id);
+      expect(parentRow.isMinor).toBe(false);
+      expect(parentRow.coppaStatus).toBe('not_applicable');
+    }
+  });
+
+  it('[LEGAL] email-matched under-13 row with default not_applicable status is blocked (no session, moved to pending_consent)', async () => {
+    const ts = Date.now();
+    const email = `backfill-${ts}@testinvcoppa.local`;
+    // Server knows the DOB but the status was never classified (column default)
+    const [existing] = await db.insert(users).values({
+      username: `invexistbackfill${ts}`,
+      firstName: 'Backfilled',
+      lastName: 'Minor',
+      fullName: 'Backfilled Minor',
+      emails: [email],
+      password: 'placeholder-hash',
+      birthDate: under13Dob(),
+      coppaStatus: 'not_applicable',
+      isMinor: false,
+      role: 'athlete',
+    }).returning({ id: users.id });
+    createdUserIds.push(existing.id);
+
+    const token = await seedInvitation({ email });
+    // The child lies with an adult DOB and provides no parent email
+    const payload = acceptPayload({ birthDate: exactlyAge(20) });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    // Server-known DOB wins → under-13 → parent email required → 400 (no session either way)
+    expect(res.status).toBe(400);
+    expect(hasSessionCookie(res)).toBe(false);
+
+    // With a parent email supplied, the accept completes but is gated
+    const token2 = await seedInvitation({ email });
+    const payload2 = acceptPayload({
+      birthDate: exactlyAge(20),
+      parentEmail: `parent-backfill-${ts}@testinvcoppa.local`,
+    });
+    const res2 = await request(app)
+      .post(`/api/invitations/${token2}/accept`)
+      .send(payload2);
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.requiresParentalConsent).toBe(true);
+    expect(hasSessionCookie(res2)).toBe(false);
+
+    const [row] = await db.select().from(users).where(eq(users.id, existing.id));
+    expect(row.coppaStatus).toBe('pending_consent');
+  });
+
+  it('[LEGAL] consent_revoked linked player → 403 BEFORE the invitation is consumed', async () => {
+    const ts = Date.now();
+    const [revoked] = await db.insert(users).values({
+      username: `invexistrevoked${ts}`,
+      firstName: 'Revoked',
+      lastName: 'Minor',
+      fullName: 'Revoked Minor',
+      emails: [`revoked-${ts}@testinvcoppa.local`],
+      password: 'placeholder-hash',
+      birthDate: under13Dob(),
+      isMinor: true,
+      role: 'athlete',
+      coppaStatus: 'consent_revoked',
+    }).returning({ id: users.id });
+    createdUserIds.push(revoked.id);
+
+    const token = await seedInvitation({
+      email: `revoked-${ts}@testinvcoppa.local`,
+      playerId: revoked.id,
+    });
+    const payload = acceptPayload({
+      birthDate: under13Dob(),
+      parentEmail: `parent-revoked-${ts}@testinvcoppa.local`,
+    });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(403);
+    expect(hasSessionCookie(res)).toBe(false);
+
+    // The invitation must remain usable (support can resolve, then retry)
+    const [inv] = await db.select().from(invitations)
+      .where(eq(invitations.token, hashToken(token)));
+    expect(inv.isUsed).toBe(false);
+
+    // Revocation must NOT be silently re-opened
+    const [row] = await db.select().from(users).where(eq(users.id, revoked.id));
+    expect(row.coppaStatus).toBe('consent_revoked');
+  });
+
+  it('[LEGAL] needs_parent_email user gets NO session via invite accept', async () => {
+    const ts = Date.now();
+    const email = `needsparent-${ts}@testinvcoppa.local`;
+    const [existing] = await db.insert(users).values({
+      username: `invexistneeds${ts}`,
+      firstName: 'Needs',
+      lastName: 'ParentEmail',
+      fullName: 'Needs ParentEmail',
+      emails: [email],
+      password: 'placeholder-hash',
+      birthDate: under13Dob(),
+      isMinor: true,
+      role: 'athlete',
+      coppaStatus: 'needs_parent_email',
+    }).returning({ id: users.id });
+    createdUserIds.push(existing.id);
+
+    const token = await seedInvitation({ email });
+    const payload = acceptPayload({
+      birthDate: under13Dob(),
+      parentEmail: `parent-needs-${ts}@testinvcoppa.local`,
+    });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBe(true);
+    // LEGAL: login blocks needs_parent_email; invite accept must not hand out a session
     expect(hasSessionCookie(res)).toBe(false);
   });
 

--- a/tests/integration/invitation-coppa-accept.test.ts
+++ b/tests/integration/invitation-coppa-accept.test.ts
@@ -1,0 +1,566 @@
+/**
+ * Integration tests — COPPA age gate on POST /api/invitations/:token/accept
+ *
+ * Spec: P0-11 (coppa-compliance-spec) — the invitation path must reach parity
+ * with self-registration: an invited under-13 athlete must NOT receive a
+ * session until Verifiable Parental Consent (VPC) is confirmed.
+ *
+ * LEGAL EXPOSURE items are marked with [LEGAL]. Failures here are ship blockers:
+ * - Under-13 accept MUST NOT establish a session (no Set-Cookie header)
+ * - Under-13 accept without parentEmail MUST be rejected (and not consume the invitation)
+ * - A pending_consent user MUST NOT gain a session via the invite path (Path B bypass)
+ *
+ * Run:
+ *   export $(cat .env | xargs) && npx vitest run --config vitest.integration.config.ts tests/integration/invitation-coppa-accept.test.ts
+ */
+
+// Set env vars before any imports
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET = 'test-secret-key-for-integration-tests-only-at-least-32-characters-long';
+process.env.BYPASS_GENERAL_RATE_LIMIT = 'true';
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import express, { type Express } from 'express';
+import crypto from 'crypto';
+import { db } from '../../packages/api/db';
+import { users, organizations } from '@shared/schema/tables/core';
+import { invitations } from '@shared/schema/tables/membership';
+import { parentAthleteLinks, parentalConsents } from '@shared/schema/tables/coppa';
+import { eq, like, inArray } from 'drizzle-orm';
+
+// Mock vite module before importing registerRoutes
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+// Mock email service to prevent real emails during testing.
+// CoppaService constructs its own `new EmailService()`, so the class and the
+// singleton must share the same mock fns for call assertions to work.
+const emailMocks = vi.hoisted(() => ({
+  sendParentalConsentRequest: vi.fn().mockResolvedValue(true),
+  sendConsentConfirmedNotification: vi.fn().mockResolvedValue(true),
+  sendParentNotification: vi.fn().mockResolvedValue(true),
+  sendEmailVerification: vi.fn().mockResolvedValue(true),
+  sendInvitation: vi.fn().mockResolvedValue(true),
+  sendParentInvitation: vi.fn().mockResolvedValue(true),
+  sendWelcome: vi.fn().mockResolvedValue(true),
+  sendPasswordReset: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../packages/api/services/email-service', () => ({
+  emailService: emailMocks,
+  EmailService: vi.fn().mockImplementation(() => emailMocks),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+import { exactlyAge } from '../shared/age-helpers';
+
+/** Birthday `daysOffset` days from now, born `years` ago. +1 → still (years-1). */
+function ageWithOffset(years: number, daysOffset: number): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - years);
+  d.setDate(d.getDate() + daysOffset);
+  return d.toISOString().split('T')[0];
+}
+
+/** Under-13 date of birth (12 years old — 13th birthday is tomorrow) */
+function under13Dob(): string {
+  return ageWithOffset(13, 1);
+}
+
+function hashToken(raw: string): string {
+  return crypto.createHash('sha256').update(raw).digest('hex');
+}
+
+function validLegalAcceptedAt(): string {
+  return new Date().toISOString();
+}
+
+let testOrgId: string;
+let inviterUserId: string;
+
+/** Insert an invitation directly; returns the RAW token to accept with. */
+async function seedInvitation(params: {
+  email: string;
+  role?: string;
+  playerId?: string;
+  firstName?: string;
+  lastName?: string;
+}): Promise<string> {
+  const rawToken = crypto.randomUUID();
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + 7);
+
+  await db.insert(invitations).values({
+    email: params.email,
+    firstName: params.firstName ?? 'Invited',
+    lastName: params.lastName ?? 'Athlete',
+    organizationId: testOrgId,
+    teamIds: [],
+    role: params.role ?? 'athlete',
+    invitedBy: inviterUserId,
+    playerId: params.playerId,
+    token: hashToken(rawToken),
+    expiresAt,
+  });
+
+  return rawToken;
+}
+
+/** Base accept payload; birthDate/parentEmail supplied per-test. */
+function acceptPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const ts = Date.now() + Math.floor(Math.random() * 1000);
+  return {
+    firstName: 'Invited',
+    lastName: 'Athlete',
+    username: `invacc${ts}`,
+    password: 'ValidPass1!!',
+    legalAcceptedAt: validLegalAcceptedAt(),
+    ...overrides,
+  };
+}
+
+function hasSessionCookie(res: request.Response): boolean {
+  const setCookieHeader = res.headers['set-cookie'];
+  return Array.isArray(setCookieHeader)
+    ? setCookieHeader.some((c: string) => c.startsWith('connect.sid'))
+    : typeof setCookieHeader === 'string' && (setCookieHeader as string).startsWith('connect.sid');
+}
+
+async function getUserByUsername(username: string) {
+  const [user] = await db.select().from(users).where(eq(users.username, username)).limit(1);
+  return user;
+}
+
+// ============================================================================
+// Setup / Teardown
+// ============================================================================
+
+let app: Express;
+const createdUserIds: string[] = [];
+
+beforeAll(async () => {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL must be set to run integration tests.');
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  await registerRoutes(app);
+
+  const ts = Date.now();
+
+  const [org] = await db.insert(organizations).values({
+    name: `InvCoppaTestOrg-${ts}`,
+  }).returning({ id: organizations.id });
+  testOrgId = org.id;
+
+  const [inviter] = await db.insert(users).values({
+    username: `invcoppainviter${ts}`,
+    firstName: 'Inviter',
+    lastName: 'Coach',
+    fullName: 'Inviter Coach',
+    emails: [`inviter-${ts}@testinvcoppa.local`],
+    password: 'not-a-real-hash',
+    role: 'coach',
+  }).returning({ id: users.id });
+  inviterUserId = inviter.id;
+  createdUserIds.push(inviter.id);
+});
+
+afterAll(async () => {
+  // Delete children first (FK order): consents/links → invitations → users → org
+  try {
+    const allUsers = await db.select({ id: users.id }).from(users)
+      .where(like(users.username, 'invacc%'));
+    const ids = [...createdUserIds, ...allUsers.map(u => u.id)];
+    if (ids.length > 0) {
+      await db.delete(parentalConsents).where(inArray(parentalConsents.athleteUserId, ids));
+      await db.delete(parentAthleteLinks).where(inArray(parentAthleteLinks.athleteUserId, ids));
+    }
+    await db.delete(invitations).where(eq(invitations.organizationId, testOrgId));
+    if (ids.length > 0) {
+      await db.delete(users).where(inArray(users.id, ids));
+    }
+    await db.delete(users).where(like(users.username, 'invexist%'));
+    await db.delete(organizations).where(eq(organizations.id, testOrgId));
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('POST /api/invitations/:token/accept — COPPA age gate', () => {
+  it('[LEGAL] under-13 with parentEmail → 200 requiresParentalConsent, NO session, pending_consent, VPC initiated, no welcome email', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `u13-${ts}@testinvcoppa.local` });
+    const payload = acceptPayload({
+      birthDate: under13Dob(),
+      parentEmail: `parent-${ts}@testinvcoppa.local`,
+    });
+
+    vi.mocked(emailMocks.sendWelcome).mockClear();
+    vi.mocked(emailMocks.sendParentalConsentRequest).mockClear();
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.requiresParentalConsent).toBe(true);
+
+    // LEGAL: no session for under-13
+    expect(hasSessionCookie(res)).toBe(false);
+
+    // DB state
+    const dbUser = await getUserByUsername(payload.username as string);
+    expect(dbUser).toBeDefined();
+    createdUserIds.push(dbUser.id);
+    expect(dbUser.coppaStatus).toBe('pending_consent');
+    expect(dbUser.isMinor).toBe(true);
+    expect(dbUser.parentEmail).toBe(payload.parentEmail);
+
+    // A pending consent record exists
+    const consents = await db.select().from(parentalConsents)
+      .where(eq(parentalConsents.athleteUserId, dbUser.id));
+    expect(consents.length).toBeGreaterThanOrEqual(1);
+    expect(consents.some(c => c.status === 'pending')).toBe(true);
+
+    // Parent got the consent email; athlete did NOT get a welcome email
+    expect(emailMocks.sendParentalConsentRequest).toHaveBeenCalled();
+    expect(emailMocks.sendWelcome).not.toHaveBeenCalled();
+
+    // Invitation is consumed
+    const [inv] = await db.select().from(invitations)
+      .where(eq(invitations.token, hashToken(token)));
+    expect(inv.isUsed).toBe(true);
+  });
+
+  it('[LEGAL] under-13 without parentEmail → 400, no user created, invitation NOT consumed', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `u13nope-${ts}@testinvcoppa.local` });
+    const payload = acceptPayload({ birthDate: under13Dob() });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message?.toLowerCase()).toContain('parent');
+
+    const dbUser = await getUserByUsername(payload.username as string);
+    expect(dbUser).toBeUndefined();
+
+    const [inv] = await db.select().from(invitations)
+      .where(eq(invitations.token, hashToken(token)));
+    expect(inv.isUsed).toBe(false);
+  });
+
+  it('[LEGAL] user created via under-13 accept cannot log in until consent confirmed', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `u13login-${ts}@testinvcoppa.local` });
+    const payload = acceptPayload({
+      birthDate: under13Dob(),
+      parentEmail: `parent-login-${ts}@testinvcoppa.local`,
+    });
+
+    const acceptRes = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+    expect(acceptRes.status).toBe(200);
+    const dbUser = await getUserByUsername(payload.username as string);
+    createdUserIds.push(dbUser.id);
+
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ username: payload.username, password: payload.password });
+
+    expect(loginRes.status).toBe(403);
+    expect(hasSessionCookie(loginRes)).toBe(false);
+  });
+
+  it('teen minor (15) with parentEmail → session + parentAthleteLinks + parent notification + welcome email', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `teen-${ts}@testinvcoppa.local` });
+    const parentEmail = `parent-teen-${ts}@testinvcoppa.local`;
+    const payload = acceptPayload({ birthDate: exactlyAge(15), parentEmail });
+
+    vi.mocked(emailMocks.sendWelcome).mockClear();
+    vi.mocked(emailMocks.sendParentNotification).mockClear();
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.requiresParentalConsent).toBeFalsy();
+    expect(hasSessionCookie(res)).toBe(true);
+
+    const dbUser = await getUserByUsername(payload.username as string);
+    createdUserIds.push(dbUser.id);
+    expect(dbUser.coppaStatus).toBe('not_applicable');
+    expect(dbUser.isMinor).toBe(true);
+
+    const links = await db.select().from(parentAthleteLinks)
+      .where(eq(parentAthleteLinks.athleteUserId, dbUser.id));
+    expect(links).toHaveLength(1);
+    expect(links[0].parentEmail).toBe(parentEmail);
+    expect(links[0].organizationId).toBe(testOrgId);
+
+    expect(emailMocks.sendParentNotification).toHaveBeenCalled();
+    expect(emailMocks.sendWelcome).toHaveBeenCalled();
+  });
+
+  it('teen minor (15) without parentEmail → normal session, no link row', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `teennope-${ts}@testinvcoppa.local` });
+    const payload = acceptPayload({ birthDate: exactlyAge(15) });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(hasSessionCookie(res)).toBe(true);
+
+    const dbUser = await getUserByUsername(payload.username as string);
+    createdUserIds.push(dbUser.id);
+    expect(dbUser.isMinor).toBe(true);
+
+    const links = await db.select().from(parentAthleteLinks)
+      .where(eq(parentAthleteLinks.athleteUserId, dbUser.id));
+    expect(links).toHaveLength(0);
+  });
+
+  it('adult (25) → session, birthDate persisted, coppaStatus not_applicable', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `adult-${ts}@testinvcoppa.local` });
+    const payload = acceptPayload({ birthDate: exactlyAge(25) });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.requiresParentalConsent).toBeFalsy();
+    expect(hasSessionCookie(res)).toBe(true);
+
+    const dbUser = await getUserByUsername(payload.username as string);
+    createdUserIds.push(dbUser.id);
+    expect(dbUser.birthDate).toBeTruthy();
+    expect(dbUser.coppaStatus).toBe('not_applicable');
+    expect(dbUser.isMinor).toBe(false);
+  });
+
+  it('athlete accept without birthDate → 400', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `nodob-${ts}@testinvcoppa.local` });
+    const payload = acceptPayload(); // no birthDate
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('athlete accept with malformed birthDate → 400', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `baddob-${ts}@testinvcoppa.local` });
+    const payload = acceptPayload({ birthDate: 'not-a-date' });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('coach-role accept with under-13 birthDate → 400 (role requires an adult)', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `coachu13-${ts}@testinvcoppa.local`, role: 'coach' });
+    const payload = acceptPayload({ birthDate: under13Dob(), parentEmail: `p-${ts}@testinvcoppa.local` });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('coach-role accept without birthDate → succeeds (birthDate only required for athletes)', async () => {
+    const ts = Date.now();
+    const token = await seedInvitation({ email: `coachok-${ts}@testinvcoppa.local`, role: 'coach' });
+    const payload = acceptPayload();
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(hasSessionCookie(res)).toBe(true);
+    const dbUser = await getUserByUsername(payload.username as string);
+    createdUserIds.push(dbUser.id);
+  });
+
+  it('Path A: linked player with adult birthDate wins over under-13 form value → session', async () => {
+    const ts = Date.now();
+    // Coach-created athlete record with a known adult DOB
+    const [player] = await db.insert(users).values({
+      username: `invexistadult${ts}`,
+      firstName: 'Existing',
+      lastName: 'Adult',
+      fullName: 'Existing Adult',
+      password: 'placeholder-hash',
+      emails: [`existadult-${ts}@testinvcoppa.local`],
+      birthDate: exactlyAge(20),
+      role: 'athlete',
+      isActive: false,
+    }).returning({ id: users.id });
+    createdUserIds.push(player.id);
+
+    const token = await seedInvitation({
+      email: `existadult-${ts}@testinvcoppa.local`,
+      playerId: player.id,
+    });
+    // Form lies: says under-13
+    const payload = acceptPayload({
+      birthDate: under13Dob(),
+      parentEmail: `p-${ts}@testinvcoppa.local`,
+    });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBeFalsy();
+    expect(hasSessionCookie(res)).toBe(true);
+  });
+
+  it('[LEGAL] Path A: linked player with under-13 birthDate wins over adult form value → no session, VPC', async () => {
+    const ts = Date.now();
+    const [player] = await db.insert(users).values({
+      username: `invexistu13${ts}`,
+      firstName: 'Existing',
+      lastName: 'Minor',
+      fullName: 'Existing Minor',
+      password: 'placeholder-hash',
+      emails: [`existu13-${ts}@testinvcoppa.local`],
+      birthDate: under13Dob(),
+      role: 'athlete',
+      isActive: false,
+    }).returning({ id: users.id });
+    createdUserIds.push(player.id);
+
+    const token = await seedInvitation({
+      email: `existu13-${ts}@testinvcoppa.local`,
+      playerId: player.id,
+    });
+    // Form lies: says adult; parentEmail still provided
+    const payload = acceptPayload({
+      birthDate: exactlyAge(20),
+      parentEmail: `p-u13-${ts}@testinvcoppa.local`,
+    });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBe(true);
+    expect(hasSessionCookie(res)).toBe(false);
+  });
+
+  it('[LEGAL] Path B: existing pending_consent user joining a new org gets NO session', async () => {
+    const ts = Date.now();
+    const email = `existpending-${ts}@testinvcoppa.local`;
+    const [existing] = await db.insert(users).values({
+      username: `invexistpend${ts}`,
+      firstName: 'Pending',
+      lastName: 'Minor',
+      fullName: 'Pending Minor',
+      emails: [email],
+      password: 'some-hashed-password',
+      birthDate: under13Dob(),
+      coppaStatus: 'pending_consent',
+      isMinor: true,
+      parentEmail: `parent-pend-${ts}@testinvcoppa.local`,
+      role: 'athlete',
+    }).returning({ id: users.id });
+    createdUserIds.push(existing.id);
+
+    const token = await seedInvitation({ email });
+    const payload = acceptPayload({
+      birthDate: under13Dob(),
+      parentEmail: `parent-pend-${ts}@testinvcoppa.local`,
+    });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBe(true);
+    // LEGAL: the login block must not be bypassable via invite accept
+    expect(hasSessionCookie(res)).toBe(false);
+  });
+
+  it('Path B: existing adult user (birthDate set) + under-13 form value → existing wins → session', async () => {
+    const ts = Date.now();
+    const email = `existadultb-${ts}@testinvcoppa.local`;
+    const [existing] = await db.insert(users).values({
+      username: `invexistab${ts}`,
+      firstName: 'Existing',
+      lastName: 'AdultB',
+      fullName: 'Existing AdultB',
+      emails: [email],
+      password: 'some-hashed-password',
+      birthDate: exactlyAge(30),
+      coppaStatus: 'not_applicable',
+      role: 'athlete',
+    }).returning({ id: users.id });
+    createdUserIds.push(existing.id);
+
+    const token = await seedInvitation({ email });
+    const payload = acceptPayload({
+      birthDate: under13Dob(),
+      parentEmail: `p-ab-${ts}@testinvcoppa.local`,
+    });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(res.body.requiresParentalConsent).toBeFalsy();
+    expect(hasSessionCookie(res)).toBe(true);
+  });
+
+  it('under-13 with parentEmail equal to invitation email → 400', async () => {
+    const ts = Date.now();
+    const email = `sameemail-${ts}@testinvcoppa.local`;
+    const token = await seedInvitation({ email });
+    const payload = acceptPayload({ birthDate: under13Dob(), parentEmail: email });
+
+    const res = await request(app)
+      .post(`/api/invitations/${token}/accept`)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/integration/invitation-create-coppa.test.ts
+++ b/tests/integration/invitation-create-coppa.test.ts
@@ -66,7 +66,12 @@ function ageWithOffset(years: number, daysOffset: number): string {
   const d = new Date();
   d.setFullYear(d.getFullYear() - years);
   d.setDate(d.getDate() + daysOffset);
-  return d.toISOString().split('T')[0];
+  // Format in LOCAL time — toISOString() (UTC) can shift a day across the
+  // 13th-birthday boundary in non-UTC timezones (see tests/shared/age-helpers.ts).
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
 }
 
 /** Under-13 date of birth (12 years old — 13th birthday is tomorrow) */
@@ -304,7 +309,7 @@ describe('POST /api/invitations — COPPA invite-create validation', () => {
     expect(rows[0].parentEmail).toBe(parentEmail);
   });
 
-  it('GET /api/invitations/:token returns birthDate and parentEmail for prefill', async () => {
+  it('[LEGAL] GET /api/invitations/:token exposes parentEmailOnFile flag but never the raw PII', async () => {
     const parentEmail = `${TEST_PREFIX}parent3_${uniqueId()}@example.com`;
     const payload = invitePayload({ birthDate: under13Dob(), parentEmail });
 
@@ -320,7 +325,10 @@ describe('POST /api/invitations — COPPA invite-create validation', () => {
 
     const getRes = await request(app).get(`/api/invitations/${token}`);
     expect(getRes.status).toBe(200);
-    expect(getRes.body.birthDate).toBe(payload.birthDate);
-    expect(getRes.body.parentEmail).toBe(parentEmail);
+    // The child's DOB and the parent's email must NOT leak to token bearers
+    expect(getRes.body.birthDate).toBeUndefined();
+    expect(getRes.body.parentEmail).toBeUndefined();
+    // The form only learns that a parent email exists (relaxes required field)
+    expect(getRes.body.parentEmailOnFile).toBe(true);
   });
 });

--- a/tests/integration/invitation-create-coppa.test.ts
+++ b/tests/integration/invitation-create-coppa.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Integration tests — COPPA validation on POST /api/invitations (invite-create)
+ *
+ * Spec: coppa-compliance-spec "Invitation flow modification" — when an org
+ * admin/coach invites an athlete, the invitation may carry the athlete's
+ * birthDate; if it classifies as under-13, a parentEmail is REQUIRED before
+ * the invitation can be created (the VPC email must be able to fire at
+ * accept time even if the athlete's form omits it).
+ *
+ * LEGAL EXPOSURE items are marked with [LEGAL].
+ *
+ * Run:
+ *   export $(cat .env | xargs) && npx vitest run --config vitest.integration.config.ts tests/integration/invitation-create-coppa.test.ts
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET = 'test-secret-key-for-integration-tests-only-at-least-32-characters-long';
+process.env.BYPASS_GENERAL_RATE_LIMIT = 'true';
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import express, { type Express } from 'express';
+import bcrypt from 'bcrypt';
+import crypto from 'crypto';
+import { db } from '../../packages/api/db';
+import { users, organizations } from '@shared/schema/tables/core';
+import { userOrganizations, invitations } from '@shared/schema/tables/membership';
+import { eq, like } from 'drizzle-orm';
+import { BCRYPT_SALT_ROUNDS } from '@shared/constants';
+
+vi.mock('../../packages/api/vite.js', () => ({
+  setupVite: vi.fn().mockResolvedValue(undefined),
+  serveStatic: vi.fn(),
+}));
+
+const emailMocks = vi.hoisted(() => ({
+  sendParentalConsentRequest: vi.fn().mockResolvedValue(true),
+  sendConsentConfirmedNotification: vi.fn().mockResolvedValue(true),
+  sendParentNotification: vi.fn().mockResolvedValue(true),
+  sendEmailVerification: vi.fn().mockResolvedValue(true),
+  sendInvitation: vi.fn().mockResolvedValue(true),
+  sendParentInvitation: vi.fn().mockResolvedValue(true),
+  sendWelcome: vi.fn().mockResolvedValue(true),
+  sendPasswordReset: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../packages/api/services/email-service', () => ({
+  emailService: emailMocks,
+  EmailService: vi.fn().mockImplementation(() => emailMocks),
+}));
+
+import { registerRoutes } from '../../packages/api/routes';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const TEST_PREFIX = 'invcreatecoppa_';
+const VALID_PASSWORD = 'TestPassword1!';
+
+function uniqueId() {
+  return crypto.randomBytes(4).toString('hex');
+}
+
+function ageWithOffset(years: number, daysOffset: number): string {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - years);
+  d.setDate(d.getDate() + daysOffset);
+  return d.toISOString().split('T')[0];
+}
+
+/** Under-13 date of birth (12 years old — 13th birthday is tomorrow) */
+function under13Dob(): string {
+  return ageWithOffset(13, 1);
+}
+
+function adultDob(): string {
+  return ageWithOffset(25, -1);
+}
+
+let app: Express;
+let testOrg: { id: string };
+let adminUser: { id: string; username: string };
+let adminCookie: string;
+
+async function loginAs(username: string): Promise<string> {
+  const res = await request(app)
+    .post('/api/auth/login')
+    .send({ username, password: VALID_PASSWORD });
+  const cookies = res.headers['set-cookie'];
+  return Array.isArray(cookies) ? cookies[0] : (cookies as unknown as string);
+}
+
+function invitePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const id = uniqueId();
+  return {
+    email: `${TEST_PREFIX}invitee_${id}@example.com`,
+    firstName: 'Invited',
+    lastName: 'Athlete',
+    role: 'athlete',
+    organizationId: testOrg.id,
+    teamIds: [],
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Setup / Teardown
+// ============================================================================
+
+beforeAll(async () => {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL must be set to run integration tests.');
+  }
+
+  app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  await registerRoutes(app);
+
+  const id = uniqueId();
+  const [org] = await db.insert(organizations).values({
+    name: `InvCreateCoppaOrg-${id}`,
+    orgType: 'club',
+  }).returning();
+  testOrg = org;
+
+  const [admin] = await db.insert(users).values({
+    username: `${TEST_PREFIX}admin_${id}`,
+    firstName: 'Org',
+    lastName: 'Admin',
+    fullName: 'Org Admin',
+    emails: [`${TEST_PREFIX}admin_${id}@example.com`],
+    password: await bcrypt.hash(VALID_PASSWORD, BCRYPT_SALT_ROUNDS),
+    role: 'org_admin',
+    isEmailVerified: true,
+    coppaStatus: 'not_applicable',
+  }).returning();
+  adminUser = admin;
+
+  await db.insert(userOrganizations).values({
+    userId: admin.id,
+    organizationId: org.id,
+    role: 'org_admin',
+  }).onConflictDoNothing();
+
+  adminCookie = await loginAs(admin.username);
+});
+
+afterAll(async () => {
+  try {
+    await db.delete(invitations).where(eq(invitations.organizationId, testOrg.id));
+    await db.delete(userOrganizations).where(eq(userOrganizations.organizationId, testOrg.id));
+    await db.delete(users).where(like(users.username, `${TEST_PREFIX}%`));
+    await db.delete(organizations).where(eq(organizations.id, testOrg.id));
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('POST /api/invitations — COPPA invite-create validation', () => {
+  it('[LEGAL] athlete invite with under-13 birthDate and no parentEmail → 400, no invitation row', async () => {
+    const payload = invitePayload({ birthDate: under13Dob() });
+
+    const res = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+    expect(res.body.message?.toLowerCase()).toContain('parent');
+
+    const rows = await db.select().from(invitations)
+      .where(eq(invitations.email, payload.email as string));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('athlete invite with under-13 birthDate and parentEmail → 201, both fields stored', async () => {
+    const parentEmail = `${TEST_PREFIX}parent_${uniqueId()}@example.com`;
+    const payload = invitePayload({ birthDate: under13Dob(), parentEmail });
+
+    const res = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send(payload);
+
+    expect(res.status).toBe(201);
+
+    const [row] = await db.select().from(invitations)
+      .where(eq(invitations.email, payload.email as string));
+    expect(row).toBeDefined();
+    expect(row.birthDate).toBe(payload.birthDate);
+    expect(row.parentEmail).toBe(parentEmail);
+  });
+
+  it('parentEmail equal to invitee email → 400', async () => {
+    const email = `${TEST_PREFIX}same_${uniqueId()}@example.com`;
+    const payload = invitePayload({ email, birthDate: under13Dob(), parentEmail: email });
+
+    const res = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('coach-role invite with under-13 birthDate → 400 (role requires an adult)', async () => {
+    const payload = invitePayload({ role: 'coach', birthDate: under13Dob() });
+
+    const res = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('athlete invite with adult birthDate and no parentEmail → 201', async () => {
+    const payload = invitePayload({ birthDate: adultDob() });
+
+    const res = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send(payload);
+
+    expect(res.status).toBe(201);
+  });
+
+  it('malformed birthDate → 400', async () => {
+    const payload = invitePayload({ birthDate: '13-01-2015' });
+
+    const res = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send(payload);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('[LEGAL] athlete-record invite (athleteId) for a linked under-13 athlete without any parentEmail → 400', async () => {
+    const id = uniqueId();
+    const [athlete] = await db.insert(users).values({
+      username: `${TEST_PREFIX}u13athlete_${id}`,
+      firstName: 'Young',
+      lastName: 'Athlete',
+      fullName: 'Young Athlete',
+      emails: [`${TEST_PREFIX}u13athlete_${id}@example.com`],
+      password: await bcrypt.hash(VALID_PASSWORD, BCRYPT_SALT_ROUNDS),
+      birthDate: under13Dob(),
+      role: 'athlete',
+      coppaStatus: 'not_applicable',
+    }).returning();
+
+    const res = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send({
+        athleteId: athlete.id,
+        role: 'athlete',
+        organizationId: testOrg.id,
+        teamIds: [],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message?.toLowerCase()).toContain('parent');
+  });
+
+  it('athlete-record invite for a linked under-13 athlete WITH request parentEmail → 201, stored on invitation', async () => {
+    const id = uniqueId();
+    const [athlete] = await db.insert(users).values({
+      username: `${TEST_PREFIX}u13athlete2_${id}`,
+      firstName: 'Young',
+      lastName: 'Athlete',
+      fullName: 'Young Athlete',
+      emails: [`${TEST_PREFIX}u13athlete2_${id}@example.com`],
+      password: await bcrypt.hash(VALID_PASSWORD, BCRYPT_SALT_ROUNDS),
+      birthDate: under13Dob(),
+      role: 'athlete',
+      coppaStatus: 'not_applicable',
+    }).returning();
+
+    const parentEmail = `${TEST_PREFIX}parent2_${id}@example.com`;
+    const res = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send({
+        athleteId: athlete.id,
+        role: 'athlete',
+        organizationId: testOrg.id,
+        teamIds: [],
+        parentEmail,
+      });
+
+    expect(res.status).toBe(201);
+
+    const rows = await db.select().from(invitations)
+      .where(eq(invitations.playerId, athlete.id));
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows[0].parentEmail).toBe(parentEmail);
+  });
+
+  it('GET /api/invitations/:token returns birthDate and parentEmail for prefill', async () => {
+    const parentEmail = `${TEST_PREFIX}parent3_${uniqueId()}@example.com`;
+    const payload = invitePayload({ birthDate: under13Dob(), parentEmail });
+
+    const createRes = await request(app)
+      .post('/api/invitations')
+      .set('Cookie', adminCookie)
+      .send(payload);
+    expect(createRes.status).toBe(201);
+
+    // Raw token only appears in the invite link
+    const token = (createRes.body.inviteLink as string).split('token=')[1];
+    expect(token).toBeTruthy();
+
+    const getRes = await request(app).get(`/api/invitations/${token}`);
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.birthDate).toBe(payload.birthDate);
+    expect(getRes.body.parentEmail).toBe(parentEmail);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the COPPA compliance gap in the invitation path (spec item **P0-11** in `coppa-compliance-spec.md`, past its 2026-04-22 deadline): an **invited** under-13 athlete previously received a live, logged-in account with no parental consent, while a self-registering under-13 was correctly blocked pending Verifiable Parental Consent (VPC).

The frontend age gate in `accept-invitation.tsx` already existed and sent `birthDate`/`parentEmail` — the backend silently dropped both. This PR makes the backend honor them and adds coach-side capture at invite-create.

### Phase 1 — Accept-time age gate (backend)
- `POST /api/invitations/:token/accept` classifies age (mirroring the registration path), persists COPPA fields fail-closed inside the accept transaction, initiates VPC via the existing `coppaService.initiateConsent()` **after** the transaction commits, returns `requiresParentalConsent: true` (the frontend holding screen already handles it), and **creates no session** for under-13 / `needs_parent_email` accounts.
- Effective birthDate precedence: **accepting user's own server-known record > invitation (coach-entered) > form value** — a form entry cannot reclassify someone the server already knows the age of.
- Teen minors (13–17) with a parent email get a `parentAthleteLinks` row + informational parent notification, then a normal session.
- All new validation early-returns 400 **before** `storage.acceptInvitation` (the catch block increments `attemptCount` and locks invitations after 5 failures).

### Phase 2 — Invite-create capture (coach-side)
- Migration `0139`: nullable `birth_date` + `parent_email` on `invitations` (paired down migration).
- An under-13 athlete invitation **cannot be created** without a parent email; under-13 DOB on a non-athlete role is rejected; parent email checked against **all** athlete emails.
- Invite modal: optional DOB for athlete invites; an under-13 DOB reveals a required parent-email field with the COPPA alert.
- Privacy: `GET /api/invitations/:token` exposes only a `parentEmailOnFile` flag — never the child's DOB or the parent's email (links get forwarded). The server applies stored values as fallback at accept, so the child can leave the field blank.

### Adversarial review hardening (multi-agent review of this branch; all fixed with regression tests)
- Parent invitations are no longer age-classified by the linked **child's** DOB, and `acceptInvitation` no longer hijacks the child's row with the parent's credentials (pre-existing bug surfaced by the review — parent accepts now create the parent's own account).
- Email-matched accepts consult the existing row's birthDate and move an under-13 row to `pending_consent` even when it already had a `birthDate` with the `not_applicable` column default.
- `consent_revoked` → 403 **before** the token is consumed, and storage never silently re-opens a revocation.
- Session gate also blocks `needs_parent_email` (login already did).
- Test DOB helpers use local-time formatting (UTC `toISOString` could flip the 13th-birthday boundary).

## Testing

- **31 new integration tests** across `tests/integration/invitation-coppa-accept.test.ts` and `invitation-create-coppa.test.ts` (legally critical assertions tagged `[LEGAL]`), written test-first (RED commits precede GREEN). All pass.
- Full integration suite: 1198 passed; only pre-existing failures remain (migration-0130 seeding, occasional password-reset flake — both reproduce on `develop`).
- Unit suite: all previously-failing invitation files pass after applying 0139 locally; no regressions attributable to this branch.
- Typecheck (`npm run check`): clean.
- **E2E specs** added (`invitation-coppa-accept.spec.ts`, `invitation-create-coppa.spec.ts`) following `coppa-consent-flow.spec.ts` patterns. They need an E2E environment with seeded role users (org_admin) — the bare local dev DB has none, so they were not executable locally; CI E2E is known-flaky on develop.
- UI screenshot verification done locally against the dev server for the accept-page changes (`screenshots/` is gitignored; local dev renders unstyled due to a pre-existing Tailwind content-path quirk, functional state verified: prefill-free DOB field, COPPA alert, relaxed parent-email requirement).

## Migration notes

`migrations/0139_add_invitation_coppa_fields.sql` (+ down) — auto-discovered by `npm run db:migrate:manual`. Both columns nullable; no backfill needed.

## Out of scope / follow-ups

- Q2 (parent-adds-child, P1-9) and Q3 (parent wellness submission) per the handoff scope guard.
- The spec's Part 4 open questions (retroactive under-13 scan, DPAs) remain owner action items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce COPPA parental-consent age gating on the invitation accept flow and capture coach-provided age data at invite creation to align the invitation path with self-registration.

New Features:
- Add COPPA age classification and parental-consent handling to invitation acceptance, including blocking under-13 sessions and initiating consent workflows.
- Allow coaches/org admins to optionally supply athlete birth date and required parent email for under-13 athlete invitations, with UI support in the invite modal.
- Expose a non-PII parentEmailOnFile flag on invitation fetch so the accept page can relax parent-email requiredness when a coach-provided email exists.

Bug Fixes:
- Prevent parent invitations from incorrectly using the linked child’s birth date for age classification or overwriting the child’s account with the parent’s credentials.
- Ensure existing under-13 users (including those with default not_applicable status or coppaStatus needs_parent_email) cannot obtain a session via the invitation accept path.
- Block invitation acceptance when parental consent has been revoked and avoid silently reopening revoked consent states.

Enhancements:
- Persist COPPA-related fields on invitations and users during accept to fail-closed and mirror registration behavior, including pending_consent status for under-13 athletes.
- Add teen minor (13–17) parent-link creation and informational notifications without gating sessions.
- Improve age and parent-email validation and precedence rules across invitation creation and acceptance, prioritizing server-known data over form entries.

Tests:
- Add comprehensive integration tests for invitation COPPA age gating on accept, covering legal-critical scenarios for under-13 and minor users.
- Add integration tests for COPPA validation on invitation creation, including coach-provided birth date/parent email and privacy behavior of invitation fetch.
- Introduce E2E Playwright specs for invite-create COPPA UI behavior and invitation accept age gating, aligned with existing COPPA consent flow tests.

Chores:
- Add database migrations to store COPPA-related birth date and parent email on invitations as nullable fields for coach-side age capture.